### PR TITLE
feat: GPU shader fireworks (CPU-era look with glow)

### DIFF
--- a/bundled-packs/effects/fireworks-volley/effect.test.ts
+++ b/bundled-packs/effects/fireworks-volley/effect.test.ts
@@ -31,6 +31,7 @@ const makeRendererStub = (): RendererAPI => ({
   addParticles: vi.fn(() => ({ dispose: () => {}, completion: Promise.resolve() })),
   addCameraMove: vi.fn(() => ({ dispose: () => {} })),
   drawOnCanvas: vi.fn(() => ({ dispose: () => {} })),
+  drawOnGLCanvas: vi.fn(() => ({ dispose: () => {} })),
   addDomLayer: vi.fn(() => ({ dispose: () => {} })),
   queryTerminalCells: vi.fn(() => null),
 });

--- a/bundled-packs/effects/fireworks/effect.test.ts
+++ b/bundled-packs/effects/fireworks/effect.test.ts
@@ -5,13 +5,13 @@ import fireworks from "./effect";
 /**
  * fireworks effect pack の unit test。
  *
- * 粒の具体的な動き（速度・gravity・色の hue 値など）は brittle になるため
- * test しない。肌触り parameter は帰納的に実装中で調整する
- * （CLAUDE.md「感触 parameter は帰納的に」方針）。
+ * 粒の具体的な動き（速度・gravity・色の hue 値など）と GPU シェーダーの描画は
+ * brittle / jsdom で再現不可なため test しない。肌触り parameter は帰納的に
+ * 実装中で調整する（CLAUDE.md「感触 parameter は帰納的に」方針）。
  *
  * ここで守るのは pack の「形」と lifecycle の 4 点のみ：
  *   1. pack が EffectDefinition の shape を満たすこと
- *   2. `drawOnCanvas` が 1 回だけ呼ばれること
+ *   2. `drawOnGLCanvas` が 1 回だけ呼ばれること（GPU overlay を acquire する）
  *   3. `time.after(durationMs)` で lifecycle を刻むこと
  *   4. 成功・失敗どちらの経路でも canvas handle が dispose されること
  */
