### PR TITLE
[codex] Preserve terminal input lines on clear

### DIFF
--- a/src/runtime/terminal-runtime/terminal-runtime.test.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.test.ts
@@ -22,7 +22,7 @@ function deferred<T>(): Deferred<T> {
 const mockState = vi.hoisted(() => {
   const state: {
     channels: Array<{ onmessage: ((data: ArrayBuffer) => void) | null }>;
-    terminals: Array<{ writes: unknown[]; disposed: boolean }>;
+    terminals: Array<{ writes: unknown[]; clearCalls: number; disposed: boolean }>;
     fitCalls: number;
     focusCalls: number;
     unlisten: ReturnType<typeof vi.fn>;
@@ -83,6 +83,7 @@ vi.mock("@xterm/xterm", () => ({
     rows = 24;
     options: { theme?: unknown };
     writes: unknown[] = [];
+    clearCalls = 0;
     disposed = false;
     buffer = { active: null };
     parser = {
@@ -123,7 +124,9 @@ vi.mock("@xterm/xterm", () => ({
       mockState.focusCalls++;
     }
     refresh(): void {}
-    clear(): void {}
+    clear(): void {
+      this.clearCalls++;
+    }
   },
 }));
 
@@ -292,6 +295,32 @@ describe("TerminalRuntime", () => {
 
     expect(received).toEqual(["y"]);
     sub.dispose();
+  });
+
+  it("/clear は xterm の可視画面を消さず scrollback だけ消す", () => {
+    getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+
+    for (const ch of "/clear") {
+      mockState.dataHandlers[0]?.(ch);
+    }
+    mockState.dataHandlers[0]?.("\r");
+
+    expect(terminal.clearCalls).toBe(0);
+    expect(terminal.writes).toContain("\x1b[3J");
+  });
+
+  it("/compact も xterm の可視画面を消さず scrollback だけ消す", () => {
+    getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+
+    for (const ch of "/compact") {
+      mockState.dataHandlers[0]?.(ch);
+    }
+    mockState.dataHandlers[0]?.("\r");
+
+    expect(terminal.clearCalls).toBe(0);
+    expect(terminal.writes).toContain("\x1b[3J");
   });
 
   // attachTo は同期的に syncAttachedRect を 1 回呼ぶ（RAF を回さなくても

--- a/src/runtime/terminal-runtime/terminal-runtime.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.ts
@@ -740,7 +740,10 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     if (data.includes("\r") || data.includes("\n")) {
       const line = this.recentInput.trim();
       if (line === "/clear" || line === "/compact") {
-        this.term.clear();
+        // ESC[3J (Erase Saved Lines): scrollback だけ破棄し、可視領域と
+        // カーソルは一切触らない。term.clear() はカーソル行以外を全消去し
+        // ink TUI の相対描画モデルを狂わせるため使わない。
+        this.term.write("\x1b[3J");
       }
       this.recentInput = "";
     } else if (data === "\x7f") {


### PR DESCRIPTION
## Summary

- Avoid calling `term.clear()` when `/clear` or `/compact` is submitted through the terminal runtime.
- Clear only xterm scrollback with `ESC[3J`, leaving the visible Ink TUI/input area and cursor state intact.
- Add regression coverage for both `/clear` and `/compact`.

## Root Cause

Charminal intercepted `/clear` and `/compact` and called xterm's `clear()`, which erased the visible terminal buffer around the agent input area. That broke the two-line input decoration after clearing.

## Validation

- `npm test -- src/runtime/terminal-runtime/terminal-runtime.test.ts --run`
- `npm run check`
- pre-push hook: `tsc --noEmit`, `biome check`, `cargo fmt --check`, `cargo clippy`, TypeDoc validation