### PR TITLE
feat: custom title bar with settings + sidebar toggle

### DIFF
--- a/bundled-packs/ui/charminal-settings/ui.test.ts
+++ b/bundled-packs/ui/charminal-settings/ui.test.ts
@@ -165,7 +165,7 @@ describe("terminal agent options", () => {
 });
 
 describe("settings presence target", () => {
-  it("declares shell presence so the in-settings Open/Close switch can operate", async () => {
+  it("declares shell presence for settings UI placement", async () => {
     const settingsPack = (await import("./ui")).default;
 
     expect(settingsPack.layout.presence).toEqual({ target: "shell" });

--- a/bundled-packs/ui/charminal-settings/ui.tsx
+++ b/bundled-packs/ui/charminal-settings/ui.tsx
@@ -18,7 +18,6 @@ import type {
   UiContext,
   UiHealthReport,
   UiPackDefinition,
-  UiPresenceLevel,
 } from "@charminal/sdk";
 import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
@@ -2036,9 +2035,6 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
   // 言語切り替えは連打できるため、古い async completion で表示 state を戻さない。
   const languageChangeSeq = useRef(0);
   const [voiceFrequency, setVoiceFrequency] = useState<"on" | "off">("on");
-  const [presenceLevel, setPresenceLevel] = useState<UiPresenceLevel>(() =>
-    ctx.app.getPresenceLevel(),
-  );
   const [configLoaded, setConfigLoaded] = useState(false);
   const personas = ctx.app.listPersonas();
   const visiblePersonas = filterPersonaOptionsForLanguage(personas, resolvedLanguage);
@@ -2070,19 +2066,6 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
       aborted = true;
     };
   }, [ctx]);
-
-  useEffect(() => {
-    const onPresenceChanged = (event: Event) => {
-      const detail = event instanceof CustomEvent ? event.detail : null;
-      if (detail?.level === "default" || detail?.level === "closed") {
-        setPresenceLevel(detail.level);
-      }
-    };
-    window.addEventListener("charminal:presence-level-changed", onPresenceChanged);
-    return () => {
-      window.removeEventListener("charminal:presence-level-changed", onPresenceChanged);
-    };
-  }, []);
 
   const onPersonaChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const next = configPrimaryPersonaForSelection(e.target.value);
@@ -2169,18 +2152,6 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
       write: (v) => ctx.app.setAmbientAudioMuted(v),
       emitEvent: (n, p) => ctx.emitEvent(n, p),
       field: "ambientAudioMuted",
-    });
-  };
-
-  const onPresenceToggle = () => {
-    const next: UiPresenceLevel = presenceLevel === "default" ? "closed" : "default";
-    void applyConfigUpdate({
-      next,
-      prev: presenceLevel,
-      setLocal: setPresenceLevel,
-      write: (level) => ctx.app.setPresenceLevel(level),
-      emitEvent: (n, p) => ctx.emitEvent(n, p),
-      field: "presenceLevel",
     });
   };
 
@@ -2280,10 +2251,10 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
     <div
       style={{
         position: "absolute",
-        top: 0,
+        top: "var(--title-bar-height, 32px)",
         left: "var(--sidebar-width)",
         width: "calc(100% - var(--sidebar-width))",
-        height: "100vh",
+        height: "calc(100vh - var(--title-bar-height, 32px))",
         background: COLORS.bgPanel,
         color: COLORS.fg,
         fontFamily: FONT.family,
@@ -2528,12 +2499,6 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
                 </span>
               ))}
             </div>
