### PR TITLE
feat(scene-layer): media controls — transform + off-screen cover panel, label/filename fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -371,6 +371,10 @@ type MutableLayer = {
   backgroundImage?: string;
   blur?: number;
   opacity?: number;
+  mediaOffsetX?: number;
+  mediaOffsetY?: number;
+  mediaScale?: number;
+  mediaRotation?: number;
 };
 
 function sceneLayerTargetKey(target: UiSceneLayerTarget): string | null {
@@ -430,7 +434,25 @@ function applySceneLayerPatch(layer: Layer, patch: UiSceneLayerPatch): Layer {
       next.opacity = patch.opacity;
     }
   }
+  applyNumericMediaPatch(next, patch);
   return next;
+}
+
+/**
+ * media transform 系（offset/scale/rotation）の数値フィールドを patch から当てる。
+ * null は削除（= default に戻す）、undefined は据え置き。
+ */
+function applyNumericMediaPatch(next: MutableLayer, patch: UiSceneLayerPatch): void {
+  const fields = ["mediaOffsetX", "mediaOffsetY", "mediaScale", "mediaRotation"] as const;
+  for (const field of fields) {
+    if (!(field in patch)) continue;
+    const value = patch[field];
+    if (value === null) {
+      delete next[field];
+    } else if (value !== undefined) {
+      next[field] = value;
+    }
+  }
 }
 
 /**

--- a/src/core/debug-controls/scene-layer-controls.tsx
+++ b/src/core/debug-controls/scene-layer-controls.tsx
@@ -101,7 +101,7 @@ function SceneLayerControlsInner({ store }: SceneLayerControlsProps) {
           "background",
           "mediaRotation",
         ),
-        backgroundFile: { value: NO_MEDIA, editable: false, label: "background media" },
+        backgroundFile: { value: NO_MEDIA, editable: false, label: "background" },
         "load bg": button(() => backgroundInputRef.current?.click()),
         "clear bg": button(() => {
           revokeUrl(backgroundUrlRef.current);
@@ -124,7 +124,7 @@ function SceneLayerControlsInner({ store }: SceneLayerControlsProps) {
           "foreground",
           "mediaRotation",
         ),
-        foregroundFile: { value: NO_MEDIA, editable: false, label: "foreground media" },
+        foregroundFile: { value: NO_MEDIA, editable: false, label: "foreground" },
         "load fg": button(() => foregroundInputRef.current?.click()),
         "clear fg": button(() => {
           revokeUrl(foregroundUrlRef.current);

--- a/src/core/debug-controls/scene-layer-controls.tsx
+++ b/src/core/debug-controls/scene-layer-controls.tsx
@@ -2,7 +2,8 @@
  * Scene layer debug controls (leva).
  *
  * Active scene に DOM layers がある場合のみ表示される。
- * background / foreground の blur / opacity と media (image/video) の読み込み・クリアを提供。
+ * background / foreground の blur / opacity / media transform（位置・拡大縮小・回転）と
+ * media (image/video) の読み込み・クリアを提供。
  */
 
 import { button, folder, useControls } from "leva";
@@ -14,6 +15,8 @@ import { getSceneLayerBridge } from "../scene/scene-layer-bridge";
 export interface SceneLayerControlsProps {
   readonly store?: LevaStore;
 }
