### PR TITLE
[codex] fix terminal IME composition input

### DIFF
--- a/src/runtime/terminal-runtime/terminal-runtime.test.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.test.ts
@@ -22,7 +22,13 @@ function deferred<T>(): Deferred<T> {
 const mockState = vi.hoisted(() => {
   const state: {
     channels: Array<{ onmessage: ((data: ArrayBuffer) => void) | null }>;
-    terminals: Array<{ writes: unknown[]; clearCalls: number; disposed: boolean }>;
+    terminals: Array<{
+      writes: unknown[];
+      clearCalls: number;
+      disposed: boolean;
+      textarea: HTMLTextAreaElement;
+      customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+    }>;
     fitCalls: number;
     focusCalls: number;
     unlisten: ReturnType<typeof vi.fn>;
@@ -85,6 +91,8 @@ vi.mock("@xterm/xterm", () => ({
     writes: unknown[] = [];
     clearCalls = 0;
     disposed = false;
+    textarea = document.createElement("textarea");
+    customKeyEventHandler?: (event: KeyboardEvent) => boolean;
     buffer = { active: null };
     parser = {
       registerOscHandler: (code: number, handler: (data: string) => boolean) => {
@@ -105,7 +113,9 @@ vi.mock("@xterm/xterm", () => ({
     }
 
     loadAddon(): void {}
-    open(): void {}
+    open(parent?: HTMLElement): void {
+      parent?.appendChild(this.textarea);
+    }
     reset(): void {
       this.writes = [];
     }
@@ -117,6 +127,9 @@ vi.mock("@xterm/xterm", () => ({
     }
     onData(handler: (data: string) => void): void {
       mockState.dataHandlers.push(handler);
+    }
+    attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void {
+      this.customKeyEventHandler = handler;
     }
     onResize(): void {}
     onScroll(): void {}
@@ -321,6 +334,70 @@ describe("TerminalRuntime", () => {
 
     expect(terminal.clearCalls).toBe(0);
     expect(terminal.writes).toContain("\x1b[3J");
+  });
+
+  it("suppresses intermediate IME data while composition is active", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    const received: string[] = [];
+    const sub = runtime.subscribeUserInput((data) => {
+      received.push(data);
+    });
+
+    terminal.textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+    mockState.dataHandlers[0]?.("g");
+    await flushMicrotasks();
+
+    expect(received).toEqual([]);
+    expect(mockState.sessionWrite).not.toHaveBeenCalled();
+    sub.dispose();
+  });
+
+  it("replaces stale xterm IME output with compositionend committed text", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    const received: string[] = [];
+    const sub = runtime.subscribeUserInput((data) => {
+      received.push(data);
+    });
+
+    terminal.textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+    terminal.textarea.dispatchEvent(new CompositionEvent("compositionend", { data: "背景の" }));
+    mockState.dataHandlers[0]?.("景a");
+    await flushMicrotasks();
+
+    expect(received).toEqual(["背景の"]);
+    expect(mockState.sessionWrite).toHaveBeenCalledWith({ sessionId: "shell-1", data: "背景の" });
+    expect(mockState.sessionWrite).not.toHaveBeenCalledWith({ sessionId: "shell-1", data: "景a" });
+    sub.dispose();
+  });
+
+  it("leaves xterm IME output alone when compositionend has no committed data", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    const received: string[] = [];
+    const sub = runtime.subscribeUserInput((data) => {
+      received.push(data);
+    });
+
+    terminal.textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+    terminal.textarea.dispatchEvent(new CompositionEvent("compositionend", { data: "" }));
+    mockState.dataHandlers[0]?.("変換");
+    await flushMicrotasks();
+
+    expect(received).toEqual(["変換"]);
+    expect(mockState.sessionWrite).toHaveBeenCalledWith({ sessionId: "shell-1", data: "変換" });
+    sub.dispose();
+  });
+
+  it("suppresses printable xterm key events during IME composition", () => {
+    getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+
+    terminal.textarea.dispatchEvent(new CompositionEvent("compositionstart"));
+
+    const event = new KeyboardEvent("keydown", { key: "g" });
+    expect(terminal.customKeyEventHandler?.(event)).toBe(false);
   });
 
   // attachTo は同期的に syncAttachedRect を 1 回呼ぶ（RAF を回さなくても

--- a/src/runtime/terminal-runtime/terminal-runtime.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.ts
@@ -33,6 +33,7 @@ import type {
 } from "./types";
 
 const TYPING_CURSOR_ACTIVE_MS = 2000;
+const IME_POST_COMMIT_SUPPRESS_MS = 80;
 
 /** xterm.js の初期カラーテーマ。scene が未設定の時のフォールバック。 */
 export const DEFAULT_TERMINAL_THEME: XTermTheme = {
@@ -113,6 +114,11 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   private latestRegionContext: TerminalRegionContext | null = null;
   private terminalReferenceCounter = 0;
   private readonly terminalReferences = new Map<string, TerminalReference>();
+  private writeQueue: Promise<void> = Promise.resolve();
+  private imeComposing = false;
+  private imePendingCommitText: string | null = null;
+  private imePendingCommitTimer: number | null = null;
+  private imeSuppressPrintableUntil = -Infinity;
 
   constructor(sessionId: string) {
     this.sessionId = sessionId;
@@ -140,6 +146,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     document.body.appendChild(this.xtermContainer);
 
     this.term.open(this.xtermContainer);
+    this.installImeCompositionGuard();
     this.installNotificationOscHandlers();
 
     const regionCtx = this.createRegionCanvas();
@@ -176,21 +183,11 @@ class TerminalRuntimeImpl implements TerminalRuntime {
       }
     })();
 
-    // ユーザー入力を PTY に流す
-    let writeQueue: Promise<void> = Promise.resolve();
     this.term.onData((data) => {
       if (this.disposed) return;
-      this.lastUserInputAt = performance.now();
-      this.perceptionRef.current?.onUserInput(data);
-      this.notifyUserInputListeners(data);
-      this.detectClearCommand(data);
-      writeQueue = writeQueue.then(async () => {
-        try {
-          await sessionWrite({ sessionId: this.sessionId, data });
-        } catch {
-          // PTY already closed — silent
-        }
-      });
+      const guardedData = this.filterImeData(data);
+      if (guardedData === null) return;
+      this.acceptUserInputData(guardedData);
     });
 
     // viewport scroll を listener に通知（attention producer の rect 再計算 trigger 用途）
@@ -316,6 +313,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
       window.clearTimeout(this.clearRegionCanvasTimeout);
       this.clearRegionCanvasTimeout = null;
     }
+    this.clearImePendingCommitTimer();
     this.term.dispose();
     if (this.xtermContainer.parentElement) {
       this.xtermContainer.parentElement.removeChild(this.xtermContainer);
@@ -730,6 +728,113 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     for (const listener of Array.from(this.userInputListeners)) {
       listener(data);
     }
+  }
+
+  // Tauri WebView can leak romanized IME key data through xterm before the committed text arrives.
+  private installImeCompositionGuard(): void {
+    const textarea = this.term.textarea;
+    if (!textarea) return;
+
+    textarea.addEventListener("compositionstart", () => {
+      this.imeComposing = true;
+      this.imePendingCommitText = null;
+      this.clearImePendingCommitTimer();
+    });
+
+    textarea.addEventListener("compositionend", (event) => {
+      this.imeComposing = false;
+
+      const committedText = event.data;
+      if (committedText.length === 0) return;
+
+      this.imeSuppressPrintableUntil = performance.now() + IME_POST_COMMIT_SUPPRESS_MS;
+      this.imePendingCommitText = committedText;
+      this.clearImePendingCommitTimer();
+      this.imePendingCommitTimer = window.setTimeout(() => {
+        this.imePendingCommitTimer = null;
+        this.flushPendingImeCommit();
+      }, 0);
+    });
+
+    this.term.attachCustomKeyEventHandler((event) => {
+      if (this.shouldSuppressImeKeyEvent(event)) return false;
+      return true;
+    });
+  }
+
+  private shouldSuppressImeKeyEvent(event: KeyboardEvent): boolean {
+    if (!this.isPrintableKeyboardEvent(event)) return false;
+    if (this.imeComposing || event.isComposing) return true;
+    return performance.now() <= this.imeSuppressPrintableUntil;
+  }
+
+  private isPrintableKeyboardEvent(event: KeyboardEvent): boolean {
+    if (event.ctrlKey || event.metaKey || event.altKey) return false;
+    return event.key.length === 1;
+  }
+
+  private filterImeData(data: string): string | null {
+    if (this.imeComposing) {
+      return null;
+    }
+
+    const pendingText = this.imePendingCommitText;
+    if (pendingText !== null) {
+      this.imePendingCommitText = null;
+      this.clearImePendingCommitTimer();
+      this.imeSuppressPrintableUntil = performance.now() + IME_POST_COMMIT_SUPPRESS_MS;
+      if (this.containsControlData(data)) {
+        this.acceptUserInputData(pendingText);
+        return null;
+      }
+      return pendingText;
+    }
+
+    if (performance.now() <= this.imeSuppressPrintableUntil && this.isPrintableTerminalData(data)) {
+      return null;
+    }
+
+    return data;
+  }
+
+  private flushPendingImeCommit(): void {
+    const pendingText = this.imePendingCommitText;
+    if (pendingText === null || this.disposed) return;
+    this.imePendingCommitText = null;
+    this.imeSuppressPrintableUntil = performance.now() + IME_POST_COMMIT_SUPPRESS_MS;
+    this.acceptUserInputData(pendingText);
+  }
+
+  private clearImePendingCommitTimer(): void {
+    if (this.imePendingCommitTimer === null) return;
+    window.clearTimeout(this.imePendingCommitTimer);
+    this.imePendingCommitTimer = null;
+  }
+
+  private containsControlData(data: string): boolean {
+    for (let i = 0; i < data.length; i++) {
+      const code = data.charCodeAt(i);
+      if (code < 0x20 || code === 0x7f) return true;
+    }
+    return false;
+  }
+
+  private isPrintableTerminalData(data: string): boolean {
+    return data.length > 0 && !this.containsControlData(data);
+  }
+
+  private acceptUserInputData(data: string): void {
+    this.lastUserInputAt = performance.now();
+    this.perceptionRef.current?.onUserInput(data);
+    this.notifyUserInputListeners(data);
+    this.detectClearCommand(data);
+    this.writeQueue = this.writeQueue.then(async () => {
+      try {
+        await sessionWrite({ sessionId: this.sessionId, data });
+      } catch {
+        // PTY already closed — silent
+      }
+    });
   }
 
   private readonly handleViewportResize = (): void => {


### PR DESCRIPTION
## Summary

Fixes terminal input corruption while composing text with an IME in Charminal's xterm-backed input surface.

## Root Cause

Tauri WebView/xterm can emit romanized intermediate key data during IME composition before the committed text arrives. That allowed stale fragments such as `g`/`a` or partial converted text to be written to the PTY alongside the final committed Japanese text.

## Changes

- Add an IME composition guard around xterm user input forwarding.
- Suppress printable key/data events while composition is active and briefly after commit.
- Prefer `compositionend.data` when available, while falling back to xterm output when no committed data is provided.
- Add focused terminal runtime tests for the IME paths and the empty-commit fallback.

## Validation

- `npx biome check src/runtime/terminal-runtime/terminal-runtime.ts src/runtime/terminal-runtime/terminal-runtime.test.ts`
- `npm test -- run src/runtime/terminal-runtime/terminal-runtime.test.ts`
- `npm run build`
- pre-push hook: `tsc --noEmit`, `biome check`, `cargo fmt --check`, `cargo clippy`, `typedoc` validation