-          </div>
-
-          {/* Sidebar */}
-          <div style={{ opacity: 0.7 }}>{strings.labelPresence}</div>
-          <div>
-            <Toggle checked={presenceLevel === "default"} onChange={onPresenceToggle} />
           </div>
 
           {/* Aura */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "charminal",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "charminal",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@pixiv/three-vrm": "^3.5.1",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,8 @@
         "height": 800,
         "minWidth": 900,
         "minHeight": 600,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
         "backgroundThrottling": "disabled"
       }
     ],

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 :root {
+  --title-bar-height: 32px;
   --sidebar-width: 280px;
   /* Shell width animates; scene/VRM content keeps this stable render width. */
   --sidebar-content-width: 280px;
@@ -44,8 +45,69 @@ body,
 /* ── Layout ─────────────────────────────────────────── */
 .app {
   display: flex;
+  flex-direction: column;
   height: 100vh;
   width: 100vw;
+  min-height: 0;
+}
+
+.app-body {
+  display: flex;
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* ── Title bar ─────────────────────────────────────── */
+.title-bar {
+  flex: 0 0 var(--title-bar-height);
+  height: var(--title-bar-height);
+  display: flex;
+  align-items: center;
+  padding: 0 12px 0 76px;
+  background: rgba(10, 17, 24, 0.92);
+  border-bottom: 1px solid var(--charminal-border);
+  color: var(--charminal-button-fg);
+  user-select: none;
+}
+
+.title-bar-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 100%;
+}
+
+.title-bar-button {
+  width: 26px;
+  height: 26px;
+  flex: 0 0 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--charminal-button-fg);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s,
+    opacity 0.15s;
+}
+
+.title-bar-button:hover,
+.title-bar-button:focus-visible {
+  background: var(--charminal-accent-soft);
+  color: var(--charminal-fg);
+  outline: none;
+}
+
+.title-bar-button.is-active {
+  background: var(--charminal-accent-soft);
+  color: var(--charminal-accent);
 }
 
 /* ── Runtime crash recovery ─────────────────────────── */
@@ -481,6 +543,7 @@ body,
 /* ── Terminal ───────────────────────────────────────── */
 .terminal-container {
   flex: 1;
+  min-width: 0;
   overflow: hidden;
   /* 左側にだけ余白を入れる（文字が sidebar 境界に張り付かないように）。
      右側は xterm の scrollbar が自然な端になるので padding 不要。 */
@@ -525,26 +588,6 @@ body,
 
 .sidebar-top-row .folder-btn {
   flex: 1;
-}
-
-.settings-btn {
-  background: transparent;
-  color: inherit;
-  opacity: 0.7;
-  border: 1px solid transparent;
-  border-radius: 8px;
-  cursor: pointer;
-  padding: 0;
-  font: inherit;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  aspect-ratio: 1;
-}
-
-.settings-btn:hover {
-  opacity: 1;
 }
 
 /* ── First-run health check ─────────────────────────── */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -222,6 +222,9 @@ import * as CharminalR3f from "./sdk/r3f";
 import type { ScenePackDefinition, ScenePackManifest } from "./sdk/scene-pack";
 import Sidebar from "./sidebar";
 import Terminal from "./terminal";
+import TitleBar from "./title-bar";
+import { useSettingsActive, useSidebarOpen } from "./title-bar-state";
+import { shouldResumeHostPresenceForUiActivation } from "./ui-pack-activation";
 import "./App.css";
 
 function mergeSystemPromptParts(
@@ -584,10 +587,6 @@ function isHostDefaultPresenceClosed(): boolean {
   return getCurrentSidebarWidth() <= 0 || shell?.classList.contains("presence-closed") === true;
 }
 
-function layoutNeedsHostPresenceResume(layout: UiLayout): boolean {
-  return layout.sidebar?.width === "fullscreen";
-}
-
 type PresenceApplyTarget = "active-ui" | "host-default";
 
 function buildPresenceDeps(target: PresenceApplyTarget = "active-ui"): PresenceIntensityDeps {
@@ -731,6 +730,8 @@ function App() {
   }));
   const appLanguageRef = useRef(appLanguage);
   const strings = useMemo(() => getStrings(appLanguage.resolved), [appLanguage.resolved]);
+  const sidebarOpen = useSidebarOpen();
+  const settingsActive = useSettingsActive(SETTINGS_PACK_ID);
   const [restoreDialog, setRestoreDialog] = useState<RestoreDialogRequest | null>(null);
   const restoreDialogResolveRef = useRef<((value: boolean) => void) | null>(null);
   const runtimeLevaStore = useRuntimeLevaStore();
@@ -804,6 +805,11 @@ function App() {
     },
     [],
   );
