### PR TITLE
feat(ui): トップバーのサイドバーボタンで全画面 UI pack を閉じる

### DIFF
--- a/bundled-packs/ui/immersive/ui.tsx
+++ b/bundled-packs/ui/immersive/ui.tsx
@@ -33,10 +33,17 @@ const immersive: UiPackDefinition = {
     sidebar: { width: "fullscreen" },
     // folder / gear 行を非表示。
     chrome: { visible: false },
-    // terminal を画面全体に固定配置し、背景のみ透明化する（element opacity 版から移行）。
-    // 文字は不透明のまま読め、背後の character + scene が鮮明に透ける。
+    // terminal を（常設タイトルバーの下の）作業域いっぱいに固定配置し、背景のみ透明化する
+    // （element opacity 版から移行）。文字は不透明のまま読め、背後の character + scene が鮮明に透ける。
+    // top/height にタイトルバー高さ(--title-bar-height)を織り込むのは、terminal がタイトルバーへ
+    // はみ出してサイドバートグル等のボタンを覆い隠さないようにするため。
     terminal: {
-      position: { top: "0", left: "0", width: "100vw", height: "100vh" },
+      position: {
+        top: "var(--title-bar-height)",
+        left: "0",
+        width: "100vw",
+        height: "calc(100vh - var(--title-bar-height))",
+      },
       transparentBackground: true,
     },
   },

--- a/src-tauri/resources/user-init-template.js
+++ b/src-tauri/resources/user-init-template.js
@@ -47,9 +47,19 @@
  */
 
 let desaturated = false;
