### PR TITLE
style(simple-room): de-slop the palette — neutral charcoal + sage, flat background

### DIFF
--- a/bundled-packs/scenes/simple-room/lib/backdrop.tsx
+++ b/bundled-packs/scenes/simple-room/lib/backdrop.tsx
@@ -1,5 +1,5 @@
 /**
- * simple-room の背景. 中立 charcoal の縦グラデ + vignette を shader quad で描画.
+ * simple-room の背景. 中立 charcoal の一色 + vignette を shader quad で描画.
  *
  * NOTE: 現構成では未使用（背景は scene.tsx の DOM layer = CSS gradient が描く）。
  * 色は scene.tsx と同期させておく。腐敗防止のための保守対象。
@@ -19,10 +19,8 @@ const fragmentShader = `
   precision highp float;
   varying vec2 vUv;
   void main() {
-    // linear-gradient(180deg, #26282c 0%, #16181b 100%)
-    vec3 top = vec3(0.149, 0.157, 0.173);
-    vec3 bottom = vec3(0.086, 0.094, 0.106);
-    vec3 color = mix(bottom, top, vUv.y);
+    // 単色 charcoal #1c1e21
+    vec3 color = vec3(0.110, 0.118, 0.129);
 
     // vignette: radial-gradient(ellipse at 50% 60%, transparent 60%, rgba(0,0,0,0.35) 100%)
     vec2 vigCenter = vec2(0.5, 0.4);

--- a/bundled-packs/scenes/simple-room/lib/backdrop.tsx
+++ b/bundled-packs/scenes/simple-room/lib/backdrop.tsx
@@ -1,5 +1,5 @@
 /**
- * simple-room の背景. 中立 charcoal gradient + 色の付かない光だまりを shader quad で描画.
+ * simple-room の背景. 中立 charcoal の縦グラデ + vignette を shader quad で描画.
  *
  * NOTE: 現構成では未使用（背景は scene.tsx の DOM layer = CSS gradient が描く）。
  * 色は scene.tsx と同期させておく。腐敗防止のための保守対象。
@@ -23,12 +23,6 @@ const fragmentShader = `
     vec3 top = vec3(0.149, 0.157, 0.173);
     vec3 bottom = vec3(0.086, 0.094, 0.106);
     vec3 color = mix(bottom, top, vUv.y);
-
-    // radial-gradient(ellipse at 50% 30%, rgba(198,204,212,0.10), transparent 70%)
-    vec2 center = vec2(0.5, 0.7);
-    float dist = length((vUv - center) * vec2(1.0, 0.7));
-    float radial = smoothstep(0.7, 0.0, dist) * 0.10;
-    color += vec3(0.776, 0.800, 0.831) * radial;
 
     // vignette: radial-gradient(ellipse at 50% 60%, transparent 60%, rgba(0,0,0,0.35) 100%)
     vec2 vigCenter = vec2(0.5, 0.4);

--- a/bundled-packs/scenes/simple-room/lib/lights.tsx
+++ b/bundled-packs/scenes/simple-room/lib/lights.tsx
@@ -15,7 +15,7 @@ import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
 export function Lights() {
   const lightRef = useRef<ThreeSpotLight>(null);
   const [controls, setControls] = useCharminalControls("lights", () => ({
-    intensity: { value: 1.5, min: 0, max: 3, step: 0.01, label: "intensity" },
+    intensity: { value: 1.2, min: 0, max: 3, step: 0.01, label: "intensity" },
     color: { value: "#ffe8ea", label: "color" },
     x: { value: -0.2, min: -5, max: 5, step: 0.1, label: "X" },
     y: { value: 1.9, min: -5, max: 5, step: 0.1, label: "Y" },

--- a/bundled-packs/scenes/simple-room/lib/lights.tsx
+++ b/bundled-packs/scenes/simple-room/lib/lights.tsx
@@ -15,15 +15,15 @@ import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
 export function Lights() {
   const lightRef = useRef<ThreeSpotLight>(null);
   const [controls, setControls] = useCharminalControls("lights", () => ({
-    intensity: { value: 3, min: 0, max: 3, step: 0.01, label: "intensity" },
+    intensity: { value: 2, min: 0, max: 3, step: 0.01, label: "intensity" },
     color: { value: "#ffe8ea", label: "color" },
     x: { value: -0.2, min: -5, max: 5, step: 0.1, label: "X" },
-    y: { value: 2.3, min: -5, max: 5, step: 0.1, label: "Y" },
+    y: { value: 1.9, min: -5, max: 5, step: 0.1, label: "Y" },
     z: { value: 0.4, min: -5, max: 5, step: 0.1, label: "Z" },
     targetX: { value: 0.1, min: -3, max: 3, step: 0.1, label: "target X" },
-    targetY: { value: 0.7, min: -1, max: 3, step: 0.1, label: "target Y" },
+    targetY: { value: 0.2, min: -1, max: 3, step: 0.1, label: "target Y" },
     targetZ: { value: 0, min: -3, max: 3, step: 0.1, label: "target Z" },
-    angle: { value: 0.3, min: 0.05, max: 1.5, step: 0.01, label: "angle" },
+    angle: { value: 0.85, min: 0.05, max: 1.5, step: 0.01, label: "angle" },
     penumbra: { value: 0.74, min: 0, max: 1, step: 0.01, label: "penumbra" },
     distance: { value: 1.4, min: 0, max: 20, step: 0.1, label: "distance" },
     decay: { value: 1.1, min: 0, max: 5, step: 0.1, label: "decay" },

--- a/bundled-packs/scenes/simple-room/lib/lights.tsx
+++ b/bundled-packs/scenes/simple-room/lib/lights.tsx
@@ -1,30 +1,52 @@
 /**
  * simple-room の lighting rig.
  *
- * 静かな部屋の控えめな lighting. SDK controls で intensity / color を調整可能.
+ * 夜の静かな部屋を一灯で作る。directional+ambient のフラットな照明ではなく、
+ * 暖色のスポットライト 1 灯を VRM に当て、毎フレーム target を追従させる。
+ * 値は simple-room (Night) に合わせた。SDK controls で intensity / color / 位置等を調整可能。
  */
 
 import { useCharminalControls } from "@charminal/sdk/controls";