@@ -25,14 +25,18 @@ interface FireworksOptions {
 /**
  * mock ctx を組み立てる helper。個々の test で必要なフィールドだけ override する。
  * screen-shake の test pattern と同じ構造。
+ *
+ * drawOnGLCanvas の mock は draw callback を呼ばない（jsdom に WebGL2 が無い）。
+ * その結果 effect 内の RAF loop は起動せず、lifecycle（after / dispose）だけが
+ * 検証対象になる。
  */
 function createMockCtx(overrides: {
   after?: (ms: number) => Promise<void>;
-  drawOnCanvasReturn?: { dispose: ReturnType<typeof vi.fn> };
-  drawOnCanvas?: ReturnType<typeof vi.fn>;
+  drawOnGLCanvasReturn?: { dispose: ReturnType<typeof vi.fn> };
+  drawOnGLCanvas?: ReturnType<typeof vi.fn>;
 }) {
-  const dispose = overrides.drawOnCanvasReturn?.dispose ?? vi.fn();
-  const drawOnCanvas = overrides.drawOnCanvas ?? vi.fn(() => ({ dispose }));
+  const dispose = overrides.drawOnGLCanvasReturn?.dispose ?? vi.fn();
+  const drawOnGLCanvas = overrides.drawOnGLCanvas ?? vi.fn(() => ({ dispose }));
   // explicit type で (ms: number) signature を渡し、after.mock.calls[0][0] が
   // number として推論されるようにする。
   const after = vi.fn<(ms: number) => Promise<void>>(overrides.after ?? (() => Promise.resolve()));
@@ -44,11 +48,11 @@ function createMockCtx(overrides: {
       addShakeFilter: vi.fn(),
       addCssFilter: vi.fn(),
       addParticles: vi.fn(),
-      drawOnCanvas,
+      drawOnGLCanvas,
     },
     audio: { play: vi.fn(async () => {}) },
   } as unknown as EffectContext<FireworksOptions>;
-  return { ctx, dispose, drawOnCanvas, after };
+  return { ctx, dispose, drawOnGLCanvas, after };
 }
 
 describe("fireworks effect", () => {
@@ -57,8 +61,8 @@ describe("fireworks effect", () => {
     expect(fireworks.type).toBe("effect");
   });
 
-  it("acquires an overlay canvas via drawOnCanvas exactly once", async () => {
-    const { ctx, drawOnCanvas } = createMockCtx({});
+  it("acquires an overlay canvas via drawOnGLCanvas exactly once", async () => {
+    const { ctx, drawOnGLCanvas } = createMockCtx({});
 
     await fireworks.run(ctx, {
       origin: { x: 0.5, y: 0.3 },
@@ -66,7 +70,7 @@ describe("fireworks effect", () => {
       durationMs: 1000,
     });
 
-    expect(drawOnCanvas).toHaveBeenCalledOnce();
+    expect(drawOnGLCanvas).toHaveBeenCalledOnce();
   });
 
   it("extends a short durationMs so the burst is not cut mid-animation", async () => {

--- a/bundled-packs/effects/fireworks/effect.ts
+++ b/bundled-packs/effects/fireworks/effect.ts
@@ -1,36 +1,59 @@
 /**
- * fireworks — 1 発の花火 bundled Effect Pack（rise → burst の 2 段階）。
+ * fireworks — 1 発の花火 bundled Effect Pack（rise → burst の 2 段階）を
+ * **GPU シェーダー**で描く版。
  *
- * `ctx.renderer.drawOnCanvas` で overlay canvas を acquire し、以下 2 phase を
- * `requestAnimationFrame` loop で animate、`max(durationMs, MIN_EFFECT_MS)`
- * 経過後に canvas を dispose する。`durationMs` が短すぎて burst が途中で
- * 切れないよう、pack 側で natural 終了時間を保証する：
+ * `ctx.renderer.drawOnGLCanvas` で全画面 WebGL2 overlay を acquire し、粒の
+ * 物理を頂点シェーダーで毎フレーム解析的に解く（CPU で 1 粒ずつ位置を更新
+ * しない）。結果、数百〜千を超える発光粒を加算合成しても 60fps を保てる。
  *
- * 1. **rise**: 画面下から origin へ rocket が左右に揺れながら上昇。
- *    `sin × cos(t·π/2)` で apex では wobble 0 に収束、direction と phase は
- *    1 発ごとに random。rise 時間自体にも ±50ms の jitter が入る
- * 2. **burst**: apex に到達した時点で particles を全方向に emit、gravity / drag /
- *    lifetime で落下しながら fade
+ * ## なぜ GPU か
  *
- * ## 尾引き（motion trail）
+ * 旧版は 2D canvas に `arc()` を粒数ぶん描いていたため、見栄えを上げようと
+ * 粒を増やすと CPU と描画呼び出しが線形に重くなる。GPU 版は粒の状態を
+ * attribute buffer に 1 度だけ積み、頂点シェーダーが `pos = p0 + v·damp(t)
+ * + ½·g·t²` を全粒並列に評価する。CPU は毎フレーム時刻 uniform を更新する
+ * だけ。粒数は描画コストにほぼ効かない。
  *
- * 毎フレーム canvas を `clearRect` で消すのではなく、
- * `globalCompositeOperation = "destination-out"` で微弱に fade（既存 alpha を
- * `1 - FADE_ALPHA` 倍に減衰）する。結果、rocket の軌道と burst 粒の動きが
- * 自然な motion blur として尾を引く。
+ * ## 物理（頂点シェーダー内・解析解）
+ *
+ * - **drag**: 指数減衰 `v(t)=v0·e^{-t/τ}` の変位閉形式 `v0·τ·(1−e^{-t/τ})`。
+ *   爆発直後に速く開き、τ で滑らかに減速する。
+ * - **gravity**: `½·g·t²` を y（画面下向き）に加える。
+ * - **life/alpha**: `(1−t/maxLife)²` に twinkle（正弦のちらつき）を乗じる。
+ * - **flash**: 爆発直後だけ `e^{-8t}` の輝度ブーストを足し、芯が白く飛ぶ。
+ *
+ * ## トレイル（fade-feedback / ping-pong FBO）
+ *
+ * 旧版の `destination-out` による残像を GPU で再現する。2 枚の RGBA8
+ * テクスチャを ping-pong し、毎フレーム「前フレームを `×TRAIL_FADE` して
+ * 写し → その上に現在の粒を加算 → 画面へ提示」する。ロケットの軌跡も
+ * 爆発粒の尾も、この減衰バッファが自然な光の尾として残す。
  *
  * ## 色は coherent family
  *
- * 1 発ごとに base hue を random で決め、rocket と burst 粒はその ±15° の幅で
- * 揺らぐ。真っ赤な花火 / 真っ青な花火のような「1 色家族」感。
+ * 1 発ごとに base hue を random で決め、粒は seed で ±`HUE_SPREAD` 揺らぐ。
+ * フラグメント側で芯ほど白へ寄せ、白熱した核と色づいた縁を作る。
+ *
+ * ## 合成（premultiplied additive）
+ *
+ * context は premultipliedAlpha。フラグメントは premultiplied 色
+ * `vec4(rgb·a, a)` を出力し `blendFunc(ONE,ONE)` で加算する。alpha も蓄積
+ * されるので、overlay は mix-blend-mode に依存せず terminal/VRM の上へ正しく
+ * 合成される（明るい所は発光が乗り、減衰すれば下が透ける）。
+ *
+ * ## graceful degradation
+ *
+ * WebGL2 が無い環境（headless / 一部 webview）では drawOnGLCanvas の draw
+ * callback が呼ばれず、RAF も起動しない。lifecycle（durationMs 待ち →
+ * dispose）だけは必ず守る。GL resource の確保に失敗した場合も同様に no-op。
  *
  * ## 肌触り parameter（帰納的に調整する領域）
  *
- * RISE_MS / WOBBLE_* / FADE_ALPHA / GRAVITY / DRAG / speed / maxLife / radius
- * は spec に固定せず、観察→微調整の loop で固める（CLAUDE.md「感触 parameter
- * は帰納的に」）。
+ * RISE_MS / WOBBLE_* / TRAIL_* / GRAVITY / DRAG_TAU / SPEED_* / LIFE_* /
+ * SIZE_* / DENSITY は spec に固定せず、観察→微調整で固める（CLAUDE.md
+ * 「感触 parameter は帰納的に」）。
  *
- * 連発は呼び出し側（persona / init.js）が `injectEffect` を複数回刻む責務。
+ * 連発は呼び出し側（persona / init.js / fireworks-volley）が複数回刻む責務。
  * この pack は 1 origin からの 1 発に集中する。
  */
 
@@ -42,50 +65,468 @@ interface FireworksOptions {
   readonly durationMs: number;
 }
 
-interface Particle {
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  life: number;
-  maxLife: number;
-  hue: number;
-}
+// ─── lifecycle timing（旧版と同じ契約）──────────────────────
 
-/** 肌触り parameter の既定値。実装中の観察で微調整可能。 */
-const GRAVITY = 0.05;
-const DRAG = 0.985;
-const PARTICLE_RADIUS = 2;
-/** rocket head の半径（px）。burst 粒より太め。 */
-const ROCKET_RADIUS = 3;
 /** rise phase の基準所要時間（ms）。実際は ±RISE_JITTER_MS 揺らぐ。 */
 const RISE_MS = 2000;
 const RISE_JITTER_MS = 100;
-/** burst 後の粒が自然に fade しきるまでの buffer（ms）。maxLife 上限 ≈ 130 frame
- *  ≈ 60fps で 2167ms、余裕を見て 2500ms。呼び出し側の durationMs が短くても
- *  pack 側でこの時間まで canvas を保つ。 */
-const BURST_FADE_TAIL_MS = 2500;
+/** burst 後の粒が自然に fade しきるまでの buffer（ms）。LIFE 上限と trail の
+ *  減衰を見込んで余裕を取る。 */
+const BURST_FADE_TAIL_MS = 2600;
 /** 1 発が natural に演じ終わるまでの最低所要時間。options.durationMs がこれを
  *  下回る場合、pack が延長して burst が途中で切れないようにする。 */
 const MIN_EFFECT_MS = RISE_MS + RISE_JITTER_MS + BURST_FADE_TAIL_MS;
-/** rocket の start 位置を origin y から画面下へどれだけ外すか（px）。 */
+
+// ─── 見た目 / 物理の肌触り parameter ────────────────────────
+
+/** rocket の start 位置を origin y から画面下へどれだけ外すか（CSS px 基準）。 */
 const START_Y_OFFSET = 30;
-/** rise 中の左右揺らぎのサイクル数（片道で何回振る）。少ないほど 1 sway が大きく見える。 */
+/** rise 中の左右揺らぎのサイクル数（片道で何回振る）。 */
 const WOBBLE_CYCLES = 5;
-/** 左右揺らぎの最大振幅（px）、t=0 で最大、apex で 0 に収束。 */
-const WOBBLE_AMPLITUDE = 6;
-/** 毎フレーム既存描画を減衰させる割合。大きいほど trail が短い。 */
-const FADE_ALPHA = 0.12;
-/** burst 粒 hue の family 幅（±この値を base hue にオフセット）。 */
-const HUE_JITTER = 15;
+/** 左右揺らぎの最大振幅（CSS px 基準）、t=0 で最大、apex で 0 に収束。 */
+const WOBBLE_AMPLITUDE = 7;
+/** 毎フレーム trail を残す割合（大きいほど尾が長い）。 */
+const TRAIL_FADE = 0.9;
+/** trail を確実に 0 へ落とすための減算項（8bit の量子化で消え残るのを防ぐ）。 */
+const TRAIL_FLOOR = 0.014;
+/** 重力（px/s²、画面下向き）。画面解像度でスケールする。 */
+const GRAVITY = 520;
+/** drag の時定数（s）。小さいほど早く失速する。 */
+const DRAG_TAU = 0.85;
+/** 爆発粒の初速レンジ（px/s、画面解像度でスケール）。 */
+const SPEED_MIN = 130;
+const SPEED_MAX = 720;
+/** 粒寿命レンジ（s）。 */
+const LIFE_MIN = 0.9;
+const LIFE_MAX = 2.3;
+/** 粒の基準サイズレンジ（CSS px 基準、稀に大きな星を混ぜる）。 */
+const SIZE_MIN = 1.6;
+const SIZE_MAX = 4.2;
+/** options.count に対する実 GPU 粒数の倍率。GPU は粒数にほぼ無依存なので、
+ *  見栄えのために増やす。総数は MIN/MAX でクランプ。 */
+const DENSITY = 12;
+const PARTICLE_MIN = 220;
+const PARTICLE_MAX = 1800;
+/** base hue からの揺らぎ幅（0-1 hue 空間、±この値）。 */
+const HUE_SPREAD = 0.05;
+/** 解像度スケールの基準高さ（px）。buffer 高さ / これでサイズ・速度を倍率。 */
+const REFERENCE_HEIGHT = 900;
+/** rocket の発光点数（head + sparks）。trail バッファが尾を作るので少数で足りる。 */
+const ROCKET_POINTS = 3;
 
 /**
- * ease-out quad: 1 - (1-t)² = 2t - t²。
- * 一定重力下の投射運動（初速で打ち上げ、重力で減速、apex で v=0）の
- * y 成分と完全一致する curve。`easeOutCubic` は v0 が 3×avg で stop が
- * 急すぎて「物理的に不自然」に見える — quad は v0=2×avg で自然な減速。
+ * ease-out quad: 1 − (1−t)² = 2t − t²。
+ * 一定重力下の投射運動（初速で打ち上げ、重力で減速、apex で v=0）の y 成分と
+ * 一致する curve。rise の高さ補間に使う。
  */
 const easeOutQuad = (t: number): number => 1 - (1 - t) ** 2;
+
+// ─── shader sources（GLSL ES 3.00 / WebGL2）────────────────
+
+/** 全画面三角形。gl_VertexID から clip 座標を出すので頂点 buffer 不要。 */
+const QUAD_VS = `#version 300 es
+precision highp float;
+out vec2 v_uv;
+void main() {
+  vec2 p = vec2((gl_VertexID == 1) ? 3.0 : -1.0, (gl_VertexID == 2) ? 3.0 : -1.0);
+  v_uv = p * 0.5 + 0.5;
+  gl_Position = vec4(p, 0.0, 1.0);
+}`;
+
+/** テクスチャを `×u_fade − u_floor`（clamp ≥0）で写す。fade-copy と present 兼用。 */
+const QUAD_FS = `#version 300 es
+precision highp float;
+uniform sampler2D u_tex;
+uniform float u_fade;
+uniform float u_floor;
+in vec2 v_uv;
+out vec4 frag;
+void main() {
+  vec4 c = texture(u_tex, v_uv) * u_fade - u_floor;
+  frag = max(c, vec4(0.0));
+}`;
+
+/**
+ * 発光粒。位置・寿命・色を頂点シェーダーで解析的に解く。
+ * a_position は基準点（爆発は origin、ロケットは head の現在位置）。
+ */
+const POINT_VS = `#version 300 es
+precision highp float;
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in vec2 a_velocity;
+layout(location = 2) in float a_seed;
+layout(location = 3) in float a_maxLife;
+layout(location = 4) in float a_size;
+
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform float u_gravity;
+uniform float u_tau;
+uniform float u_baseHue;
+uniform float u_hueSpread;
+uniform float u_sizeMax;
+
+out float v_alpha;
+out vec3 v_color;
+
+vec3 hue2rgb(float h) {
+  h = fract(h);
+  float r = abs(h * 6.0 - 3.0) - 1.0;
+  float g = 2.0 - abs(h * 6.0 - 2.0);
+  float b = 2.0 - abs(h * 6.0 - 4.0);
+  return clamp(vec3(r, g, b), 0.0, 1.0);
+}
+
+void main() {
+  float t = max(u_time, 0.0);
+  // drag の変位閉形式 + gravity（y は画面下向き px）。
+  float damp = u_tau * (1.0 - exp(-t / u_tau));
+  vec2 pos = a_position + a_velocity * damp;
+  pos.y += 0.5 * u_gravity * t * t;
+
+  float life = clamp(t / a_maxLife, 0.0, 1.0);
+  float fade = 1.0 - life;
+  // twinkle（粒ごとに位相と周期を散らす）。
+  float tw = 0.78 + 0.22 * sin(t * (7.0 + a_seed * 13.0) + a_seed * 31.4);
+  // 爆発直後の白熱ブースト。
+  float flash = 1.0 + 1.4 * exp(-t * 8.0);
+  v_alpha = fade * fade * tw * flash;
+
+  float hue = u_baseHue + (a_seed - 0.5) * u_hueSpread;
+  v_color = hue2rgb(hue);
+
+  // px(y 下向き) → clip。
+  vec2 clip = (pos / u_resolution) * 2.0 - 1.0;
+  clip.y = -clip.y;
+  gl_Position = vec4(clip, 0.0, 1.0);
+  gl_PointSize = clamp(a_size * (0.45 + 0.55 * fade), 1.0, u_sizeMax);
+}`;
+
+/** 円形ソフトグロー。premultiplied 加算用に `vec4(rgb·a, a)` を出力。 */
+const POINT_FS = `#version 300 es
+precision highp float;
+in float v_alpha;
+in vec3 v_color;
+out vec4 frag;
+void main() {
+  vec2 d = gl_PointCoord - 0.5;
+  float r = length(d) * 2.0;          // 0=中心, 1=縁
+  float core = smoothstep(1.0, 0.0, r);
+  float glow = pow(core, 2.2);
+  float a = glow * v_alpha;
+  if (a <= 0.002) discard;
+  // 芯ほど白へ寄せ、白熱した核を作る。
+  vec3 c = mix(v_color, vec3(1.0), core * 0.6);
+  frag = vec4(c * a, a);
+}`;
+
+// ─── GL helpers ────────────────────────────────────────────
+
+function compileShader(gl: WebGL2RenderingContext, type: number, src: string): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    console.warn("[fireworks] shader compile failed:", gl.getShaderInfoLog(shader));
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+function linkProgram(
+  gl: WebGL2RenderingContext,
+  vsSrc: string,
+  fsSrc: string,
+): WebGLProgram | null {
+  const vs = compileShader(gl, gl.VERTEX_SHADER, vsSrc);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, fsSrc);
+  if (!vs || !fs) return null;
+  const program = gl.createProgram();
+  if (!program) return null;
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.linkProgram(program);
+  // shader は program に紐付いたので個別参照は捨ててよい。
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    console.warn("[fireworks] program link failed:", gl.getProgramInfoLog(program));
+    gl.deleteProgram(program);
+    return null;
+  }
+  return program;
+}
+
+interface RenderTarget {
+  readonly tex: WebGLTexture;
+  readonly fbo: WebGLFramebuffer;
+}
+
+/** RGBA8 の color-attachment 付き framebuffer を 1 枚作り、透明にクリアする。 */
+function createTarget(gl: WebGL2RenderingContext, w: number, h: number): RenderTarget | null {
+  const tex = gl.createTexture();
+  const fbo = gl.createFramebuffer();
+  if (!tex || !fbo) return null;
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+  if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
+    gl.deleteTexture(tex);
+    gl.deleteFramebuffer(fbo);
+    return null;
+  }
+  gl.clearColor(0, 0, 0, 0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  return { tex, fbo };
+}
+
+/** 1 粒あたりの interleave float 数（pos2, vel2, seed, maxLife, size）。 */
+const STRIDE_FLOATS = 7;
+
+/** attribute location（POINT_VS の layout と一致させる）。 */
+const ATTR = { position: 0, velocity: 1, seed: 2, maxLife: 3, size: 4 } as const;
+
+/** interleave buffer を attribute へ結線する VAO を作る。 */
+function createPointVao(
+  gl: WebGL2RenderingContext,
+  buffer: WebGLBuffer,
+): WebGLVertexArrayObject | null {
+  const vao = gl.createVertexArray();
+  if (!vao) return null;
+  const stride = STRIDE_FLOATS * 4;
+  gl.bindVertexArray(vao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+  gl.enableVertexAttribArray(ATTR.position);
+  gl.vertexAttribPointer(ATTR.position, 2, gl.FLOAT, false, stride, 0);
+  gl.enableVertexAttribArray(ATTR.velocity);
+  gl.vertexAttribPointer(ATTR.velocity, 2, gl.FLOAT, false, stride, 8);
+  gl.enableVertexAttribArray(ATTR.seed);
+  gl.vertexAttribPointer(ATTR.seed, 1, gl.FLOAT, false, stride, 16);
+  gl.enableVertexAttribArray(ATTR.maxLife);
+  gl.vertexAttribPointer(ATTR.maxLife, 1, gl.FLOAT, false, stride, 20);
+  gl.enableVertexAttribArray(ATTR.size);
+  gl.vertexAttribPointer(ATTR.size, 1, gl.FLOAT, false, stride, 24);
+  gl.bindVertexArray(null);
+  return vao;
+}
+
+interface Scene {
+  renderFrame(elapsedMs: number): void;
+  dispose(): void;
+}
+
+/**
+ * WebGL2 の program / buffer / FBO を組み立て、毎フレーム描く Scene を返す。
+ * 何か 1 つでも確保に失敗したら null（呼び出し側は no-op に倒す）。
+ */
+function setupScene(gl: WebGL2RenderingContext, options: FireworksOptions): Scene | null {
+  const W = gl.drawingBufferWidth;
+  const H = gl.drawingBufferHeight;
+  if (W <= 0 || H <= 0) return null;
+  // buffer は HiDPI 込みの実 pixel。基準高さで割って px 量をスケールする。
+  const scale = H / REFERENCE_HEIGHT;
+  const sizeMax = (gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE) as Float32Array | null)?.[1] ?? 64;
+
+  const quadProgram = linkProgram(gl, QUAD_VS, QUAD_FS);
+  const pointProgram = linkProgram(gl, POINT_VS, POINT_FS);
+  if (!quadProgram || !pointProgram) return null;
+
+  let targetA = createTarget(gl, W, H);
+  let targetB = createTarget(gl, W, H);
+  const emptyVao = gl.createVertexArray();
+  const burstBuffer = gl.createBuffer();
+  const rocketBuffer = gl.createBuffer();
+  if (!targetA || !targetB || !emptyVao || !burstBuffer || !rocketBuffer) return null;
+
+  const burstVao = createPointVao(gl, burstBuffer);
+  const rocketVao = createPointVao(gl, rocketBuffer);
+  if (!burstVao || !rocketVao) return null;
+
+  // uniform locations。
+  const qTex = gl.getUniformLocation(quadProgram, "u_tex");
+  const qFade = gl.getUniformLocation(quadProgram, "u_fade");
+  const qFloor = gl.getUniformLocation(quadProgram, "u_floor");
+  const pRes = gl.getUniformLocation(pointProgram, "u_resolution");
+  const pTime = gl.getUniformLocation(pointProgram, "u_time");
+  const pGravity = gl.getUniformLocation(pointProgram, "u_gravity");
+  const pTau = gl.getUniformLocation(pointProgram, "u_tau");
+  const pBaseHue = gl.getUniformLocation(pointProgram, "u_baseHue");
+  const pHueSpread = gl.getUniformLocation(pointProgram, "u_hueSpread");
+  const pSizeMax = gl.getUniformLocation(pointProgram, "u_sizeMax");
+
+  // 1 発ぶんの色と動きの揺らぎ。
+  const baseHue = Math.random();
+  const wobbleDir = Math.random() < 0.5 ? 1 : -1;
+  const actualRiseMs = RISE_MS + (Math.random() * 2 - 1) * RISE_JITTER_MS;
+  const targetX = options.origin.x * W;
+  const targetY = options.origin.y * H;
+  const startY = H + START_Y_OFFSET * scale;
+
+  // 爆発粒の attribute を生成（origin から全方向へ）。一部は低速で長寿命の
+  // 残り火、一部は高速の殻。
+  const particleCount = Math.max(
+    PARTICLE_MIN,
+    Math.min(PARTICLE_MAX, Math.round(options.count * DENSITY)),
+  );
+  const burstData = new Float32Array(particleCount * STRIDE_FLOATS);
+  for (let i = 0; i < particleCount; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    // sqrt 分布で外殻に粒を寄せ、丸い burst に見せる。30% は低速の残り火。
+    const isEmber = Math.random() < 0.3;
+    const speedT = isEmber ? Math.random() * 0.35 : 0.35 + Math.sqrt(Math.random()) * 0.65;
+    const speed = (SPEED_MIN + (SPEED_MAX - SPEED_MIN) * speedT) * scale;
+    const maxLife = LIFE_MIN + Math.random() * (LIFE_MAX - LIFE_MIN) + (isEmber ? 0.4 : 0);
+    // 稀に大きな星。
+    const sizeBase = SIZE_MIN + Math.random() * (SIZE_MAX - SIZE_MIN);
+    const size = (Math.random() < 0.04 ? sizeBase * 2.2 : sizeBase) * scale;
+    const o = i * STRIDE_FLOATS;
+    burstData[o] = targetX;
+    burstData[o + 1] = targetY;
+    burstData[o + 2] = Math.cos(angle) * speed;
+    burstData[o + 3] = Math.sin(angle) * speed;
+    burstData[o + 4] = Math.random();
+    burstData[o + 5] = maxLife;
+    burstData[o + 6] = size;
+  }
+  gl.bindBuffer(gl.ARRAY_BUFFER, burstBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, burstData, gl.STATIC_DRAW);
+
+  // ロケット buffer は毎フレーム head 位置を書き換えるので DYNAMIC。
+  const rocketData = new Float32Array(ROCKET_POINTS * STRIDE_FLOATS);
+  for (let i = 0; i < ROCKET_POINTS; i++) {
+    const o = i * STRIDE_FLOATS;
+    rocketData[o + 2] = 0; // velocity 0（位置は JS が毎フレーム与える）
+    rocketData[o + 3] = 0;
+    rocketData[o + 4] = Math.random();
+    rocketData[o + 5] = 1; // maxLife（u_time=0 で常に full bright なので無効）
+    rocketData[o + 6] = (i === 0 ? 4.0 : 2.4) * scale; // head は太め
+  }
+  gl.bindBuffer(gl.ARRAY_BUFFER, rocketBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, rocketData, gl.DYNAMIC_DRAW);
+
+  let burstStarted = false;
+  let burstStartMs = 0;
+  // 前フレームの head 位置（spark の lag に使う）。
+  let prevRx = targetX;
+  let prevRy = startY;
+
+  const drawFullscreen = (srcTex: WebGLTexture, fade: number, floor: number): void => {
+    // biome-ignore lint/correctness/useHookAtTopLevel: WebGL の gl.useProgram であって React hook ではない（命名衝突の誤検知）。
+    gl.useProgram(quadProgram);
+    gl.uniform1i(qTex, 0);
+    gl.uniform1f(qFade, fade);
+    gl.uniform1f(qFloor, floor);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, srcTex);
+    gl.bindVertexArray(emptyVao);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  };
+
+  const drawPoints = (vao: WebGLVertexArrayObject, count: number, timeSec: number): void => {
+    // biome-ignore lint/correctness/useHookAtTopLevel: WebGL の gl.useProgram であって React hook ではない（命名衝突の誤検知）。
+    gl.useProgram(pointProgram);
+    gl.uniform2f(pRes, W, H);
+    gl.uniform1f(pTime, timeSec);
+    gl.uniform1f(pGravity, GRAVITY * scale);
+    gl.uniform1f(pTau, DRAG_TAU);
+    gl.uniform1f(pBaseHue, baseHue);
+    gl.uniform1f(pHueSpread, HUE_SPREAD);
+    gl.uniform1f(pSizeMax, sizeMax);
+    gl.bindVertexArray(vao);
+    gl.drawArrays(gl.POINTS, 0, count);
+  };
+
+  const updateRocket = (elapsed: number): void => {
+    const t = Math.min(1, elapsed / actualRiseMs);
+    const ry = startY + (targetY - startY) * easeOutQuad(t);
+    const wobble =
+      wobbleDir *
+      Math.sin(t * Math.PI * 2 * WOBBLE_CYCLES) *
+      WOBBLE_AMPLITUDE *
+      scale *
+      Math.cos((t * Math.PI) / 2);
+    const rx = targetX + wobble;
+    // head は現在位置、spark は直前位置寄りに少し散らす（trail バッファが尾を作る）。
+    for (let i = 0; i < ROCKET_POINTS; i++) {
+      const o = i * STRIDE_FLOATS;
+      if (i === 0) {
+        rocketData[o] = rx;
+        rocketData[o + 1] = ry;
+      } else {
+        const lag = i / ROCKET_POINTS;
+        rocketData[o] = rx + (prevRx - rx) * lag + (Math.random() * 2 - 1) * 2 * scale;
+        rocketData[o + 1] = ry + (prevRy - ry) * lag + (Math.random() * 2 - 1) * 2 * scale;
+      }
+    }
+    prevRx = rx;
+    prevRy = ry;
+    gl.bindBuffer(gl.ARRAY_BUFFER, rocketBuffer);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, rocketData);
+  };
+
+  const renderFrame = (elapsedMs: number): void => {
+    if (!targetA || !targetB) return;
+    gl.viewport(0, 0, W, H);
+
+    // 1) fade pass: 前フレーム（targetA）を減衰させて targetB へ写す。
+    gl.bindFramebuffer(gl.FRAMEBUFFER, targetB.fbo);
+    gl.disable(gl.BLEND);
+    drawFullscreen(targetA.tex, TRAIL_FADE, TRAIL_FLOOR);
+
+    // 2) 現在の粒を targetB に加算合成。
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE);
+    if (elapsedMs < actualRiseMs) {
+      updateRocket(elapsedMs);
+      drawPoints(rocketVao, ROCKET_POINTS, 0);
+    } else {
+      if (!burstStarted) {
+        burstStarted = true;
+        burstStartMs = elapsedMs;
+      }
+      drawPoints(burstVao, particleCount, (elapsedMs - burstStartMs) / 1000);
+    }
+
+    // 3) present: targetB を画面（default framebuffer）へ提示。
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.disable(gl.BLEND);
+    drawFullscreen(targetB.tex, 1, 0);
+
+    // 4) ping-pong swap。
+    const tmp = targetA;
+    targetA = targetB;
+    targetB = tmp;
+  };
+
+  const dispose = (): void => {
+    gl.deleteProgram(quadProgram);
+    gl.deleteProgram(pointProgram);
+    gl.deleteBuffer(burstBuffer);
+    gl.deleteBuffer(rocketBuffer);
+    gl.deleteVertexArray(burstVao);
+    gl.deleteVertexArray(rocketVao);
+    gl.deleteVertexArray(emptyVao);
+    if (targetA) {
+      gl.deleteTexture(targetA.tex);
+      gl.deleteFramebuffer(targetA.fbo);
+    }
+    if (targetB) {
+      gl.deleteTexture(targetB.tex);
+      gl.deleteFramebuffer(targetB.fbo);
+    }
+    targetA = null;
+    targetB = null;
+  };
+
+  return { renderFrame, dispose };
+}
 
 export default {
   id: "fireworks",
@@ -93,137 +534,36 @@ export default {
   singleton: true,
   run: async (ctx: EffectContext<FireworksOptions>, options: FireworksOptions): Promise<void> => {
     let rafId: number | null = null;
+    let sceneDispose: (() => void) | null = null;
 
-    const handle = ctx.renderer.drawOnCanvas((g) => {
-      // HiDPI 済み canvas から CSS pixel 寸法を逆算する。
-      // drawOnCanvas 側で ctx.scale(dpr, dpr) 済みなので、transform の
-      // スケール値 a = dpr。canvas.width は実 pixel、/ dpr で論理 pixel。
-      // decision: docs/decisions/effect-rendering-primitives.md 「生 DOM を
-      // pack に渡さない」— pack から window / document への直接アクセスは
-      // 避け、RendererAPI 経由で得られる情報だけで完結させる。
-      const dpr = g.getTransform().a || 1;
-      const W = g.canvas.width / dpr;
-      const H = g.canvas.height / dpr;
-      const targetX = options.origin.x * W;
-      const targetY = options.origin.y * H;
-      const startY = H + START_Y_OFFSET;
+    const handle = ctx.renderer.drawOnGLCanvas((gl) => {
+      const scene = setupScene(gl, options);
+      if (!scene) return; // GL resource 確保に失敗したら no-op。
+      sceneDispose = scene.dispose;
 
-      // 1 発ごとの色と動きの揺らぎ。
-      const baseHue = Math.random() * 360;
-      const wobbleDir = Math.random() < 0.5 ? 1 : -1;
-      const actualRiseMs = RISE_MS + (Math.random() * 2 - 1) * RISE_JITTER_MS;
-
-      const particles: Particle[] = [];
-      let burstStarted = false;
       const startTime = performance.now();
-      // 前フレームの rocket 位置。streak（線分）で尾を引くために保持する。
-      // 初回 frame は prev === current なので線は描画されない。
-      let prevRx = targetX;
-      let prevRy = startY;
-
-      const spawnBurst = (): void => {
-        for (let i = 0; i < options.count; i++) {
-          const angle = (i / options.count) * Math.PI * 2 + Math.random() * 0.08;
-          const speed = 2.0 + Math.random() * 2.6;
-          particles.push({
-            x: targetX,
-            y: targetY,
-            vx: Math.cos(angle) * speed,
-            vy: Math.sin(angle) * speed,
-            life: 0,
-            maxLife: 80 + Math.random() * 50,
-            hue: baseHue + (Math.random() * 2 - 1) * HUE_JITTER,
-          });
-        }
-      };
-
-      /** 既存描画を一定割合だけ透明化。clearRect の代わりに使うと trail になる。 */
-      const fadeCanvas = (): void => {
-        g.globalCompositeOperation = "destination-out";
-        g.fillStyle = `rgba(0,0,0,${FADE_ALPHA})`;
-        g.fillRect(0, 0, W, H);
-        g.globalCompositeOperation = "source-over";
-      };
-
-      const drawRise = (elapsed: number): void => {
-        const t = Math.min(1, elapsed / actualRiseMs);
-        const ry = startY + (targetY - startY) * easeOutQuad(t);
-        // wobble: sin で左右に振り、apex（t=1）へ向けて cos(t·π/2) で 0 に収束。
-        const wobble =
-          wobbleDir *
-          Math.sin(t * Math.PI * 2 * WOBBLE_CYCLES) *
-          WOBBLE_AMPLITUDE *
-          Math.cos((t * Math.PI) / 2);
-        const rx = targetX + wobble;
-
-        // prev → current の線分で streak を描く。fade-based 残像と
-        // 組み合わさって、揺れながら登る軌跡が光の尾として残る。
-        g.beginPath();
-        g.moveTo(prevRx, prevRy);
-        g.lineTo(rx, ry);
-        g.strokeStyle = `hsla(${baseHue}, 95%, 78%, 0.92)`;
-        g.lineWidth = ROCKET_RADIUS * 0.85;
-        g.lineCap = "round";
-        g.stroke();
-
-        // rocket head（熱源の core）。streak より彩度 / 明度を高く。
-        g.beginPath();
-        g.arc(rx, ry, ROCKET_RADIUS, 0, Math.PI * 2);
-        g.fillStyle = `hsla(${baseHue}, 100%, 86%, 1)`;
-        g.fill();
-
-        prevRx = rx;
-        prevRy = ry;
-      };
-
-      const drawBurst = (): void => {
-        for (const p of particles) {
-          p.x += p.vx;
-          p.y += p.vy;
-          p.vy += GRAVITY;
-          p.vx *= DRAG;
-          p.vy *= DRAG;
-          p.life += 1;
-
-          const t = 1 - p.life / p.maxLife;
-          if (t <= 0) continue;
-          g.beginPath();
-          g.arc(p.x, p.y, PARTICLE_RADIUS, 0, Math.PI * 2);
-          g.fillStyle = `hsla(${p.hue}, 90%, 62%, ${t})`;
-          g.fill();
-        }
-      };
-
       const tick = (): void => {
         if (ctx.signal.aborted) {
           rafId = null;
           return;
         }
-        fadeCanvas();
-
-        const elapsed = performance.now() - startTime;
-        if (elapsed < actualRiseMs) {
-          drawRise(elapsed);
-        } else {
-          if (!burstStarted) {
-            spawnBurst();
-            burstStarted = true;
-          }
-          drawBurst();
-        }
-
+        scene.renderFrame(performance.now() - startTime);
         rafId = requestAnimationFrame(tick);
       };
       rafId = requestAnimationFrame(tick);
     });
 
-    // signal abort 時に即座に RAF cancel + handle.dispose する。
+    // signal abort 時に即 RAF cancel + GL 解放 + canvas 撤去する。
     // singleton: true なので、同 id の新規 dispatch で前の signal が abort される。
-    // handle.dispose() は冪等なので finally と二重呼びになっても安全。
-    const cleanup = () => {
+    // cleanup は冪等。
+    const cleanup = (): void => {
       if (rafId !== null) {
         cancelAnimationFrame(rafId);
         rafId = null;
+      }
+      if (sceneDispose) {
+        sceneDispose();
+        sceneDispose = null;
       }
       handle.dispose();
     };
@@ -231,8 +571,7 @@ export default {
 
     try {
       // durationMs は「呼び出し側が canvas を保持したい最低時間」の hint。
-      // rise + burst fade の自然終了時間を下回る場合は pack 側で延長する
-      // （burst が途中で切れないように）。
+      // rise + burst fade の自然終了時間を下回る場合は pack 側で延長する。
       await ctx.time.after(Math.max(options.durationMs, MIN_EFFECT_MS));
     } finally {
       ctx.signal.removeEventListener("abort", cleanup);

--- a/bundled-packs/effects/fireworks/effect.ts
+++ b/bundled-packs/effects/fireworks/effect.ts
@@ -72,7 +72,7 @@ const RISE_MS = 2000;
 const RISE_JITTER_MS = 100;
 /** burst 後の粒が自然に fade しきるまでの buffer（ms）。LIFE 上限と trail の
  *  減衰を見込んで余裕を取る。 */
-const BURST_FADE_TAIL_MS = 2600;
+const BURST_FADE_TAIL_MS = 2500;
 /** 1 発が natural に演じ終わるまでの最低所要時間。options.durationMs がこれを
  *  下回る場合、pack が延長して burst が途中で切れないようにする。 */
 const MIN_EFFECT_MS = RISE_MS + RISE_JITTER_MS + BURST_FADE_TAIL_MS;
@@ -85,29 +85,30 @@ const START_Y_OFFSET = 30;
 const WOBBLE_CYCLES = 5;
 /** 左右揺らぎの最大振幅（CSS px 基準）、t=0 で最大、apex で 0 に収束。 */
 const WOBBLE_AMPLITUDE = 7;
-/** 毎フレーム trail を残す割合（大きいほど尾が長い）。流れ過ぎないよう尾は短め。 */
-const TRAIL_FADE = 0.84;
+/** 毎フレーム trail を残す割合（大きいほど尾が長い）。CPU 版 FADE_ALPHA=0.12 ≈ 1-0.12=0.88 相当。 */
+const TRAIL_FADE = 0.88;
 /** trail を確実に 0 へ落とすための減算項（8bit の量子化で消え残るのを防ぐ）。 */
 const TRAIL_FLOOR = 0.01;
-/** 重力（px/s²、画面下向き）。画面解像度でスケールする。雨だれ化を抑えるため弱め。 */
-const GRAVITY = 120;
-/** drag の時定数（s）。小さいほど早く失速する。強めの drag で「ふわっと開いて漂う」。 */
-const DRAG_TAU = 0.46;
-/** 爆発粒の初速レンジ（px/s、画面解像度でスケール）。ゆっくり開くため抑えめ。 */
-const SPEED_MIN = 80;
-const SPEED_MAX = 340;
-/** 粒寿命レンジ（s）。長めに取って bloom をふわっと残す。 */
-const LIFE_MIN = 1.5;
-const LIFE_MAX = 3.4;
-/** 粒の基準サイズレンジ（CSS px 基準、稀に大きな星を混ぜる）。柔らかい綿毛感のため大きめ。 */
-const SIZE_MIN = 5.0;
-const SIZE_MAX = 11.0;
-/** options.count に対する実 GPU 粒数の倍率。細かすぎないよう粒は大きく数は控えめに。 */
-const DENSITY = 9;
-const PARTICLE_MIN = 180;
-const PARTICLE_MAX = 1200;
-/** base hue からの揺らぎ幅（0-1 hue 空間、±この値）。 */
-const HUE_SPREAD = 0.06;
+/** 重力（px/s²、画面下向き）。CPU 版 0.05 px/frame² ≈ 180 px/s² 相当。 */
+const GRAVITY = 180;
+/** drag の時定数（s）。CPU 版の per-frame drag 0.985 ≈ τ≈1.1s 相当だが、
+ *  GPU 版は解析解なのでやや短めに取ってテンポよく収まらせる。 */
+const DRAG_TAU = 0.55;
+/** 爆発粒の初速レンジ（px/s、画面解像度でスケール）。CPU 版 2.0-4.6 px/frame ≈ 120-276 px/s 相当。 */
+const SPEED_MIN = 120;
+const SPEED_MAX = 280;
+/** 粒寿命レンジ（s）。CPU 版 80-130 frame ≈ 1.3-2.2s 相当。 */
+const LIFE_MIN = 1.3;
+const LIFE_MAX = 2.2;
+/** 粒の基準サイズレンジ（CSS px 基準）。glow が映えるよう大きめに。 */
+const SIZE_MIN = 4.5;
+const SIZE_MAX = 9.0;
+/** options.count をそのまま粒数に使う（CPU 版と同じ）。DENSITY=1 で倍率なし。 */
+const DENSITY = 1;
+const PARTICLE_MIN = 30;
+const PARTICLE_MAX = 300;
+/** base hue からの揺らぎ幅（0-1 hue 空間、±この値）。CPU 版 ±15° ≈ ±0.042。 */
+const HUE_SPREAD = 0.042;
 /** 解像度スケールの基準高さ（px）。buffer 高さ / これでサイズ・速度を倍率。 */
 const REFERENCE_HEIGHT = 900;
 /** rocket の発光点数（head + sparks）。trail バッファが尾を作るので少数で足りる。 */
@@ -214,7 +215,6 @@ void main() {
   float r = length(d) * 2.0;          // 0=中心, 1=縁
   if (r > 1.0) discard;
   float core = smoothstep(1.0, 0.0, r);
-  // 広いハロー主体の柔らかいグロー（鋭い芯は控えめ）。綿毛のような発光に。
   float glow = pow(core, 1.35) + 0.22 * pow(core, 3.0);
   float a = glow * v_alpha;
   if (a <= 0.003) discard;

--- a/bundled-packs/effects/fireworks/effect.ts
+++ b/bundled-packs/effects/fireworks/effect.ts
@@ -85,28 +85,27 @@ const START_Y_OFFSET = 30;
 const WOBBLE_CYCLES = 5;
 /** 左右揺らぎの最大振幅（CSS px 基準）、t=0 で最大、apex で 0 に収束。 */
 const WOBBLE_AMPLITUDE = 7;
-/** 毎フレーム trail を残す割合（大きいほど尾が長い）。 */
-const TRAIL_FADE = 0.92;
+/** 毎フレーム trail を残す割合（大きいほど尾が長い）。流れ過ぎないよう尾は短め。 */
+const TRAIL_FADE = 0.84;
 /** trail を確実に 0 へ落とすための減算項（8bit の量子化で消え残るのを防ぐ）。 */
-const TRAIL_FLOOR = 0.009;
-/** 重力（px/s²、画面下向き）。画面解像度でスケールする。 */
-const GRAVITY = 520;
-/** drag の時定数（s）。小さいほど早く失速する。 */
-const DRAG_TAU = 0.9;
-/** 爆発粒の初速レンジ（px/s、画面解像度でスケール）。 */
-const SPEED_MIN = 130;
-const SPEED_MAX = 680;
-/** 粒寿命レンジ（s）。長めに取って bloom を画面に残す。 */
-const LIFE_MIN = 1.3;
-const LIFE_MAX = 3.0;
-/** 粒の基準サイズレンジ（CSS px 基準、稀に大きな星を混ぜる）。発光感のため太め。 */
-const SIZE_MIN = 3.2;
-const SIZE_MAX = 7.5;
-/** options.count に対する実 GPU 粒数の倍率。GPU は粒数にほぼ無依存なので、
- *  見栄えのために増やす。総数は MIN/MAX でクランプ。 */
-const DENSITY = 14;
-const PARTICLE_MIN = 260;
-const PARTICLE_MAX = 2000;
+const TRAIL_FLOOR = 0.01;
+/** 重力（px/s²、画面下向き）。画面解像度でスケールする。雨だれ化を抑えるため弱め。 */
+const GRAVITY = 120;
+/** drag の時定数（s）。小さいほど早く失速する。強めの drag で「ふわっと開いて漂う」。 */
+const DRAG_TAU = 0.46;
+/** 爆発粒の初速レンジ（px/s、画面解像度でスケール）。ゆっくり開くため抑えめ。 */
+const SPEED_MIN = 80;
+const SPEED_MAX = 340;
+/** 粒寿命レンジ（s）。長めに取って bloom をふわっと残す。 */
+const LIFE_MIN = 1.5;
+const LIFE_MAX = 3.4;
+/** 粒の基準サイズレンジ（CSS px 基準、稀に大きな星を混ぜる）。柔らかい綿毛感のため大きめ。 */
+const SIZE_MIN = 5.0;
+const SIZE_MAX = 11.0;
+/** options.count に対する実 GPU 粒数の倍率。細かすぎないよう粒は大きく数は控えめに。 */
+const DENSITY = 9;
+const PARTICLE_MIN = 180;
+const PARTICLE_MAX = 1200;
 /** base hue からの揺らぎ幅（0-1 hue 空間、±この値）。 */
 const HUE_SPREAD = 0.06;
 /** 解像度スケールの基準高さ（px）。buffer 高さ / これでサイズ・速度を倍率。 */
@@ -187,11 +186,11 @@ void main() {
   float life = clamp(t / a_maxLife, 0.0, 1.0);
   float fade = 1.0 - life;
   // twinkle（粒ごとに位相と周期を散らす）。
-  float tw = 0.82 + 0.18 * sin(t * (7.0 + a_seed * 13.0) + a_seed * 31.4);
-  // 爆発直後の白熱ブースト。
-  float flash = 1.0 + 2.4 * exp(-t * 7.0);
-  // fade^1.25 で bloom を fade² より長く保つ。
-  v_alpha = pow(fade, 1.25) * tw * flash;
+  float tw = 0.84 + 0.16 * sin(t * (6.0 + a_seed * 11.0) + a_seed * 31.4);
+  // 爆発直後の白熱ブースト（柔らかめ）。
+  float flash = 1.0 + 1.5 * exp(-t * 5.5);
+  // fade^1.1 で bloom をふわっと長く保つ。
+  v_alpha = pow(fade, 1.1) * tw * flash;
 
   float hue = u_baseHue + (a_seed - 0.5) * u_hueSpread;
   v_color = hue2rgb(hue);
@@ -200,7 +199,8 @@ void main() {
   vec2 clip = (pos / u_resolution) * 2.0 - 1.0;
   clip.y = -clip.y;
   gl_Position = vec4(clip, 0.0, 1.0);
-  gl_PointSize = clamp(a_size * (0.58 + 0.42 * fade), 2.0, u_sizeMax);
+  // サイズは寿命をかけてゆっくり縮む程度に留め、ふっくらした見た目を保つ。
+  gl_PointSize = clamp(a_size * (0.72 + 0.28 * fade), 2.0, u_sizeMax);
 }`;
 
 /** 円形ソフトグロー。premultiplied 加算用に `vec4(rgb·a, a)` を出力。 */
@@ -214,12 +214,12 @@ void main() {
   float r = length(d) * 2.0;          // 0=中心, 1=縁
   if (r > 1.0) discard;
   float core = smoothstep(1.0, 0.0, r);
-  // 鋭い芯 + 広いハローの二層で発光感を強める。
-  float glow = pow(core, 1.7) + 0.45 * pow(core, 5.0);
+  // 広いハロー主体の柔らかいグロー（鋭い芯は控えめ）。綿毛のような発光に。
+  float glow = pow(core, 1.35) + 0.22 * pow(core, 3.0);
   float a = glow * v_alpha;
   if (a <= 0.003) discard;
-  // 芯ほど白熱、全体の輝度を底上げ。
-  vec3 c = mix(v_color, vec3(1.0), core * core * 0.75) * 1.35;
+  // 芯ほど白へ寄せるが控えめ、全体の輝度を底上げ。
+  vec3 c = mix(v_color, vec3(1.0), core * core * 0.55) * 1.28;
   frag = vec4(c * a, a);
 }`;
 
@@ -381,9 +381,10 @@ function setupScene(gl: WebGL2RenderingContext, options: FireworksOptions): Scen
   const burstData = new Float32Array(particleCount * STRIDE_FLOATS);
   for (let i = 0; i < particleCount; i++) {
     const angle = Math.random() * Math.PI * 2;
-    // sqrt 分布で外殻に粒を寄せ、丸い burst に見せる。30% は低速の残り火。
-    const isEmber = Math.random() < 0.3;
-    const speedT = isEmber ? Math.random() * 0.35 : 0.35 + Math.sqrt(Math.random()) * 0.65;
+    // 速度を一様に散らして中身まで満たし、外殻に粒が寄った硬い放射スポークを避ける。
+    // 35% は低速の残り火で芯をふっくらさせる。
+    const isEmber = Math.random() < 0.35;
+    const speedT = isEmber ? Math.random() * 0.4 : 0.25 + Math.random() * 0.75;
     const speed = (SPEED_MIN + (SPEED_MAX - SPEED_MIN) * speedT) * scale;
     const maxLife = LIFE_MIN + Math.random() * (LIFE_MAX - LIFE_MIN) + (isEmber ? 0.4 : 0);
     // 稀に大きな星。

--- a/bundled-packs/effects/fireworks/effect.ts
+++ b/bundled-packs/effects/fireworks/effect.ts
@@ -86,29 +86,29 @@ const WOBBLE_CYCLES = 5;
 /** 左右揺らぎの最大振幅（CSS px 基準）、t=0 で最大、apex で 0 に収束。 */
 const WOBBLE_AMPLITUDE = 7;
 /** 毎フレーム trail を残す割合（大きいほど尾が長い）。 */
-const TRAIL_FADE = 0.9;
+const TRAIL_FADE = 0.92;
 /** trail を確実に 0 へ落とすための減算項（8bit の量子化で消え残るのを防ぐ）。 */
-const TRAIL_FLOOR = 0.014;
+const TRAIL_FLOOR = 0.009;
 /** 重力（px/s²、画面下向き）。画面解像度でスケールする。 */
 const GRAVITY = 520;
 /** drag の時定数（s）。小さいほど早く失速する。 */
-const DRAG_TAU = 0.85;
+const DRAG_TAU = 0.9;
 /** 爆発粒の初速レンジ（px/s、画面解像度でスケール）。 */
 const SPEED_MIN = 130;
-const SPEED_MAX = 720;
-/** 粒寿命レンジ（s）。 */
-const LIFE_MIN = 0.9;
-const LIFE_MAX = 2.3;
-/** 粒の基準サイズレンジ（CSS px 基準、稀に大きな星を混ぜる）。 */
-const SIZE_MIN = 1.6;
-const SIZE_MAX = 4.2;
+const SPEED_MAX = 680;
+/** 粒寿命レンジ（s）。長めに取って bloom を画面に残す。 */
+const LIFE_MIN = 1.3;
+const LIFE_MAX = 3.0;
+/** 粒の基準サイズレンジ（CSS px 基準、稀に大きな星を混ぜる）。発光感のため太め。 */
+const SIZE_MIN = 3.2;
+const SIZE_MAX = 7.5;
 /** options.count に対する実 GPU 粒数の倍率。GPU は粒数にほぼ無依存なので、
  *  見栄えのために増やす。総数は MIN/MAX でクランプ。 */
-const DENSITY = 12;
-const PARTICLE_MIN = 220;
-const PARTICLE_MAX = 1800;
+const DENSITY = 14;
+const PARTICLE_MIN = 260;
+const PARTICLE_MAX = 2000;
 /** base hue からの揺らぎ幅（0-1 hue 空間、±この値）。 */
-const HUE_SPREAD = 0.05;
+const HUE_SPREAD = 0.06;
 /** 解像度スケールの基準高さ（px）。buffer 高さ / これでサイズ・速度を倍率。 */
 const REFERENCE_HEIGHT = 900;
 /** rocket の発光点数（head + sparks）。trail バッファが尾を作るので少数で足りる。 */
@@ -187,10 +187,11 @@ void main() {
   float life = clamp(t / a_maxLife, 0.0, 1.0);
   float fade = 1.0 - life;
   // twinkle（粒ごとに位相と周期を散らす）。
-  float tw = 0.78 + 0.22 * sin(t * (7.0 + a_seed * 13.0) + a_seed * 31.4);
+  float tw = 0.82 + 0.18 * sin(t * (7.0 + a_seed * 13.0) + a_seed * 31.4);
   // 爆発直後の白熱ブースト。
-  float flash = 1.0 + 1.4 * exp(-t * 8.0);
-  v_alpha = fade * fade * tw * flash;
+  float flash = 1.0 + 2.4 * exp(-t * 7.0);
+  // fade^1.25 で bloom を fade² より長く保つ。
+  v_alpha = pow(fade, 1.25) * tw * flash;
 
   float hue = u_baseHue + (a_seed - 0.5) * u_hueSpread;
   v_color = hue2rgb(hue);
@@ -199,7 +200,7 @@ void main() {
   vec2 clip = (pos / u_resolution) * 2.0 - 1.0;
   clip.y = -clip.y;
   gl_Position = vec4(clip, 0.0, 1.0);
-  gl_PointSize = clamp(a_size * (0.45 + 0.55 * fade), 1.0, u_sizeMax);
+  gl_PointSize = clamp(a_size * (0.58 + 0.42 * fade), 2.0, u_sizeMax);
 }`;
 
 /** 円形ソフトグロー。premultiplied 加算用に `vec4(rgb·a, a)` を出力。 */
@@ -211,12 +212,14 @@ out vec4 frag;
 void main() {
   vec2 d = gl_PointCoord - 0.5;
   float r = length(d) * 2.0;          // 0=中心, 1=縁
+  if (r > 1.0) discard;
   float core = smoothstep(1.0, 0.0, r);
-  float glow = pow(core, 2.2);
+  // 鋭い芯 + 広いハローの二層で発光感を強める。
+  float glow = pow(core, 1.7) + 0.45 * pow(core, 5.0);
   float a = glow * v_alpha;
-  if (a <= 0.002) discard;
-  // 芯ほど白へ寄せ、白熱した核を作る。
-  vec3 c = mix(v_color, vec3(1.0), core * 0.6);
+  if (a <= 0.003) discard;
+  // 芯ほど白熱、全体の輝度を底上げ。
+  vec3 c = mix(v_color, vec3(1.0), core * core * 0.75) * 1.35;
   frag = vec4(c * a, a);
 }`;
 
@@ -406,7 +409,7 @@ function setupScene(gl: WebGL2RenderingContext, options: FireworksOptions): Scen
     rocketData[o + 3] = 0;
     rocketData[o + 4] = Math.random();
     rocketData[o + 5] = 1; // maxLife（u_time=0 で常に full bright なので無効）
-    rocketData[o + 6] = (i === 0 ? 4.0 : 2.4) * scale; // head は太め
+    rocketData[o + 6] = (i === 0 ? 6.0 : 3.4) * scale; // head は太め
   }
   gl.bindBuffer(gl.ARRAY_BUFFER, rocketBuffer);
   gl.bufferData(gl.ARRAY_BUFFER, rocketData, gl.DYNAMIC_DRAW);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "charminal",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "charminal",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@pixiv/three-vrm": "^3.5.1",

--- a/src/core/space/effect-pack-runner.test.ts
+++ b/src/core/space/effect-pack-runner.test.ts
@@ -10,6 +10,7 @@ const makeRendererStub = (): RendererAPI => ({
   addParticles: vi.fn(() => ({ dispose: () => {}, completion: Promise.resolve() })),
   addCameraMove: vi.fn(() => ({ dispose: () => {} })),
   drawOnCanvas: vi.fn(() => ({ dispose: () => {} })),
+  drawOnGLCanvas: vi.fn(() => ({ dispose: () => {} })),
   addDomLayer: vi.fn(() => ({ dispose: () => {} })),
   queryTerminalCells: vi.fn(() => null),
 });

--- a/src/core/space/renderer.test.ts
+++ b/src/core/space/renderer.test.ts
@@ -125,13 +125,26 @@ interface FakeMountLike {
 const makeFakeContext = (): CanvasRenderingContext2D =>
   ({ scale: vi.fn() }) as unknown as CanvasRenderingContext2D;
 
-const makeFakeCanvas = (ctx: CanvasRenderingContext2D | null): FakeCanvasLike => {
+/** drawOnGLCanvas 用の fake WebGL2 context。viewport の呼び出しだけ観測する。 */
+const makeFakeGl = (): WebGL2RenderingContext =>
+  ({
+    viewport: vi.fn(),
+    drawingBufferWidth: 0,
+    drawingBufferHeight: 0,
+  }) as unknown as WebGL2RenderingContext;
+
+const makeFakeCanvas = (
+  ctx: CanvasRenderingContext2D | null,
+  gl: WebGL2RenderingContext | null,
+): FakeCanvasLike => {
   const canvas: FakeCanvasLike = {
     style: {},
     width: 0,
     height: 0,
     parentElements: [],
-    getContext: vi.fn().mockReturnValue(ctx),
+    // getContext は要求された種別で振り分ける。"webgl2"/"webgl" は gl、
+    // それ以外（"2d"）は 2D context を返す。
+    getContext: vi.fn((type: string) => (type === "webgl2" || type === "webgl" ? gl : ctx)),
     remove: vi.fn(function remove(this: unknown): void {
       const c = canvas;
       // 最後に append された parent から自分を外す（1 回しか発生しない想定）。
@@ -178,6 +191,7 @@ interface DomHarness {
   readonly canvases: FakeCanvasLike[];
   readonly divs: FakeDivLike[];
   ctx: CanvasRenderingContext2D | null;
+  gl: WebGL2RenderingContext | null;
   dpr: number;
   width: number;
   height: number;
@@ -185,6 +199,7 @@ interface DomHarness {
 
 const makeDomHarness = (overrides?: {
   ctx?: CanvasRenderingContext2D | null;
+  gl?: WebGL2RenderingContext | null;
   dpr?: number;
   width?: number;
   height?: number;
@@ -194,12 +209,13 @@ const makeDomHarness = (overrides?: {
     canvases: [],
     divs: [],
     ctx: overrides?.ctx === undefined ? makeFakeContext() : overrides.ctx,
+    gl: overrides?.gl === undefined ? makeFakeGl() : overrides.gl,
     dpr: overrides?.dpr ?? 1,
     width: overrides?.width ?? 1024,
     height: overrides?.height ?? 768,
     dom: {
       createCanvas: () => {
-        const canvas = makeFakeCanvas(harness.ctx);
+        const canvas = makeFakeCanvas(harness.ctx, harness.gl);
         harness.canvases.push(canvas);
         return canvas as unknown as HTMLCanvasElement;
       },
@@ -344,6 +360,141 @@ describe("Renderer.drawOnCanvas", () => {
     const mount = makeFakeMount();
     const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
     const handle = renderer.drawOnCanvas(() => {});
+    const canvas = harness.canvases[0];
+    expect(canvas?.style.position).toBe("fixed");
+    expect(canvas?.style.inset).toBe("0");
+    expect(canvas?.style.width).toBe("100vw");
+    expect(canvas?.style.height).toBe("100vh");
+    expect(canvas?.style.pointerEvents).toBe("none");
+    expect(canvas?.style.zIndex).toBe("9999");
+    handle.dispose();
+  });
+});
+
+// ─── drawOnGLCanvas ───────────────────────────────────────
+
+describe("Renderer.drawOnGLCanvas", () => {
+  const makeRenderer = (harness: DomHarness, canvasMount?: HTMLElement): Renderer =>
+    new Renderer({
+      shakeTarget: { style: { transform: "" } } as unknown as HTMLElement,
+      canvasMount,
+      dom: harness.dom,
+    });
+
+  it("returns a Disposable handle", () => {
+    const harness = makeDomHarness();
+    const mount = makeFakeMount();
+    const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
+    const handle = renderer.drawOnGLCanvas(() => {});
+    expect(typeof handle.dispose).toBe("function");
+    handle.dispose();
+  });
+
+  it("canvasMount に渡した element に canvas を append する", () => {
+    const harness = makeDomHarness();
+    const mount = makeFakeMount();
+    const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
+    const handle = renderer.drawOnGLCanvas(() => {});
+    expect(mount.appendChild).toHaveBeenCalledTimes(1);
+    expect(mount.children.length).toBe(1);
+    expect(mount.children[0]).toBe(harness.canvases[0]);
+    handle.dispose();
+  });
+
+  it("canvasMount を省略すると dom.getDefaultCanvasMount() の返り値が使われる", () => {
+    const fakeDefaultMount = makeFakeMount();
+    const harness = makeDomHarness({
+      defaultCanvasMount: fakeDefaultMount as unknown as HTMLElement,
+    });
+    const renderer = makeRenderer(harness);
+    const handle = renderer.drawOnGLCanvas(() => {});
+    expect(fakeDefaultMount.appendChild).toHaveBeenCalledTimes(1);
+    expect(fakeDefaultMount.children.length).toBe(1);
+    handle.dispose();
+  });
+
+  it("getContext('webgl2') の結果を draw callback にそのまま渡す", () => {
+    const gl = makeFakeGl();
+    const harness = makeDomHarness({ gl });
+    const mount = makeFakeMount();
+    const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
+    const draw = vi.fn();
+    const handle = renderer.drawOnGLCanvas(draw);
+    expect(draw).toHaveBeenCalledTimes(1);
+    expect(draw).toHaveBeenCalledWith(gl);
+    handle.dispose();
+  });
+
+  it("draw callback は 1 回だけ呼ばれる（毎フレームは呼ばない）", () => {
+    const harness = makeDomHarness();
+    const mount = makeFakeMount();
+    const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
+    const draw = vi.fn();
+    const handle = renderer.drawOnGLCanvas(draw);
+    expect(draw).toHaveBeenCalledTimes(1);
+    handle.dispose();
+    expect(draw).toHaveBeenCalledTimes(1);
+  });
+
+  it("getContext が null を返す場合は throw せず Disposable を返す", () => {
+    const harness = makeDomHarness({ gl: null });
+    const mount = makeFakeMount();
+    const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
+    const draw = vi.fn();
+    let handle: { dispose: () => void } | undefined;
+    expect(() => {
+      handle = renderer.drawOnGLCanvas(draw);
+    }).not.toThrow();
+    expect(handle).toBeDefined();
+    expect(typeof handle?.dispose).toBe("function");
+    // gl が取れない以上 draw callback は呼ばない（無効な gl を渡さない）。
+    expect(draw).not.toHaveBeenCalled();
+    expect(() => handle?.dispose()).not.toThrow();
+  });
+
+  it("dispose で canvas が parent から remove される", () => {
+    const harness = makeDomHarness();
+    const mount = makeFakeMount();
+    const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
+    const handle = renderer.drawOnGLCanvas(() => {});
+    const canvas = harness.canvases[0];
+    expect(mount.children).toContain(canvas);
+    handle.dispose();
+    expect(canvas?.remove).toHaveBeenCalledTimes(1);
+    expect(mount.children).not.toContain(canvas);
+  });
+
+  it("dispose は冪等：2 回呼んでも例外なし、canvas.remove は 1 回だけ発生する", () => {
+    const harness = makeDomHarness();
+    const mount = makeFakeMount();
+    const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
+    const handle = renderer.drawOnGLCanvas(() => {});
+    const canvas = harness.canvases[0];
+    expect(() => {
+      handle.dispose();
+      handle.dispose();
+    }).not.toThrow();
+    expect(canvas?.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it("HiDPI を考慮した canvas.width / height を設定し gl.viewport(0,0,w,h) を呼ぶ", () => {
+    const gl = makeFakeGl();
+    const harness = makeDomHarness({ gl, dpr: 2, width: 800, height: 600 });
+    const mount = makeFakeMount();
+    const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
+    const handle = renderer.drawOnGLCanvas(() => {});
+    const canvas = harness.canvases[0];
+    expect(canvas?.width).toBe(1600); // 800 * 2
+    expect(canvas?.height).toBe(1200); // 600 * 2
+    expect(gl.viewport).toHaveBeenCalledWith(0, 0, 1600, 1200);
+    handle.dispose();
+  });
+
+  it("overlay の fixed style（position / inset / pointer-events / z-index）が canvas に適用される", () => {
+    const harness = makeDomHarness();
+    const mount = makeFakeMount();
+    const renderer = makeRenderer(harness, mount as unknown as HTMLElement);
+    const handle = renderer.drawOnGLCanvas(() => {});
     const canvas = harness.canvases[0];
     expect(canvas?.style.position).toBe("fixed");
     expect(canvas?.style.inset).toBe("0");

--- a/src/core/space/renderer.ts
+++ b/src/core/space/renderer.ts
@@ -308,6 +308,64 @@ export class Renderer implements RendererAPI {
   }
 
   /**
+   * 画面全面 overlay の WebGL2 canvas を生成し、`webgl2` context を 1 回だけ
+   * draw callback に渡す（GPU シェーダー effect 用）。drawOnCanvas と同じ
+   * overlay 原則（全画面 fixed / pointer 透過 / z-index 9999 / HiDPI backing
+   * store）に従う。
+   *
+   * drawOnCanvas が ctx.scale(dpr,dpr) で論理座標へ正規化するのに対し、
+   * WebGL では viewport を backing store の実 pixel に合わせるだけ——pack は
+   * `gl.drawingBufferWidth / Height` を画面寸法として clip 変換すればよい
+   * （dpr が backing store に畳み込まれるので point size も自動で物理 size に
+   * スケールする）。
+   *
+   * GL resource の解放は pack 側の責務。ここは canvas の DOM 着脱だけを
+   * 冪等に担保する。webgl2 が取れない環境では draw を呼ばず cleanup のみ。
+   */
+  drawOnGLCanvas(draw: (gl: WebGL2RenderingContext) => void): Disposable {
+    const canvas = this.dom.createCanvas();
+
+    Object.assign(canvas.style, CANVAS_OVERLAY_STYLES);
+
+    const dpr = this.dom.getDevicePixelRatio();
+    canvas.width = this.dom.getWindowWidth() * dpr;
+    canvas.height = this.dom.getWindowHeight() * dpr;
+
+    const mount = this.resolveCanvasMount();
+    mount.appendChild(canvas);
+
+    let disposed = false;
+    const disposable: Disposable = {
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        canvas.remove();
+      },
+    };
+
+    // premultipliedAlpha: pack は premultiplied color を出力し blendFunc(ONE,ONE)
+    // で加算合成する前提。alpha も蓄積されるので overlay が page 上で正しく
+    // 合成される（mix-blend-mode に依存しない）。
+    const gl = canvas.getContext("webgl2", {
+      alpha: true,
+      premultipliedAlpha: true,
+      antialias: true,
+      depth: false,
+      stencil: false,
+    });
+    if (gl === null) {
+      // webgl2 が使えない環境（test / 古い webview 等）では draw を呼ばず、
+      // cleanup だけ担保する。
+      return disposable;
+    }
+
+    gl.viewport(0, 0, canvas.width, canvas.height);
+    draw(gl);
+
+    return disposable;
+  }
+
+  /**
    * 画面全面 overlay の div を生成し、setup callback を 1 回だけ呼ぶ。
    * pack は container 内で自由に DOM 操作可能。
    * Disposable.dispose で div を DOM から remove する。冪等実装。

--- a/src/sdk/context.d.ts
+++ b/src/sdk/context.d.ts
@@ -799,6 +799,25 @@ export interface RendererAPI {
   addCameraMove(config: CameraMoveConfig): Disposable;
   /** Canvas に直接描画 */
   drawOnCanvas(draw: (ctx: CanvasRenderingContext2D) => void): Disposable;
+  /**
+   * WebGL2 canvas に直接描画（GPU シェーダー用）。`drawOnCanvas` の WebGL 版。
+   *
+   * 全画面 overlay の canvas を 1 つ acquire し、`webgl2` context を 1 回だけ
+   * draw callback に渡す。drawOnCanvas と同じく runtime 側で毎フレーム再呼出し
+   * はしない——pack は closure で gl を保持し自前 RAF loop を回す。viewport は
+   * backing store の実 pixel（HiDPI 込み）に合わせて設定済みで渡る。pack は
+   * `gl.drawingBufferWidth / drawingBufferHeight` を画面寸法として使えばよい
+   * （dpr は backing store に畳み込まれているので別途意識しなくてよい）。
+   *
+   * WebGL2 が使えない環境（headless / 一部の古い webview）では `getContext`
+   * が null を返すため draw callback は呼ばれず、cleanup だけが担保される。
+   * pack 側は「呼ばれなければ no-op」を前提に書くこと。
+   *
+   * Disposable.dispose で canvas を DOM から remove する。GL resource
+   * （program / buffer / texture / framebuffer）の解放は pack 側の責務
+   * （自前 RAF の cancel と合わせて signal abort 時に行う）。
+   */
+  drawOnGLCanvas(draw: (gl: WebGL2RenderingContext) => void): Disposable;
   /** DOM overlay layer を追加。container 内で自由に DOM 操作可能 */
   addDomLayer(setup: (container: HTMLDivElement) => void): Disposable;
   /** 画面振動フィルタを追加 */


### PR DESCRIPTION
## Summary
- `drawOnGLCanvas` WebGL2 renderer primitive を追加し、花火を CPU canvas から GPU シェーダーに移行
- 粒の物理を頂点シェーダーの解析解で解き、ping-pong FBO でトレイルを描画
- 最終的に CPU 版の見た目（粒数・速度・寿命・重力）に寄せつつ、GPU の glow だけ残した控えめな表現に調整

## Test plan
- [x] vitest 全テストパス（1497 tests）
- [x] TSC / biome / cargo-clippy 全パス
- [x] Charminal 上で Cmd+Shift+F で花火を発火し、以前の CPU 版と同程度の控えめさであることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)