-let settingsVisible = false;
-let theaterVisible = false;
-let immersiveVisible = false;
+
+// Toggle a UI pack from its *actual* active state rather than a local flag.
+// Keeps F1/F3/F4 in sync even when the pack is dismissed another way (e.g.
+// closing the fullscreen view with the title-bar sidebar button), so a single
+// keypress always re-opens it. ctx.getActiveUi may be absent on older Charminal
+// builds — fall back to null (always open).
+// 実際の active UI からトグルする（ローカル真偽値ではなく）。タイトルバーの
+// サイドバーボタンなど別経路で閉じられても状態がズレないので、キー 1 回で必ず開き直せる。
+// 旧ビルドには ctx.getActiveUi が無いことがある——その場合は null（常に開く側）。
+const toggleUi = (ctx, id) => {
+  const active = ctx.getActiveUi ? ctx.getActiveUi() : null;
+  ctx.setActiveUi(active === id ? null : id);
+};
 
 export default (ctx) => {
   window.addEventListener(
@@ -58,20 +68,17 @@ export default (ctx) => {
       if (!e.repeat && e.code === "F1") {
         e.preventDefault();
         e.stopImmediatePropagation();
-        settingsVisible = !settingsVisible;
-        ctx.setActiveUi(settingsVisible ? "charminal-settings" : null);
+        toggleUi(ctx, "charminal-settings");
       }
       if (!e.repeat && e.code === "F3") {
         e.preventDefault();
         e.stopImmediatePropagation();
-        theaterVisible = !theaterVisible;
-        ctx.setActiveUi(theaterVisible ? "theater" : null);
+        toggleUi(ctx, "theater");
       }
       if (!e.repeat && e.code === "F4") {
         e.preventDefault();
         e.stopImmediatePropagation();
-        immersiveVisible = !immersiveVisible;
-        ctx.setActiveUi(immersiveVisible ? "immersive" : null);
+        toggleUi(ctx, "immersive");
       }
       if (e.metaKey && e.shiftKey && e.code === "KeyF") {
         e.preventDefault();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,7 +225,10 @@ import Sidebar from "./sidebar";
 import Terminal from "./terminal";
 import TitleBar from "./title-bar";
 import { useSettingsActive, useSidebarOpen } from "./title-bar-state";
-import { shouldResumeHostPresenceForUiActivation } from "./ui-pack-activation";
+import {
+  layoutNeedsHostPresenceResume,
+  shouldResumeHostPresenceForUiActivation,
+} from "./ui-pack-activation";
 import "./App.css";
 
 function mergeSystemPromptParts(
@@ -822,6 +825,9 @@ function App() {
     resolved: resolveLanguage("auto", getBrowserLocales()),
   }));
   const appLanguageRef = useRef(appLanguage);
+  // トップバーのボタンで全画面 UI pack を閉じるとき、stage-close を closed presence
+  // （＝ターミナルだけ）へ一続きに着地させたい意思を playStage へ伝える 1-shot フラグ。
+  const exitFullscreenToClosedRef = useRef(false);
   const strings = useMemo(() => getStrings(appLanguage.resolved), [appLanguage.resolved]);
   const sidebarOpen = useSidebarOpen();
   const settingsActive = useSettingsActive(SETTINGS_PACK_ID);
@@ -900,6 +906,16 @@ function App() {
   );
 
   const handleToggleSidebar = useCallback(() => {
+    // 全画面 UI pack（theater/immersive 等、sidebar を fullscreen 占有する pack）が出ている
+    // ときは、ボタンを「全画面を閉じる」操作にする。setActiveUi(null) が stage-close を
+    // 再生し、exitFullscreenToClosedRef により closed presence（＝ターミナルだけ）へ一続きに
+    // 着地する。閉じたあとの押下は通常どおり closed→default（普通のサイドバー表示）に戻る。
+    const activeUi = getUiRegistry().getActiveUi();
+    if (activeUi && layoutNeedsHostPresenceResume(activeUi.pack.layout)) {
+      exitFullscreenToClosedRef.current = true;
+      getUiRegistry().setActiveUi(null);
+      return;
+    }
     const nextLevel: PresenceLevel = sidebarOpen ? "closed" : "default";
     applyPresenceLevelFromApp(nextLevel, "settings");
   }, [applyPresenceLevelFromApp, sidebarOpen]);
@@ -2447,13 +2463,37 @@ function App() {
       return { shell, character, chrome };
     };
 
-    const playStage = (direction: "open" | "close") => {
+    // closed を確定する：width 0 / presence-closed / render pause / level=closed / event 発火。
+    // 全画面 pack をボタンで閉じたあとの「ターミナルだけ」着地に使う。
+    const settlePresenceClosed = () => {
+      // 着地直前に別の UI pack が出ていたら何もしない（その pack の状態を尊重）。
+      if (getUiRegistry().getActiveUiId() !== null) return;
+      applyPresenceLevelFromApp("closed", "settings", { immediate: true }, "host-default");
+      syncPresenceLevelStyles("closed");
+    };
+
+    const playStage = (direction: "open" | "close", exitToClosed = false) => {
       const surfaces = getStageSurfaces();
       if (!surfaces) return;
-      void playStageTransition(direction, surfaces, {
+      // exitToClosed のときだけ、closed presence（ターミナルだけ）へ一続きに畳む。
+      // それ以外（F3 トグル等）は従来どおり 280（サイドバー表示）へ。
+      const toClosed = direction === "close" && exitToClosed;
+      if (toClosed) {
+        // inline width クリア後の着地点を CSS 0 にして、フルスクリーン→0 を途切れず見せる。
+        // presence-closed クラス（display:none）はアニメ中は付けない——付けると shell-column が
+        // 消えて閉じアニメが見えなくなる。完了後に settlePresenceClosed で正式に確定する。
+        syncPresenceClosedStyles(document.documentElement, null, true);
+      }
+      const transition = playStageTransition(direction, surfaces, {
         tweenManager: getThreeRuntime().getTweenManager(),
         viewportWidth: () => window.innerWidth,
+        closeCollapsedWidthPx: toClosed ? 0 : undefined,
       });
+      if (toClosed) {
+        void transition.then(settlePresenceClosed);
+      } else {
+        void transition;
+      }
     };
 
     const refitActiveTerminal = () => {
@@ -2931,9 +2971,18 @@ function App() {
       setSceneLayerOverrides([]);
 
       if (!entry) {
-        // 前 pack が stage 遷移なら、reset 後の素の状態から「閉じアニメ」を再生する
-        // （resetLayout で end-state を一旦 clear → playStage("close") が反対端へ override して tween）。
-        if (prevLayout?.transition?.kind === "stage") playStage("close");
+        // トップバーのボタンで全画面 pack を閉じたか（closed presence＝ターミナルだけへ着地）。
+        // 1-shot フラグはここで必ず消費する（pack 種別に関わらずリークさせない）。
+        const exitToClosed = exitFullscreenToClosedRef.current;
+        exitFullscreenToClosedRef.current = false;
+        if (prevLayout?.transition?.kind === "stage") {
+          // 前 pack が stage 遷移（theater 等）：reset 後の素の状態から「閉じアニメ」を再生する
+          // （resetLayout で end-state を一旦 clear → playStage("close") が反対端へ override して tween）。
+          playStage("close", exitToClosed);
+        } else if (exitToClosed) {
+          // 非 stage の全画面 pack（immersive 等）：閉じアニメは無いので即 closed presence へ。
+          settlePresenceClosed();
+        }
         return;
       }
 

--- a/src/runtime/ui-pack-transition/stage-transition.test.ts
+++ b/src/runtime/ui-pack-transition/stage-transition.test.ts
@@ -118,4 +118,28 @@ describe("playStageTransition", () => {
     expect(surfaces.character.style.width).toBe("");
     expect(surfaces.chrome.style.marginTop).toBe("");
   });
+
+  it("close: 既定では shell/character を 280px まで畳む", async () => {
+    const surfaces = makeSurfaces();
+    const { tm, calls } = makeTweenManager();
+
+    await playStageTransition("close", surfaces, { tweenManager: tm, viewportWidth: () => 1000 });
+
+    expect(calls.find((c) => c.key === "stage.shell")?.to).toBe(280);
+    expect(calls.find((c) => c.key === "stage.char")?.to).toBe(280);
+  });
+
+  it("close: closeCollapsedWidthPx を渡すとその幅まで畳む（0 でターミナルだけに着地）", async () => {
+    const surfaces = makeSurfaces();
+    const { tm, calls } = makeTweenManager();
+
+    await playStageTransition("close", surfaces, {
+      tweenManager: tm,
+      viewportWidth: () => 1000,
+      closeCollapsedWidthPx: 0,
+    });
+
+    expect(calls.find((c) => c.key === "stage.shell")?.to).toBe(0);
+    expect(calls.find((c) => c.key === "stage.char")?.to).toBe(0);
+  });
 });

--- a/src/runtime/ui-pack-transition/stage-transition.ts
+++ b/src/runtime/ui-pack-transition/stage-transition.ts
@@ -29,6 +29,12 @@ export interface StageTransitionDeps {
   readonly tweenManager: TweenManager;
   /** 100vw を px に解決する（通常 window.innerWidth）。 */
   readonly viewportWidth: () => number;
+  /**
+   * close 時に shell/character を畳む先の幅(px)。既定は COLLAPSED_WIDTH_PX(280)＝通常の
+   * サイドバー表示。0 を渡すと「ターミナルだけ」へ一続きに畳む（closed presence 着地）。
+   * open には影響しない。
+   */
+  readonly closeCollapsedWidthPx?: number;
 }
 
 /** 畳んだ状態の幅。App.css の --sidebar-width / --sidebar-content-width 初期値に一致。 */
@@ -135,6 +141,8 @@ export async function playStageTransition(
 
   // close — resetLayout が inline を clear 済み（shell/char は CSS 280px、chrome は
   // display:"" / marginTop なし）。end-state へ上書きしてから start へ tween。
+  // collapsed: 既定 280（通常サイドバー）。0 を渡すと「ターミナルだけ」へ一続きに畳む。
+  const collapsed = deps.closeCollapsedWidthPx ?? COLLAPSED_WIDTH_PX;
   setShell(vw);
   setChar(vw);
   // chrome を可視化して退避量を測り、畳んだ（上へ退避した）状態から開始する。
@@ -144,8 +152,8 @@ export async function playStageTransition(
 
   // ① shell/character を畳む
   await Promise.all([
-    tweenTo(tm, "stage.shell", vw, COLLAPSED_WIDTH_PX, WIDTH_MS, setShell),
-    tweenTo(tm, "stage.char", vw, COLLAPSED_WIDTH_PX, WIDTH_MS, setChar),
+    tweenTo(tm, "stage.shell", vw, collapsed, WIDTH_MS, setShell),
+    tweenTo(tm, "stage.char", vw, collapsed, WIDTH_MS, setChar),
   ]);
   if (!isCurrent()) return;
   // inline を外して CSS（--sidebar-width / --sidebar-content-width）へ返す

--- a/src/runtime/user-pack-loader/init-script.test.ts
+++ b/src/runtime/user-pack-loader/init-script.test.ts
@@ -351,4 +351,51 @@ describe("loadInitScript", () => {
     expect(result.ran).toBe(true);
     expect(selected).toEqual(["camera-lighting-panel", null]);
   });
+
+  it("ctx.getActiveUi returns the active UI id from the dep", async () => {
+    const effectReg = makeEffectRegistrar();
+    const personaReg = makePersonaRegistrar();
+    const { subsystem } = makeDevLog();
+    let observed: string | null = "unset";
+
+    const userDefault = (ctx: CharminalInitContext): void => {
+      observed = ctx.getActiveUi();
+    };
+
+    const result = await loadInitScript({
+      effectPackRunner: effectReg,
+      personaRegistry: personaReg,
+      devLog: subsystem,
+      effectDispatcher: makeEffectDispatcher(),
+      getActiveUi: () => "theater",
+      fetchInitScriptPath: async () => "/home/user/.charminal/init.js",
+      importModule: async () => ({ default: userDefault }),
+    });
+
+    expect(result.ran).toBe(true);
+    expect(observed).toBe("theater");
+  });
+
+  it("ctx.getActiveUi returns null when no getActiveUi dep is provided", async () => {
+    const effectReg = makeEffectRegistrar();
+    const personaReg = makePersonaRegistrar();
+    const { subsystem } = makeDevLog();
+    let observed: string | null = "unset";
+
+    const userDefault = (ctx: CharminalInitContext): void => {
+      observed = ctx.getActiveUi();
+    };
+
+    const result = await loadInitScript({
+      effectPackRunner: effectReg,
+      personaRegistry: personaReg,
+      devLog: subsystem,
+      effectDispatcher: makeEffectDispatcher(),
+      fetchInitScriptPath: async () => "/home/user/.charminal/init.js",
+      importModule: async () => ({ default: userDefault }),
+    });
+
+    expect(result.ran).toBe(true);
+    expect(observed).toBe(null);
+  });
 });

--- a/src/runtime/user-pack-loader/init-script.ts
+++ b/src/runtime/user-pack-loader/init-script.ts
@@ -49,6 +49,11 @@ export interface CharminalInitContext {
   dispatchEffect(request: SpaceEffectRequest): void;
   emitEvent(name: string, payload?: unknown): void;
   setActiveUi(id: string | null): void;
+  /**
+   * 現在 active な UI pack の id（無ければ null）。F3/F4 のようなトグルを、ローカル真偽値で
+   * はなく実状態から決めたいとき使う（ボタンで全画面を閉じても次のキーで即トグルできる）。
+   */
+  getActiveUi(): string | null;
   /** Per-frame parameter 補間。init scope で開始した tween はアプリ終了まで有効。 */
   tween: TweenAPI;
 }
@@ -61,6 +66,7 @@ export interface LoadInitScriptDeps {
   readonly personaDefaults?: PersonaDefinition;
   readonly emitEvent?: (name: string, payload?: unknown) => void;
   readonly setActiveUi?: (id: string | null) => void;
+  readonly getActiveUi?: () => string | null;
   readonly tweenManager?: TweenManager;
   /**
    * Tauri の user_init_script_path を叩いて init.js の absolute path を返す。
@@ -124,6 +130,9 @@ const makeInitContext = (
       throw new Error("setActiveUi is not available in this runtime");
     }
     deps.setActiveUi(id);
+  },
+  getActiveUi() {
+    return deps.getActiveUi ? deps.getActiveUi() : null;
   },
   tween: {
     start(key, to, durationMs, apply, options) {

--- a/src/runtime/user-pack-loader/runtime-wire.ts
+++ b/src/runtime/user-pack-loader/runtime-wire.ts
@@ -149,6 +149,7 @@ export async function loadUserLayer(deps: LoadUserLayerDeps): Promise<LoadUserLa
         emitEvent: deps.emitEvent,
         devLog: deps.initScriptLog,
         setActiveUi: (id) => deps.uiPackRegistry.setActiveUi(id),
+        getActiveUi: () => deps.uiPackRegistry.getActiveUiId(),
         tweenManager: deps.tweenManager,
         fetchInitScriptPath: () => invoke<string | null>("user_init_script_path"),
         importModule: async (path) => {


### PR DESCRIPTION
## 概要

トップバーのサイドバートグルボタンに「全画面 UI pack を閉じる」役割を持たせる。theater / immersive など `sidebar.width === "fullscreen"` の pack が出ているときにボタンを押すと、その pack を閉じて **closed presence（ターミナルだけ）** へ一続きに着地する。閉じたあとの押下は従来どおり closed→default（普通のサイドバー表示）に戻る。

## 変更点

### 機能（`feat(ui)`）
- **init context に `getActiveUi()` を追加**。`user-init-template` の F1/F3/F4 トグルを、ローカル真偽値ではなく**実 active UI** から決めるよう変更（別経路で閉じられても次のキーで必ず開き直せる）。`runtime-wire` / `init-script` / 型・テストを配線。旧ビルド互換のため `ctx.getActiveUi` 不在時は `null`（常に開く側）にフォールバック。
- **`handleToggleSidebar`**: 全画面 pack 時は `exitFullscreenToClosedRef` を立てて `setActiveUi(null)`。fullscreen 判定は既存 `layoutNeedsHostPresenceResume` を再利用。
- **`playStage(direction, exitToClosed)`**: stage close を `closeCollapsedWidthPx: 0` で「ターミナルだけ」へ畳み、完了後 `settlePresenceClosed` で closed を確定。非 stage の全画面 pack（immersive）は閉じアニメが無いので即 `settlePresenceClosed`。
- **`stage-transition` に `closeCollapsedWidthPx`** を追加（既定 280＝通常サイドバー、0 で closed 着地）。

### バグ修正（`fix(immersive)`）
- 動作確認で発覚：**immersive（F4）の全画面 terminal が常設タイトルバーを覆い、サイドバートグル等のボタンを押せなくなっていた**。terminal は `position:fixed` で `top:0 / height:100vh` だったため。作業域をタイトルバーの下から始めるよう `top: var(--title-bar-height)` / `height: calc(100vh - var(--title-bar-height))` に修正。

## テスト
- `tsc --noEmit` ✅ / `biome check` ✅ / `cargo clippy` ✅ / `vitest run` ✅（124 files / 1548 tests）
- 追加 test: `getActiveUi` の dep 配線（あり/なし）、stage close の畳み先幅（既定 280 / `closeCollapsedWidthPx:0`）。
- user による実機での動作確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)