+import { useFrame } from "@react-three/fiber";
+import { useRef } from "react";
+import type { SpotLight as ThreeSpotLight } from "three";
 import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
 
 export function Lights() {
+  const lightRef = useRef<ThreeSpotLight>(null);
   const [controls, setControls] = useCharminalControls("lights", () => ({
-    // key は whisper warm、fill は中立に寄せて「本物の光」感を出す（値はライブ調整前提の起点）。
-    directionalIntensity: { value: 0.8, min: 0, max: 3, step: 0.05, label: "light int." },
-    directionalColor: { value: "#fff6ec", label: "light color" },
-    ambientIntensity: { value: 0.4, min: 0, max: 1, step: 0.02, label: "ambient int." },
-    ambientColor: { value: "#eef0ee", label: "ambient color" },
+    intensity: { value: 3, min: 0, max: 3, step: 0.01, label: "intensity" },
+    color: { value: "#ffe8ea", label: "color" },
+    x: { value: -0.2, min: -5, max: 5, step: 0.1, label: "X" },
+    y: { value: 2.3, min: -5, max: 5, step: 0.1, label: "Y" },
+    z: { value: 0.4, min: -5, max: 5, step: 0.1, label: "Z" },
+    targetX: { value: 0.1, min: -3, max: 3, step: 0.1, label: "target X" },
+    targetY: { value: 0.7, min: -1, max: 3, step: 0.1, label: "target Y" },
+    targetZ: { value: 0, min: -3, max: 3, step: 0.1, label: "target Z" },
+    angle: { value: 0.3, min: 0.05, max: 1.5, step: 0.01, label: "angle" },
+    penumbra: { value: 0.74, min: 0, max: 1, step: 0.01, label: "penumbra" },
+    distance: { value: 1.4, min: 0, max: 20, step: 0.1, label: "distance" },
+    decay: { value: 1.1, min: 0, max: 5, step: 0.1, label: "decay" },
   }));
   useControlsBridge("simple-room", controls, setControls);
 
+  useFrame(() => {
+    if (lightRef.current) {
+      lightRef.current.target.position.set(controls.targetX, controls.targetY, controls.targetZ);
+      lightRef.current.target.updateMatrixWorld();
+    }
+  });
+
   return (
-    <>
-      <directionalLight
-        position={[1, 2, 2]}
-        intensity={controls.directionalIntensity}
-        color={controls.directionalColor}
-      />
-      <ambientLight intensity={controls.ambientIntensity} color={controls.ambientColor} />
-    </>
+    <spotLight
+      ref={lightRef}
+      position={[controls.x, controls.y, controls.z]}
+      intensity={controls.intensity}
+      color={controls.color}
+      angle={controls.angle}
+      penumbra={controls.penumbra}
+      distance={controls.distance}
+      decay={controls.decay}
+    />
   );
 }

