### PR TITLE
fix(window): タイトルバーでウィンドウをドラッグ移動できるようにする

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,11 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "core:window:allow-set-title", "opener:default", "dialog:default"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-set-title",
+    "core:window:allow-start-dragging",
+    "opener:default",
+    "dialog:default"
+  ]
 }


### PR DESCRIPTION
## 概要
トップバー（タイトルバー）実装後、マウスドラッグでウィンドウを移動できなくなっていた問題を修正します。

## 原因
`src/title-bar.tsx` の `data-tauri-drag-region` は内部的に `start_dragging` コマンドを呼び出します。しかし `src-tauri/capabilities/default.json` に付与されていた `core:default`（= `core:window:default`）には `allow-start-dragging` が含まれておらず、Tauri v2 の ACL によって `start_dragging` がブロックされていました。

`core:window:default` の実体は `allow-scale-factor` / `allow-is-*` などの読み取り系のみで、ドラッグ系コマンドは含まれません。

## 修正内容
メインウィンドウの capability に `core:window:allow-start-dragging` を追加。

## 確認
- `npm run check`（tsc / biome / cargo fmt / clippy）パス
- 権限は起動時に組み込まれるため、`npm run tauri dev` で再起動後にタイトルバーの空き領域をドラッグしてウィンドウが移動できることを確認してください。