### PR TITLE
fix(ci): run cargo build before fmt to generate build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Generate Rust build artifacts (bundled_examples_gen.rs)
+        run: cargo build --manifest-path src-tauri/Cargo.toml
+
       - run: npm run check
 
   test:

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -430,7 +430,7 @@ pub(crate) fn snapshot_list_impl(home_root: &Path) -> Result<Vec<SnapshotEntry>,
             entries.push(entry);
         }
     }
-    entries.sort_by(|a, b| b.seq.cmp(&a.seq));
+    entries.sort_by_key(|e| std::cmp::Reverse(e.seq));
     entries.truncate(DEFAULT_KEEP);
     Ok(entries)
 }


### PR DESCRIPTION
## Summary

- `cargo fmt --check` が `mod bundled_examples_gen` を解決しようとするが、このファイルは `build.rs` で生成され `.gitignore` されているため CI には存在しない
- `npm run check` の前に `cargo build` を実行してファイルを生成する
- main でも同じ理由で CI が壊れていた既存問題の修正

## Test plan

- [x] CI の check job が pass する（`cargo fmt --check` が `bundled_examples_gen.rs` を解決できる）
- [ ] CI の test job が pass する

🤖 Generated with [Claude Code](https://claude.com/claude-code)