--- a/bundled-packs/scenes/simple-room/lib/lights.tsx
+++ b/bundled-packs/scenes/simple-room/lib/lights.tsx
@@ -15,13 +15,13 @@ import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
 export function Lights() {
   const lightRef = useRef<ThreeSpotLight>(null);
   const [controls, setControls] = useCharminalControls("lights", () => ({
-    intensity: { value: 2, min: 0, max: 3, step: 0.01, label: "intensity" },
+    intensity: { value: 1.5, min: 0, max: 3, step: 0.01, label: "intensity" },
     color: { value: "#ffe8ea", label: "color" },
     x: { value: -0.2, min: -5, max: 5, step: 0.1, label: "X" },
     y: { value: 1.9, min: -5, max: 5, step: 0.1, label: "Y" },
     z: { value: 0.4, min: -5, max: 5, step: 0.1, label: "Z" },
     targetX: { value: 0.1, min: -3, max: 3, step: 0.1, label: "target X" },
-    targetY: { value: 0.2, min: -1, max: 3, step: 0.1, label: "target Y" },
+    targetY: { value: -0.1, min: -1, max: 3, step: 0.1, label: "target Y" },
     targetZ: { value: 0, min: -3, max: 3, step: 0.1, label: "target Z" },
     angle: { value: 0.85, min: 0.05, max: 1.5, step: 0.01, label: "angle" },
     penumbra: { value: 0.74, min: 0, max: 1, step: 0.01, label: "penumbra" },

--- a/bundled-packs/scenes/simple-room/scene.tsx
+++ b/bundled-packs/scenes/simple-room/scene.tsx
@@ -31,9 +31,8 @@ const definition: ScenePackDefinition = {
       {
         id: "backdrop",
         role: "background",
-        // 中立 charcoal（青みは気配程度に脱飽和）＋ 色の付かない柔らかい光だまり。
-        backgroundImage:
-          "radial-gradient(ellipse at 50% 30%, rgba(198, 204, 212, 0.10) 0%, transparent 70%), linear-gradient(180deg, #26282c 0%, #16181b 100%)",
+        // 中立 charcoal の素直な縦グラデのみ。出所のない radial 光だまりは置かない。
+        backgroundImage: "linear-gradient(180deg, #26282c 0%, #16181b 100%)",
       },
       {
         id: "vrm-slot",

--- a/bundled-packs/scenes/simple-room/scene.tsx
+++ b/bundled-packs/scenes/simple-room/scene.tsx
@@ -31,8 +31,8 @@ const definition: ScenePackDefinition = {
       {
         id: "backdrop",
         role: "background",
-        // 中立 charcoal の素直な縦グラデのみ。出所のない radial 光だまりは置かない。
-        backgroundImage: "linear-gradient(180deg, #26282c 0%, #16181b 100%)",
+        // 中立 charcoal の一色。グラデも radial も置かない静かな壁。陰影は vignette に任せる。
+        backgroundColor: "#1c1e21",
       },
       {
         id: "vrm-slot",


### PR DESCRIPTION
## 概要
bundled reference scene `simple-room`(「静かな部屋」) の配色が、いかにもな AI slop（ネイビー＋シアン＋どこからともなく差す青い光）に見えるのを是正する。方針は「実際の部屋として読めるようにする」。

## 何が slop だったか
- ベース = 飽和したネイビー/スレート青灰（`#232838`→`#161a24`）
- アクセント = 使い回されたティール/シアン（`#4dd9cf` / `#39c5bb`）。cursor・UI accent・terminal の green まで全部これ
- 上中央の青いアンビエント glow（`rgba(120,150,200,0.18)`）= 出所のない未来的な光の常套句

## 変更（段階的に「引いて」いった）
1. **再調色** — charcoal ニュートラル（青みは気配程度に脱飽和）＋ **セージ/青磁アクセント**（`#8eb09c`）。terminal ANSI 16色も再調整し、ティールを本物の green に直し、cyan と分離。lighting tone は key=whisper warm / fill=中立へ（値はライブ調整前提の起点）
2. **radial 光だまり除去** — 中立色にしてもなお「どこから差すか分からない光」は slop の核なので撤去
3. **縦グラデ除去 → 単色化** — 背景は単色 charcoal `#1c1e21` のみ。layer は正式な `backgroundColor` フィールドで表現。陰影は foreground vignette に一任

未使用の `backdrop.tsx`（shader、現構成では DOM layer の CSS が描くため未描画）も色を同期。`bundled_examples_gen.rs` が `include_str!` で参照しているため削除はせず保守。

## 確認
- `tsc --noEmit` / `biome check` パス
- pre-commit / pre-push hook（cargo fmt・clippy・typedoc 含む）パス
- 実機の目視確認は未実施（次段）。色値はライブで微調整余地あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)