+
+  const handleToggleSidebar = useCallback(() => {
+    const nextLevel: PresenceLevel = sidebarOpen ? "closed" : "default";
+    applyPresenceLevelFromApp(nextLevel, "settings");
+  }, [applyPresenceLevelFromApp, sidebarOpen]);
 
   const restorePresenceFromPrompt = useCallback(() => {
     const state = getPresenceState();
@@ -2818,9 +2824,13 @@ function App() {
       // ここで開けたいのは host default shell なので、active-ui contract ではなく
       // host-default surface を即時復帰する（presence tween は stage tween と競合させない）。
       if (
-        layoutNeedsHostPresenceResume(entry.pack.layout) ||
-        getPresenceState().level === "closed" ||
-        isHostDefaultPresenceClosed()
+        shouldResumeHostPresenceForUiActivation({
+          entryId: entry.id,
+          layout: entry.pack.layout,
+          presenceLevel: getPresenceState().level,
+          hostDefaultClosed: isHostDefaultPresenceClosed(),
+          settingsPackId: SETTINGS_PACK_ID,
+        })
       ) {
         applyPresenceLevelFromApp("default", "default", { immediate: true }, "host-default");
         syncPresenceLevelStyles("default");
@@ -3502,6 +3512,14 @@ function App() {
 
   return (
     <div className="app">
+      <TitleBar
+        sidebarOpen={sidebarOpen}
+        settingsActive={settingsActive}
+        sidebarLabel={strings.labelPresence}
+        settingsLabel={strings.settings}
+        onToggleSidebar={handleToggleSidebar}
+        onOpenSettings={handleOpenSettings}
+      />
       {runtimeLevaStore ? (
         <LevaPanel
           store={runtimeLevaStore}
@@ -3526,67 +3544,64 @@ function App() {
           titleBar={{ title: "Scene", drag: true, filter: true, position: { x: -300, y: 0 } }}
         />
       ) : null}
-      <div
-        className="shell-column"
-        // .shell-column は App と同寿命で条件 unmount しない。register は置換
-        // semantics、ref が null で呼ばれても if(el) で no-op なので unregister 不要。
-        ref={(el) => {
-          if (el) getSurfaceRegistry().register("shell", el);
-        }}
-      >
-        <Sidebar
-          folderName={folderName}
-          onPickFolder={handlePickFolder}
-          onOpenSettings={handleOpenSettings}
-          settingsLabel={strings.settings}
-        />
-        <CharacterSurface
-          vrmUrl={vrmUrl}
-          onBodyReady={handleBodyReady}
-          bodyDevLog={bodyDevLog}
-          scene={renderedSceneEntry}
-        />
-      </div>
-      {canMountTerminals && (
-        <>
-          {tabState.sessions.map((sessionId) => {
-            const sessionCwd = tabManager.getSessionCwd(sessionId);
-            return (
-              <Terminal
-                key={sessionId}
-                sessionId={sessionId}
-                visible={sessionId === tabState.activeSessionId}
-                spec={
-                  sessionId === DEFAULT_SESSION_ID
-                    ? withAgentRuntimeFields(
-                        defaultSpec ?? {
-                          kind: "agent",
-                          agent: terminalAgent,
-                        },
-                        resolvedSystemPrompt,
-                        localizedPluginDir,
-                      )
-                    : { kind: "shell", integration: true }
-                }
-                cwd={sessionCwd === undefined ? cwd : sessionCwd}
-                perception={sessionId === tabState.activeSessionId ? perception : null}
-                attachFirst={tabManager.shouldAttachExistingSession(sessionId)}
-              />
-            );
-          })}
-          <TabIndicator
-            state={tabState}
-            labels={
-              new Map([
-                [DEFAULT_SESSION_ID, terminalAgent],
-                ...tabState.sessions
-                  .filter((id) => id !== DEFAULT_SESSION_ID)
-                  .map((id) => [id, id] as const),
-              ])
-            }
+      <div className="app-body">
+        <div
+          className="shell-column"
+          // .shell-column は App と同寿命で条件 unmount しない。register は置換
+          // semantics、ref が null で呼ばれても if(el) で no-op なので unregister 不要。
+          ref={(el) => {
+            if (el) getSurfaceRegistry().register("shell", el);
+          }}
+        >
+          <Sidebar folderName={folderName} onPickFolder={handlePickFolder} />
+          <CharacterSurface
+            vrmUrl={vrmUrl}
+            onBodyReady={handleBodyReady}
+            bodyDevLog={bodyDevLog}
+            scene={renderedSceneEntry}
           />
-        </>
-      )}
+        </div>
+        {canMountTerminals && (
+          <>
+            {tabState.sessions.map((sessionId) => {
+              const sessionCwd = tabManager.getSessionCwd(sessionId);
+              return (
+                <Terminal
+                  key={sessionId}
+                  sessionId={sessionId}
+                  visible={sessionId === tabState.activeSessionId}
+                  spec={
+                    sessionId === DEFAULT_SESSION_ID
+                      ? withAgentRuntimeFields(
+                          defaultSpec ?? {
+                            kind: "agent",
+                            agent: terminalAgent,
+                          },
+                          resolvedSystemPrompt,
+                          localizedPluginDir,
+                        )
+                      : { kind: "shell", integration: true }
+                  }
+                  cwd={sessionCwd === undefined ? cwd : sessionCwd}
+                  perception={sessionId === tabState.activeSessionId ? perception : null}
+                  attachFirst={tabManager.shouldAttachExistingSession(sessionId)}
+                />
+              );
+            })}
+            <TabIndicator
+              state={tabState}
+              labels={
+                new Map([
+                  [DEFAULT_SESSION_ID, terminalAgent],
+                  ...tabState.sessions
+                    .filter((id) => id !== DEFAULT_SESSION_ID)
+                    .map((id) => [id, id] as const),
+                ])
+              }
+            />
+          </>
+        )}
+      </div>
       {firstRunHealth && (
         <FirstRunHealthPanel
           report={firstRunHealth}

--- a/src/sidebar.tsx
+++ b/src/sidebar.tsx
@@ -1,20 +1,13 @@
-import { Folder, Settings } from "lucide-react";
+import { Folder } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { getSurfaceRegistry } from "./runtime/surface-registry";
 
 interface SidebarProps {
   readonly folderName: string;
   readonly onPickFolder: () => void;
-  readonly onOpenSettings: () => void;
-  readonly settingsLabel: string;
 }
 
-export default function Sidebar({
-  folderName,
-  onPickFolder,
-  onOpenSettings,
-  settingsLabel,
-}: SidebarProps) {
+export default function Sidebar({ folderName, onPickFolder }: SidebarProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   // NOTE: React StrictMode の effect 二重実行は cleanup→re-register の順で進み、
@@ -33,15 +26,6 @@ export default function Sidebar({
         <button type="button" className="folder-btn" onClick={onPickFolder} title={folderName}>
           <Folder className="folder-icon" size={14} aria-hidden="true" />
           <span className="folder-name">{folderName}</span>
-        </button>
-        <button
-          type="button"
-          className="settings-btn"
-          onClick={onOpenSettings}
-          aria-label={settingsLabel}
-          title={settingsLabel}
-        >
-          <Settings size={14} aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/src/title-bar-state.test.tsx
+++ b/src/title-bar-state.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _clearForTest as clearHotDataForTest } from "./runtime/hot-data/hot-data";
+import { _resetForTest as resetPresenceForTest } from "./runtime/presence-intensity/presence-intensity";
+import type { UiPackEntry } from "./runtime/ui-pack-registry";
+import { getUiRegistry } from "./runtime/ui-pack-registry";
+import { useSettingsActive, useSidebarOpen } from "./title-bar-state";
+
+const SETTINGS_PACK_ID = "charminal-settings";
+
+function SidebarOpenProbe() {
+  const sidebarOpen = useSidebarOpen();
+  return <output aria-label="sidebar-open">{sidebarOpen ? "open" : "closed"}</output>;
+}
+
+function SettingsActiveProbe() {
+  const settingsActive = useSettingsActive(SETTINGS_PACK_ID);
+  return <output aria-label="settings-active">{settingsActive ? "active" : "inactive"}</output>;
+}
+
+function uiEntry(id: string): UiPackEntry {
+  return {
+    id,
+    origin: "bundled",
+    manifest: {} as UiPackEntry["manifest"],
+    pack: {
+      layout: {} as UiPackEntry["pack"]["layout"],
+      mount: () => ({ dispose: () => {} }),
+    },
+  };
+}
+
+beforeEach(() => {
+  clearHotDataForTest();
+  resetPresenceForTest();
+});
+
+afterEach(() => {
+  cleanup();
+  clearHotDataForTest();
+});
+
+describe("title bar state hooks", () => {
+  it("syncs sidebarOpen from presence level change events", () => {
+    render(<SidebarOpenProbe />);
+
+    expect(screen.getByLabelText("sidebar-open").textContent).toBe("open");
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("charminal:presence-level-changed", { detail: { level: "closed" } }),
+      );
+    });
+
+    expect(screen.getByLabelText("sidebar-open").textContent).toBe("closed");
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("charminal:presence-level-changed", { detail: { level: "default" } }),
+      );
+    });
+
+    expect(screen.getByLabelText("sidebar-open").textContent).toBe("open");
+  });
+
+  it("syncs settingsActive from the active UI registry", () => {
+    const registry = getUiRegistry();
+    const settingsRegistration = registry.register(uiEntry(SETTINGS_PACK_ID));
+    const otherRegistration = registry.register(uiEntry("attention-aura"));
+    registry.setActiveUi("attention-aura");
+
+    try {
+      render(<SettingsActiveProbe />);
+
+      expect(screen.getByLabelText("settings-active").textContent).toBe("inactive");
+
+      act(() => {
+        registry.setActiveUi(SETTINGS_PACK_ID);
+      });
+
+      expect(screen.getByLabelText("settings-active").textContent).toBe("active");
+
+      act(() => {
+        registry.setActiveUi("attention-aura");
+      });
+
+      expect(screen.getByLabelText("settings-active").textContent).toBe("inactive");
+    } finally {
+      settingsRegistration.dispose();
+      otherRegistration.dispose();
+    }
+  });
+});

--- a/src/title-bar-state.ts
+++ b/src/title-bar-state.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { getPresenceState, type PresenceLevel } from "./runtime/presence-intensity";
+import { getUiRegistry } from "./runtime/ui-pack-registry";
+
+export function sidebarOpenFromPresenceLevel(level: PresenceLevel): boolean {
+  return level === "default";
+}
+
+function isPresenceLevel(value: unknown): value is PresenceLevel {
+  return value === "default" || value === "closed";
+}
+
+export function useSidebarOpen(): boolean {
+  const [sidebarOpen, setSidebarOpen] = useState(() =>
+    sidebarOpenFromPresenceLevel(getPresenceState().level),
+  );
+
+  useEffect(() => {
+    const onPresenceChanged = (event: Event) => {
+      const detail = event instanceof CustomEvent ? event.detail : null;
+      if (!isPresenceLevel(detail?.level)) return;
+      setSidebarOpen(sidebarOpenFromPresenceLevel(detail.level));
+    };
+    window.addEventListener("charminal:presence-level-changed", onPresenceChanged);
+    return () => {
+      window.removeEventListener("charminal:presence-level-changed", onPresenceChanged);
+    };
+  }, []);
+
+  return sidebarOpen;
+}
+
+export function useSettingsActive(settingsPackId: string): boolean {
+  const [settingsActive, setSettingsActive] = useState(
+    () => getUiRegistry().getActiveUi()?.id === settingsPackId,
+  );
+
+  useEffect(() => {
+    const uiPackRegistry = getUiRegistry();
+    const sub = uiPackRegistry.subscribeActive((entry) => {
+      setSettingsActive(entry?.id === settingsPackId);
+    });
+    return () => sub.dispose();
+  }, [settingsPackId]);
+
+  return settingsActive;
+}

--- a/src/title-bar.test.tsx
+++ b/src/title-bar.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TitleBar from "./title-bar";
+
+function renderTitleBar(overrides: Partial<Parameters<typeof TitleBar>[0]> = {}) {
+  return render(
+    <TitleBar
+      sidebarOpen
+      settingsActive={false}
+      sidebarLabel="Sidebar"
+      settingsLabel="Settings"
+      onToggleSidebar={vi.fn()}
+      onOpenSettings={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("TitleBar", () => {
+  it("calls onToggleSidebar when the sidebar button is clicked", () => {
+    const onToggleSidebar = vi.fn();
+    renderTitleBar({ onToggleSidebar });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sidebar" }));
+
+    expect(onToggleSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onOpenSettings when the settings button is clicked", () => {
+    const onOpenSettings = vi.fn();
+    renderTitleBar({ onOpenSettings });
+
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("reflects sidebarOpen through aria-pressed", () => {
+    const { rerender } = renderTitleBar({ sidebarOpen: true });
+    const sidebarButton = screen.getByRole("button", { name: "Sidebar" });
+
+    expect(sidebarButton.getAttribute("aria-pressed")).toBe("true");
+
+    rerender(
+      <TitleBar
+        sidebarOpen={false}
+        settingsActive={false}
+        sidebarLabel="Sidebar"
+        settingsLabel="Settings"
+        onToggleSidebar={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Sidebar" }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+  });
+
+  it("marks the settings button as active while settings is open", () => {
+    renderTitleBar({ settingsActive: true });
+
+    const settingsButton = screen.getByRole("button", { name: "Settings" });
+    expect(settingsButton.classList.contains("is-active")).toBe(true);
+    expect(settingsButton.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("keeps only the title bar root as a Tauri drag region", () => {
+    const { container } = renderTitleBar();
+    const root = container.firstElementChild;
+
+    expect(root?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Sidebar" }).hasAttribute("data-tauri-drag-region"),
+    ).toBe(false);
+    expect(
+      screen.getByRole("button", { name: "Settings" }).hasAttribute("data-tauri-drag-region"),
+    ).toBe(false);
+  });
+});

--- a/src/title-bar.tsx
+++ b/src/title-bar.tsx
@@ -1,0 +1,50 @@
+import { PanelLeftClose, PanelLeftOpen, Settings } from "lucide-react";
+
+export interface TitleBarProps {
+  readonly onToggleSidebar: () => void;
+  readonly onOpenSettings: () => void;
+  readonly sidebarOpen: boolean;
+  readonly settingsActive: boolean;
+  readonly settingsLabel: string;
+  readonly sidebarLabel: string;
+}
+
+export default function TitleBar({
+  onToggleSidebar,
+  onOpenSettings,
+  sidebarOpen,
+  settingsActive,
+  settingsLabel,
+  sidebarLabel,
+}: TitleBarProps) {
+  const SidebarIcon = sidebarOpen ? PanelLeftClose : PanelLeftOpen;
+
+  return (
+    <header className="title-bar" data-tauri-drag-region="">
+      <div className="title-bar-controls">
+        <button
+          type="button"
+          className="title-bar-button title-bar-sidebar-button"
+          onClick={onToggleSidebar}
+          aria-label={sidebarLabel}
+          aria-pressed={sidebarOpen}
+          title={sidebarLabel}
+        >
+          <SidebarIcon size={15} strokeWidth={1.8} aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className={`title-bar-button title-bar-settings-button${
+            settingsActive ? " is-active" : ""
+          }`}
+          onClick={onOpenSettings}
+          aria-label={settingsLabel}
+          aria-pressed={settingsActive}
+          title={settingsLabel}
+        >
+          <Settings size={15} strokeWidth={1.8} aria-hidden="true" />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/ui-pack-activation.test.ts
+++ b/src/ui-pack-activation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { shouldResumeHostPresenceForUiActivation } from "./ui-pack-activation";
+
+const SETTINGS_PACK_ID = "charminal-settings";
+
+describe("shouldResumeHostPresenceForUiActivation", () => {
+  it("does not reopen host presence when opening settings", () => {
+    expect(
+      shouldResumeHostPresenceForUiActivation({
+        entryId: SETTINGS_PACK_ID,
+        layout: { sidebar: {}, presence: { target: "shell" } },
+        presenceLevel: "closed",
+        hostDefaultClosed: true,
+        settingsPackId: SETTINGS_PACK_ID,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps reopening host presence for fullscreen UI packs", () => {
+    expect(
+      shouldResumeHostPresenceForUiActivation({
+        entryId: "theater",
+        layout: { sidebar: { width: "fullscreen" } },
+        presenceLevel: "closed",
+        hostDefaultClosed: true,
+        settingsPackId: SETTINGS_PACK_ID,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/ui-pack-activation.ts
+++ b/src/ui-pack-activation.ts
@@ -1,0 +1,25 @@
+import type { UiLayout } from "@charminal/sdk";
+import type { PresenceLevel } from "./runtime/presence-intensity";
+
+export interface HostPresenceResumeInput {
+  readonly entryId: string;
+  readonly layout: UiLayout;
+  readonly presenceLevel: PresenceLevel;
+  readonly hostDefaultClosed: boolean;
+  readonly settingsPackId: string;
+}
+
+export function layoutNeedsHostPresenceResume(layout: UiLayout): boolean {
+  return layout.sidebar?.width === "fullscreen";
+}
+
+export function shouldResumeHostPresenceForUiActivation({
+  entryId,
+  layout,
+  presenceLevel,
+  hostDefaultClosed,
+  settingsPackId,
+}: HostPresenceResumeInput): boolean {
+  if (entryId === settingsPackId) return false;
+  return layoutNeedsHostPresenceResume(layout) || presenceLevel === "closed" || hostDefaultClosed;
+}


### PR DESCRIPTION
## Summary

- ウィンドウ最上部に cmux 風のカスタムトップバーを新設し、設定ボタン（サイドバーから移設）とサイドバー（住人列）開閉トグルを集約
- macOS `titleBarStyle: "Overlay"` でネイティブ信号機を温存しつつ、その右にボタンを左端配置
- トグルは既存 presence source `"settings"` に乗り、手動 pin セマンティクスを保持（新ロジックほぼ無し）
- 設定パネル内の旧 Sidebar トグルを撤去しトップバーに一本化
- 設定オープン時に presence が勝手に resume されてサイドバーが開く問題を修正

## Design

- spec: `~/Charminal-design-record/2026-06-27-titlebar-design.md`
- `TitleBar` は state を持たず presence の「鏡」（`charminal:presence-level-changed` を購読）
- `.app` を縦 flex 化し `.app-body` ラッパで既存横並びレイアウトを維持
- `TitleBar` は全 OS で描画（Overlay 化のみ macOS）→ 設定アクセスを全 OS で保全

## Test plan

- [x] `npm run check` (tsc + biome + cargo fmt + clippy) pass
- [x] `npm run test:run` — 1488 tests pass (120 files, +9 new tests)
- [x] pre-push hook (tsc + biome + cargo + typedoc) pass
- [x] macOS 実機目視: Overlay で信号機温存・ボタン配置・ドラッグ・トグル↔presence 双方向同期・設定オープン/クローズ
- [x] production build (`npm run tauri build`) で Overlay + CSP 検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)