+
+const NO_MEDIA = "(none)";
 
 export function SceneLayerControls({ store }: SceneLayerControlsProps) {
   const [hasLayers, setHasLayers] = useState(false);
@@ -37,13 +40,16 @@ export function SceneLayerControls({ store }: SceneLayerControlsProps) {
 function SceneLayerControlsInner({ store }: SceneLayerControlsProps) {
   const backgroundInputRef = useRef<HTMLInputElement | null>(null);
   const foregroundInputRef = useRef<HTMLInputElement | null>(null);
-  const [backgroundName, setBackgroundName] = useState("");
-  const [foregroundName, setForegroundName] = useState("");
   const backgroundUrlRef = useRef("");
   const foregroundUrlRef = useRef("");
+  const setRef = useRef<(values: Record<string, unknown>) => void>(() => {});
 
   useEffect(() => {
-    if (!backgroundInputRef.current) {
+    const makeInput = (
+      urlRef: { current: string },
+      role: "background" | "foreground",
+      fileKey: string,
+    ): HTMLInputElement => {
       const input = document.createElement("input");
       input.type = "file";
       input.accept = "image/*,video/*";
@@ -51,33 +57,24 @@ function SceneLayerControlsInner({ store }: SceneLayerControlsProps) {
       input.addEventListener("change", () => {
         const file = input.files?.[0];
         if (!file) return;
-        revokeUrl(backgroundUrlRef.current);
+        revokeUrl(urlRef.current);
         const url = URL.createObjectURL(file);
-        backgroundUrlRef.current = url;
-        setBackgroundName(file.name);
+        urlRef.current = url;
         const mediaType = file.type.startsWith("video/") ? "video" : "image";
-        getSceneLayerBridge()?.updateLayer({ role: "background" }, { src: url, mediaType });
+        getSceneLayerBridge()?.updateLayer({ role }, { src: url, mediaType });
+        // leva の string control は schema の value を初期値としてしか読まないため、
+        // 読み込んだファイル名を表示するには set() で明示的に push する必要がある。
+        setRef.current({ [fileKey]: file.name });
       });
       document.body.appendChild(input);
-      backgroundInputRef.current = input;
+      return input;
+    };
+
+    if (!backgroundInputRef.current) {
+      backgroundInputRef.current = makeInput(backgroundUrlRef, "background", "backgroundFile");
     }
     if (!foregroundInputRef.current) {
-      const input = document.createElement("input");
-      input.type = "file";
-      input.accept = "image/*,video/*";
-      input.style.display = "none";
-      input.addEventListener("change", () => {
-        const file = input.files?.[0];
-        if (!file) return;
-        revokeUrl(foregroundUrlRef.current);
-        const url = URL.createObjectURL(file);
-        foregroundUrlRef.current = url;
-        setForegroundName(file.name);
-        const mediaType = file.type.startsWith("video/") ? "video" : "image";
-        getSceneLayerBridge()?.updateLayer({ role: "foreground" }, { src: url, mediaType });
-      });
-      document.body.appendChild(input);
-      foregroundInputRef.current = input;
+      foregroundInputRef.current = makeInput(foregroundUrlRef, "foreground", "foregroundFile");
     }
     return () => {
       revokeUrl(backgroundUrlRef.current);
@@ -87,82 +84,109 @@ function SceneLayerControlsInner({ store }: SceneLayerControlsProps) {
     };
   }, []);
 
-  useControls(
+  const [, set] = useControls(
     () => ({
       "scene layers": folder({
-        backgroundBlur: {
-          value: 0,
-          min: 0,
-          max: 24,
-          step: 1,
-          label: "bg blur",
-          onChange: (v: number) => {
-            getSceneLayerBridge()?.updateLayer({ role: "background" }, { blur: v });
-          },
-        },
-        backgroundOpacity: {
-          value: 1,
-          min: 0,
-          max: 1,
-          step: 0.01,
-          label: "bg opacity",
-          onChange: (v: number) => {
-            getSceneLayerBridge()?.updateLayer({ role: "background" }, { opacity: v });
-          },
-        },
-        backgroundFile: {
-          value: backgroundName || "(none)",
-          editable: false,
-          label: "bg media",
-        },
+        backgroundBlur: numberControl("bg blur", 0, 0, 24, 1, "background", "blur"),
+        backgroundOpacity: numberControl("bg opacity", 1, 0, 1, 0.01, "background", "opacity"),
+        backgroundOffsetX: numberControl("bg pos x", 0, -100, 100, 1, "background", "mediaOffsetX"),
+        backgroundOffsetY: numberControl("bg pos y", 0, -100, 100, 1, "background", "mediaOffsetY"),
+        backgroundScale: numberControl("bg scale", 1, 0.1, 3, 0.01, "background", "mediaScale"),
+        backgroundRotation: numberControl(
+          "bg rotate",
+          0,
+          -180,
+          180,
+          1,
+          "background",
+          "mediaRotation",
+        ),
+        backgroundFile: { value: NO_MEDIA, editable: false, label: "background media" },
         "load bg": button(() => backgroundInputRef.current?.click()),
         "clear bg": button(() => {
           revokeUrl(backgroundUrlRef.current);
           backgroundUrlRef.current = "";
-          setBackgroundName("");
           getSceneLayerBridge()?.resetLayer({ role: "background" });
           if (backgroundInputRef.current) backgroundInputRef.current.value = "";
+          setRef.current(resetValues("background"));
         }),
-        foregroundBlur: {
-          value: 0,
-          min: 0,
-          max: 24,
-          step: 1,
-          label: "fg blur",
-          onChange: (v: number) => {
-            getSceneLayerBridge()?.updateLayer({ role: "foreground" }, { blur: v });
-          },
-        },
-        foregroundOpacity: {
-          value: 1,
-          min: 0,
-          max: 1,
-          step: 0.01,
-          label: "fg opacity",
-          onChange: (v: number) => {
-            getSceneLayerBridge()?.updateLayer({ role: "foreground" }, { opacity: v });
-          },
-        },
-        foregroundFile: {
-          value: foregroundName || "(none)",
-          editable: false,
-          label: "fg media",
-        },
+        foregroundBlur: numberControl("fg blur", 0, 0, 24, 1, "foreground", "blur"),
+        foregroundOpacity: numberControl("fg opacity", 1, 0, 1, 0.01, "foreground", "opacity"),
+        foregroundOffsetX: numberControl("fg pos x", 0, -100, 100, 1, "foreground", "mediaOffsetX"),
+        foregroundOffsetY: numberControl("fg pos y", 0, -100, 100, 1, "foreground", "mediaOffsetY"),
+        foregroundScale: numberControl("fg scale", 1, 0.1, 3, 0.01, "foreground", "mediaScale"),
+        foregroundRotation: numberControl(
+          "fg rotate",
+          0,
+          -180,
+          180,
+          1,
+          "foreground",
+          "mediaRotation",
+        ),
+        foregroundFile: { value: NO_MEDIA, editable: false, label: "foreground media" },
         "load fg": button(() => foregroundInputRef.current?.click()),
         "clear fg": button(() => {
           revokeUrl(foregroundUrlRef.current);
           foregroundUrlRef.current = "";
-          setForegroundName("");
           getSceneLayerBridge()?.resetLayer({ role: "foreground" });
           if (foregroundInputRef.current) foregroundInputRef.current.value = "";
+          setRef.current(resetValues("foreground"));
         }),
       }),
     }),
     { store },
-    [backgroundName, foregroundName],
   );
 
+  setRef.current = set as (values: Record<string, unknown>) => void;
+
   return null;
+}
+
+type LayerPatchKey =
+  | "blur"
+  | "opacity"
+  | "mediaOffsetX"
+  | "mediaOffsetY"
+  | "mediaScale"
+  | "mediaRotation";
+
+/**
+ * number control 定義の生成ヘルパ。onChange で対応する layer patch を bridge に流す。
+ */
+function numberControl(
+  label: string,
+  value: number,
+  min: number,
+  max: number,
+  step: number,
+  role: "background" | "foreground",
+  patchKey: LayerPatchKey,
+) {
+  return {
+    value,
+    min,
+    max,
+    step,
+    label,
+    onChange: (v: number) => {
+      getSceneLayerBridge()?.updateLayer({ role }, { [patchKey]: v });
+    },
+  };
+}
+
+/**
+ * clear 時に panel のスライダを default へ戻す値セット。
+ * file 表示と media transform を初期値に戻す（blur/opacity は既存挙動どおり据え置き）。
+ */
+function resetValues(role: "background" | "foreground"): Record<string, unknown> {
+  return {
+    [`${role}File`]: NO_MEDIA,
+    [`${role}OffsetX`]: 0,
+    [`${role}OffsetY`]: 0,
+    [`${role}Scale`]: 1,
+    [`${role}Rotation`]: 0,
+  };
 }
 
 function revokeUrl(url: string): void {

--- a/src/core/scene/scene-compositor.test.ts
+++ b/src/core/scene/scene-compositor.test.ts
@@ -1,7 +1,7 @@
 // src/core/scene/scene-compositor.test.ts
 
 import { describe, expect, it } from "vitest";
-import { isVideoLayer, isVideoSrc, layerStyle } from "./scene-compositor";
+import { isVideoLayer, isVideoSrc, layerStyle, mediaStyle } from "./scene-compositor";
 import type { Layer } from "./types";
 
 describe("layerStyle", () => {
@@ -148,5 +148,51 @@ describe("isVideoLayer", () => {
 
   it("falls back to src extension when mediaType is omitted", () => {
     expect(isVideoLayer({ id: "bg", src: "/path/bg.webm" })).toBe(true);
+  });
+});
+
+describe("mediaStyle", () => {
+  it("returns no transform when no media transform fields are set", () => {
+    const style = mediaStyle({ id: "bg" });
+    expect(style.transform).toBeUndefined();
+    expect(style.objectFit).toBe("cover");
+  });
+
+  it("applies translate when offsetX is set (offsetY defaults to 0)", () => {
+    const style = mediaStyle({ id: "bg", mediaOffsetX: 10 });
+    expect(style.transform).toBe("translate(10%, 0%)");
+  });
+
+  it("applies translate when only offsetY is set (offsetX defaults to 0)", () => {
+    const style = mediaStyle({ id: "bg", mediaOffsetY: -15 });
+    expect(style.transform).toBe("translate(0%, -15%)");
+  });
+
+  it("applies scale when mediaScale is set", () => {
+    const style = mediaStyle({ id: "bg", mediaScale: 1.5 });
+    expect(style.transform).toBe("scale(1.5)");
+  });
+
+  it("applies rotate when mediaRotation is set", () => {
+    const style = mediaStyle({ id: "bg", mediaRotation: 45 });
+    expect(style.transform).toBe("rotate(45deg)");
+  });
+
+  it("combines translate / scale / rotate in order", () => {
+    const style = mediaStyle({
+      id: "bg",
+      mediaOffsetX: 5,
+      mediaOffsetY: -5,
+      mediaScale: 2,
+      mediaRotation: 90,
+    });
+    expect(style.transform).toBe("translate(5%, -5%) scale(2) rotate(90deg)");
+  });
+
+  it("does not mutate the shared coverStyle (identity differs when transformed)", () => {
+    const plain = mediaStyle({ id: "bg" });
+    const transformed = mediaStyle({ id: "bg", mediaScale: 2 });
+    expect(transformed).not.toBe(plain);
+    expect(plain.transform).toBeUndefined();
   });
 });

--- a/src/core/scene/scene-compositor.test.ts
+++ b/src/core/scene/scene-compositor.test.ts
@@ -152,33 +152,39 @@ describe("isVideoLayer", () => {
 });
 
 describe("mediaStyle", () => {
-  it("returns no transform when no media transform fields are set", () => {
+  it("sizes the element to cover the viewport (cqw/cqh + --media-aspect)", () => {
     const style = mediaStyle({ id: "bg" });
-    expect(style.transform).toBeUndefined();
-    expect(style.objectFit).toBe("cover");
+    expect(style.position).toBe("absolute");
+    expect(style.width).toBe("max(100cqw, calc(100cqh * var(--media-aspect, 1)))");
+    expect(style.height).toBe("max(100cqh, calc(100cqw / var(--media-aspect, 1)))");
   });
 
-  it("applies translate when offsetX is set (offsetY defaults to 0)", () => {
+  it("always centers with translate(-50%, -50%) when no transform fields are set", () => {
+    const style = mediaStyle({ id: "bg" });
+    expect(style.transform).toBe("translate(-50%, -50%)");
+  });
+
+  it("appends translate after centering when offsetX is set (offsetY defaults to 0)", () => {
     const style = mediaStyle({ id: "bg", mediaOffsetX: 10 });
-    expect(style.transform).toBe("translate(10%, 0%)");
+    expect(style.transform).toBe("translate(-50%, -50%) translate(10%, 0%)");
   });
 
-  it("applies translate when only offsetY is set (offsetX defaults to 0)", () => {
+  it("appends translate after centering when only offsetY is set", () => {
     const style = mediaStyle({ id: "bg", mediaOffsetY: -15 });
-    expect(style.transform).toBe("translate(0%, -15%)");
+    expect(style.transform).toBe("translate(-50%, -50%) translate(0%, -15%)");
   });
 
-  it("applies scale when mediaScale is set", () => {
+  it("appends scale after centering when mediaScale is set", () => {
     const style = mediaStyle({ id: "bg", mediaScale: 1.5 });
-    expect(style.transform).toBe("scale(1.5)");
+    expect(style.transform).toBe("translate(-50%, -50%) scale(1.5)");
   });
 
-  it("applies rotate when mediaRotation is set", () => {
+  it("appends rotate after centering when mediaRotation is set", () => {
     const style = mediaStyle({ id: "bg", mediaRotation: 45 });
-    expect(style.transform).toBe("rotate(45deg)");
+    expect(style.transform).toBe("translate(-50%, -50%) rotate(45deg)");
   });
 
-  it("combines translate / scale / rotate in order", () => {
+  it("composes centering + translate + scale + rotate in order", () => {
     const style = mediaStyle({
       id: "bg",
       mediaOffsetX: 5,
@@ -186,13 +192,23 @@ describe("mediaStyle", () => {
       mediaScale: 2,
       mediaRotation: 90,
     });
-    expect(style.transform).toBe("translate(5%, -5%) scale(2) rotate(90deg)");
+    expect(style.transform).toBe("translate(-50%, -50%) translate(5%, -5%) scale(2) rotate(90deg)");
   });
 
-  it("does not mutate the shared coverStyle (identity differs when transformed)", () => {
+  it("does not mutate the shared base style across calls", () => {
     const plain = mediaStyle({ id: "bg" });
     const transformed = mediaStyle({ id: "bg", mediaScale: 2 });
     expect(transformed).not.toBe(plain);
-    expect(plain.transform).toBeUndefined();
+    expect(plain.transform).toBe("translate(-50%, -50%)");
+  });
+});
+
+describe("layerStyle container-type for media layers", () => {
+  it("adds container-type: size when the layer has a media src", () => {
+    expect(layerStyle({ id: "bg", src: "/x.png" }).containerType).toBe("size");
+  });
+
+  it("omits container-type when the layer has no src", () => {
+    expect(layerStyle({ id: "bg" }).containerType).toBeUndefined();
   });
 });

--- a/src/core/scene/scene-compositor.tsx
+++ b/src/core/scene/scene-compositor.tsx
@@ -1,6 +1,6 @@
 // src/core/scene/scene-compositor.tsx
 
-import type { CSSProperties, ReactNode } from "react";
+import { type CSSProperties, type ReactNode, useState } from "react";
 import { ProceduralSceneLayer } from "./procedural-scene-layer";
 import type { Layer, SceneSpec } from "./types";
 
@@ -46,11 +46,26 @@ const layerBaseStyle: CSSProperties = {
 
 const foregroundLayerZIndex = 1;
 
-const coverStyle: CSSProperties = {
-  width: "100%",
-  height: "100%",
+/**
+ * media（img / video）の base style。
+ *
+ * 要素自体を「cover サイズ」（短辺が viewport にピッタリ、長辺は viewport を超える native 比率）
+ * に広げて中央配置する。object-fit:cover とは違い、要素そのものが viewport の外まで実体として
+ * 存在するため、transform で pan / scale すると画面外にあった部分が入ってくる。はみ出した分は
+ * 親 (.scene-compositor / .charactor-container) の overflow:hidden でクリップされ、ターミナル等
+ * カメラ外には描画されない。
+ *
+ * 寸法は container query 単位で算出する（layer div に container-type:size を付ける）。
+ * --media-aspect（= naturalWidth / naturalHeight）は読み込み時に SceneMedia が set する。
+ * cover: scaledW = max(Cw, Ch * aspect), scaledH = max(Ch, Cw / aspect)。
+ */
+const mediaBaseStyle: CSSProperties = {
+  position: "absolute",
+  left: "50%",
+  top: "50%",
+  width: "max(100cqw, calc(100cqh * var(--media-aspect, 1)))",
+  height: "max(100cqh, calc(100cqw / var(--media-aspect, 1)))",
   objectFit: "cover",
-  objectPosition: "center",
   display: "block",
 };
 
@@ -103,16 +118,23 @@ export function layerStyle(layer: Layer): CSSProperties {
   if (layer.backgroundImage !== undefined) {
     style.backgroundImage = layer.backgroundImage;
   }
+  // media layer は container query の基準にする（cover サイズ算出のため）。
+  // size containment は paint を clip しないので、はみ出しは親の overflow が握る。
+  if (layer.src !== undefined) {
+    style.containerType = "size";
+  }
   return style;
 }
 
 /**
  * media（img / video）要素の inline style を作る pure 関数。test 対象。
- * coverStyle をベースに、layer の offset/scale/rotation から CSS transform を組む。
- * 値が全て省略されていれば transform は付けない（= 既存挙動と完全に一致）。
+ *
+ * mediaBaseStyle（cover サイズ + 中央配置）をベースに、中央寄せの translate(-50%,-50%) と
+ * layer の offset/scale/rotation を 1 本の transform に合成する。offset が無くても中央寄せの
+ * transform は常に付く（要素を viewport 中央に置くため）。
  */
 export function mediaStyle(layer: Layer): CSSProperties {
-  const transforms: string[] = [];
+  const transforms: string[] = ["translate(-50%, -50%)"];
   const { mediaOffsetX, mediaOffsetY } = layer;
   if (typeof mediaOffsetX === "number" || typeof mediaOffsetY === "number") {
     transforms.push(`translate(${mediaOffsetX ?? 0}%, ${mediaOffsetY ?? 0}%)`);
@@ -123,8 +145,55 @@ export function mediaStyle(layer: Layer): CSSProperties {
   if (typeof layer.mediaRotation === "number") {
     transforms.push(`rotate(${layer.mediaRotation}deg)`);
   }
-  if (transforms.length === 0) return coverStyle;
-  return { ...coverStyle, transform: transforms.join(" ") };
+  return { ...mediaBaseStyle, transform: transforms.join(" ") };
+}
+
+/**
+ * style に --media-aspect を載せて返す。aspect 未確定（読み込み前）は
+ * mediaBaseStyle 側の fallback 1 が効くので付けない。
+ */
+function withAspect(style: CSSProperties, aspect: number | null): CSSProperties {
+  if (aspect === null) return style;
+  return { ...style, ["--media-aspect" as string]: aspect } as CSSProperties;
+}
+
+/**
+ * media 要素。読み込み時に naturalWidth/Height（video は videoWidth/Height）から
+ * 縦横比を測り、--media-aspect として style に載せる。これで cover サイズが確定し、
+ * 要素が viewport の外まで広がる（はみ出しは親の overflow:hidden が clip）。
+ */
+function SceneMedia({ layer }: { layer: Layer }) {
+  const [aspect, setAspect] = useState<number | null>(null);
+  const style = withAspect(mediaStyle(layer), aspect);
+
+  if (isVideoLayer(layer)) {
+    return (
+      <video
+        src={layer.src}
+        autoPlay
+        muted
+        loop
+        playsInline
+        style={style}
+        onLoadedMetadata={(e) => {
+          const v = e.currentTarget;
+          if (v.videoWidth > 0 && v.videoHeight > 0) setAspect(v.videoWidth / v.videoHeight);
+        }}
+      />
+    );
+  }
+  return (
+    <img
+      src={layer.src}
+      alt=""
+      style={style}
+      onLoad={(e) => {
+        const img = e.currentTarget;
+        if (img.naturalWidth > 0 && img.naturalHeight > 0)
+          setAspect(img.naturalWidth / img.naturalHeight);
+      }}
+    />
+  );
 }
 
 export function SceneCompositor({ scene, children }: SceneCompositorProps) {
@@ -135,13 +204,7 @@ export function SceneCompositor({ scene, children }: SceneCompositorProps) {
           {layer.procedural !== undefined ? (
             <ProceduralSceneLayer procedural={layer.procedural} />
           ) : null}
-          {layer.src !== undefined ? (
-            isVideoLayer(layer) ? (
-              <video src={layer.src} autoPlay muted loop playsInline style={mediaStyle(layer)} />
-            ) : (
-              <img src={layer.src} alt="" style={mediaStyle(layer)} />
-            )
-          ) : null}
+          {layer.src !== undefined ? <SceneMedia layer={layer} /> : null}
           {layer.role === "character" ? children : null}
         </div>
       ))}

--- a/src/core/scene/scene-compositor.tsx
+++ b/src/core/scene/scene-compositor.tsx
@@ -106,6 +106,27 @@ export function layerStyle(layer: Layer): CSSProperties {
   return style;
 }
 
+/**
+ * media（img / video）要素の inline style を作る pure 関数。test 対象。
+ * coverStyle をベースに、layer の offset/scale/rotation から CSS transform を組む。
+ * 値が全て省略されていれば transform は付けない（= 既存挙動と完全に一致）。
+ */
+export function mediaStyle(layer: Layer): CSSProperties {
+  const transforms: string[] = [];
+  const { mediaOffsetX, mediaOffsetY } = layer;
+  if (typeof mediaOffsetX === "number" || typeof mediaOffsetY === "number") {
+    transforms.push(`translate(${mediaOffsetX ?? 0}%, ${mediaOffsetY ?? 0}%)`);
+  }
+  if (typeof layer.mediaScale === "number") {
+    transforms.push(`scale(${layer.mediaScale})`);
+  }
+  if (typeof layer.mediaRotation === "number") {
+    transforms.push(`rotate(${layer.mediaRotation}deg)`);
+  }
+  if (transforms.length === 0) return coverStyle;
+  return { ...coverStyle, transform: transforms.join(" ") };
+}
+
 export function SceneCompositor({ scene, children }: SceneCompositorProps) {
   return (
     <div className="scene-compositor" style={containerStyle}>
@@ -116,9 +137,9 @@ export function SceneCompositor({ scene, children }: SceneCompositorProps) {
           ) : null}
           {layer.src !== undefined ? (
             isVideoLayer(layer) ? (
-              <video src={layer.src} autoPlay muted loop playsInline style={coverStyle} />
+              <video src={layer.src} autoPlay muted loop playsInline style={mediaStyle(layer)} />
             ) : (
-              <img src={layer.src} alt="" style={coverStyle} />
+              <img src={layer.src} alt="" style={mediaStyle(layer)} />
             )
           ) : null}
           {layer.role === "character" ? children : null}

--- a/src/sdk/scene.d.ts
+++ b/src/sdk/scene.d.ts
@@ -52,6 +52,17 @@ export interface Layer {
   /** 0-1。省略は 1（完全不透明）。 */
   readonly opacity?: number;
   /**
+   * media（img / video）の水平オフセット。要素サイズに対する %。省略は 0。
+   * objectFit:cover の表示位置をパンするための値。layer 全体ではなく media のみに効く。
+   */
+  readonly mediaOffsetX?: number;
+  /** media の垂直オフセット。要素サイズに対する %。省略は 0。 */
+  readonly mediaOffsetY?: number;
+  /** media の拡大率。1 が等倍。省略は 1。 */
+  readonly mediaScale?: number;
+  /** media の回転角（deg）。省略は 0。 */
+  readonly mediaRotation?: number;
+  /**
    * per-layer のドロップシャドウ（CSS `filter: drop-shadow()`）。
    * character レイヤーに付けると VRM のシルエット影になる（透過 canvas の alpha を拾う）。
    * 2D の screen-space オフセット影で、床への遠近投影ではない。

--- a/src/sdk/ui-pack.d.ts
+++ b/src/sdk/ui-pack.d.ts
@@ -372,6 +372,14 @@ export interface UiSceneLayerPatch {
   readonly blur?: number | null;
   /** 0-1。null でリセット（= 1 に戻る）。 */
   readonly opacity?: number | null;
+  /** media の水平オフセット（%）。null でリセット（= 0）。 */
+  readonly mediaOffsetX?: number | null;
+  /** media の垂直オフセット（%）。null でリセット（= 0）。 */
+  readonly mediaOffsetY?: number | null;
+  /** media の拡大率。null でリセット（= 1）。 */
+  readonly mediaScale?: number | null;
+  /** media の回転角（deg）。null でリセット（= 0）。 */
+  readonly mediaRotation?: number | null;
 }
 
 export interface UiSceneAPI {


### PR DESCRIPTION
F2 debug panel の scene-layer media コントロールを刷新。simple-room recolor (PR #8) とは直交する core 機能。**実機で動作確認済み**。

## 変更

### 1. ラベルのリネーム
`bg media` / `fg media` → **`background` / `foreground`**。
（当初 `background media` を試したが leva panel の幅に収まらなかったため、実機目視で `background` / `foreground` に短縮。）

### 2. ファイル名が表示されないバグ修正
**根本原因**: leva の string control は schema の `value` を*初期値*としてしか読まず、`useControls` を deps で再マウントしても既存ストア値（`(none)`）は更新されない。旧コードは setter を捨てていた。
**修正**: `const [, set] = useControls(...)` で setter を捕まえ、ロード時に `set({ backgroundFile: file.name })` を命令的に呼ぶ。clear で `(none)` に戻す。

### 3. media の位置・拡大縮小・回転
bg / fg それぞれに pos x / pos y（offset %）・scale（0.1–3）・rotate（±180°）を追加。`updateLayer` 経由で `mediaOffsetX/Y` `mediaScale` `mediaRotation` を流す。clear でスライダ初期化。

### 4. media を「画面外まで実在する cover パネル」として描画
表示モデルを `object-fit:cover`（要素の箱で内容を clip）から、**要素自体を cover サイズに広げて中央配置**へ変更。これにより：
- native 比率・短辺が viewport にピッタリ・長辺ははみ出し（letterbox 無し）
- はみ出した部分は親の `overflow:hidden` が clip → ターミナル等カメラ外には描画されない
- **#3 の offset/scale で動かすと、画面外にあった部分が入ってくる**（要素が実体として viewport 外まで存在するため）
- 無変換時の見た目は従来と同じ中央 cover クロップ（後方互換）

実装: `mediaBaseStyle` が container query 単位で cover 寸法を算出（`width: max(100cqw, calc(100cqh * var(--media-aspect)))` 等）。media layer の div に `container-type:size` を付与（cqw/cqh の基準・size containment は paint を clip しない）。`SceneMedia` が読み込み時に `naturalWidth/Height`（video は `videoWidth/Height`）から `--media-aspect` を実測。

## 型・データフロー
`Layer`（`sdk/scene.d.ts`）/ `UiSceneLayerPatch`（`sdk/ui-pack.d.ts`）/ `applySceneLayerPatch`（App.tsx）に media transform フィールドを追加。

## テスト / 検証
- `mediaStyle` / `container-type` のユニットテスト追加・更新
- tsc / biome / vitest **pass**（scene+runtime 48 / 全体 green）
- **実機で動作確認済み**（横長動画を縦長サイドバーに読み込み → 中央 cover 表示、はみ出しは clip、pan で画面外が現れることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)