### PR TITLE
[codex] Protect main agent interrupts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -575,6 +575,34 @@ body,
   height: 100%;
 }
 
+.xterm-singleton-container .terminal-runtime-notice {
+  position: absolute;
+  left: 12px;
+  bottom: 10px;
+  z-index: 4;
+  display: none;
+  max-width: calc(100% - 24px);
+  min-height: 24px;
+  align-items: center;
+  padding: 4px 10px;
+  border: 1px solid var(--charminal-border, rgba(120, 134, 124, 0.28));
+  border-radius: 6px;
+  background: var(--charminal-panel-bg, rgba(20, 22, 25, 0.96));
+  color: var(--charminal-fg-dim, rgba(232, 235, 231, 0.7));
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.22);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 12px;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.xterm-singleton-container .terminal-runtime-notice.is-visible {
+  display: inline-flex;
+}
+
 /* xterm.js の hardcoded 色を scene テーマに追従させる */
 .xterm .composition-view {
   background: var(--charminal-bg);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,7 @@ import {
   DEFAULT_SESSION_ID,
   resolveDefaultAgentProfileId,
   resolveEffectiveAgent,
+  resolveInterruptProtectionModeForSpawnSpec,
   resolveProfile,
 } from "./runtime/sessions";
 import {
@@ -3920,26 +3921,31 @@ function App() {
         {canMountTerminals &&
           tabState.sessions.map((sessionId) => {
             const sessionLaunchCwd = tabManager.getSessionLaunchCwd(sessionId);
+            const spec =
+              sessionId === DEFAULT_SESSION_ID
+                ? withAgentRuntimeFields(
+                    defaultSpec ?? {
+                      kind: "agent",
+                      agent: terminalAgent,
+                    },
+                    resolvedSystemPrompt,
+                    localizedPluginDir,
+                  )
+                : { kind: "shell" as const, integration: true };
+            const interruptProtectionMode =
+              sessionId === DEFAULT_SESSION_ID
+                ? resolveInterruptProtectionModeForSpawnSpec(spec)
+                : "none";
             return (
               <Terminal
                 key={sessionId}
                 sessionId={sessionId}
                 visible={sessionId === tabState.activeSessionId}
-                spec={
-                  sessionId === DEFAULT_SESSION_ID
-                    ? withAgentRuntimeFields(
-                        defaultSpec ?? {
-                          kind: "agent",
-                          agent: terminalAgent,
-                        },
-                        resolvedSystemPrompt,
-                        localizedPluginDir,
-                      )
-                    : { kind: "shell", integration: true }
-                }
+                spec={spec}
                 cwd={sessionLaunchCwd === undefined ? cwd : sessionLaunchCwd}
                 perception={sessionId === tabState.activeSessionId ? perception : null}
                 attachFirst={tabManager.shouldAttachExistingSession(sessionId)}
+                interruptProtectionMode={interruptProtectionMode}
               />
             );
           })}

--- a/src/runtime/sessions/agent-runtime-policy.test.ts
+++ b/src/runtime/sessions/agent-runtime-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAgentRuntimePolicy,
+  resolveInterruptProtectionModeForSpawnSpec,
+} from "./agent-runtime-policy";
+
+describe("agent runtime policy", () => {
+  it("allows Claude Code's first Ctrl+C but suppresses repeated Ctrl+C", () => {
+    expect(getAgentRuntimePolicy("claude").interruptProtectionMode).toBe("repeated");
+  });
+
+  it("suppresses the first Ctrl+C for Codex and OpenCode", () => {
+    expect(getAgentRuntimePolicy("codex").interruptProtectionMode).toBe("all");
+    expect(getAgentRuntimePolicy("opencode").interruptProtectionMode).toBe("all");
+  });
+
+  it("defaults unknown agents to the non-exiting Ctrl+C policy", () => {
+    expect(getAgentRuntimePolicy("custom-agent").interruptProtectionMode).toBe("all");
+  });
+
+  it("does not protect shell specs", () => {
+    expect(
+      resolveInterruptProtectionModeForSpawnSpec({
+        kind: "shell",
+        command: null,
+        integration: true,
+      }),
+    ).toBe("none");
+  });
+
+  it("resolves interrupt protection from agent spawn specs", () => {
+    expect(
+      resolveInterruptProtectionModeForSpawnSpec({
+        kind: "agent",
+        agent: "opencode",
+        command: null,
+      }),
+    ).toBe("all");
+  });
+});

--- a/src/runtime/sessions/agent-runtime-policy.ts
+++ b/src/runtime/sessions/agent-runtime-policy.ts
@@ -1,0 +1,33 @@
+import type { SpawnSpec } from "../../bindings/tauri-commands";
+import type { InterruptProtectionMode } from "../terminal-runtime";
+
+export interface AgentRuntimePolicy {
+  readonly interruptProtectionMode: InterruptProtectionMode;
+}
+
+const DEFAULT_AGENT_RUNTIME_POLICY: AgentRuntimePolicy = {
+  interruptProtectionMode: "all",
+};
+
+const AGENT_RUNTIME_POLICIES: Readonly<Record<string, AgentRuntimePolicy>> = {
+  claude: {
+    interruptProtectionMode: "repeated",
+  },
+  codex: {
+    interruptProtectionMode: "all",
+  },
+  opencode: {
+    interruptProtectionMode: "all",
+  },
+};
+
+export function getAgentRuntimePolicy(agent: string): AgentRuntimePolicy {
+  return AGENT_RUNTIME_POLICIES[agent] ?? DEFAULT_AGENT_RUNTIME_POLICY;
+}
+
+export function resolveInterruptProtectionModeForSpawnSpec(
+  spec: SpawnSpec,
+): InterruptProtectionMode {
+  if (spec.kind !== "agent") return "none";
+  return getAgentRuntimePolicy(spec.agent).interruptProtectionMode;
+}

--- a/src/runtime/sessions/index.ts
+++ b/src/runtime/sessions/index.ts
@@ -7,6 +7,11 @@
  * Internal design-record: 2026-05-05-multi-pane-terminal.md.
  */
 
+export type { AgentRuntimePolicy } from "./agent-runtime-policy";
+export {
+  getAgentRuntimePolicy,
+  resolveInterruptProtectionModeForSpawnSpec,
+} from "./agent-runtime-policy";
 export {
   getBundledProfile,
   listAvailableProfiles,

--- a/src/runtime/terminal-runtime/index.ts
+++ b/src/runtime/terminal-runtime/index.ts
@@ -15,4 +15,4 @@ export {
   getAllTerminalRuntimes,
   getTerminalRuntime,
 } from "./terminal-runtime";
-export type { PtyParams, TerminalRuntime } from "./types";
+export type { InterruptProtectionMode, PtyParams, TerminalRuntime } from "./types";

--- a/src/runtime/terminal-runtime/terminal-runtime.test.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.test.ts
@@ -161,6 +161,12 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
 
+function interruptNoticeElement(): HTMLElement {
+  const el = document.body.querySelector<HTMLElement>(".terminal-runtime-notice");
+  if (!el) throw new Error("interrupt notice element not found");
+  return el;
+}
+
 describe("TerminalRuntime", () => {
   beforeEach(() => {
     _clearForTest();
@@ -308,6 +314,100 @@ describe("TerminalRuntime", () => {
 
     expect(received).toEqual(["y"]);
     sub.dispose();
+  });
+
+  it("suppresses first Ctrl+C data in all interrupt protection mode", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    runtime.setInterruptProtectionMode("all");
+
+    mockState.dataHandlers[0]?.("\x03");
+    await flushMicrotasks();
+
+    expect(mockState.sessionWrite).not.toHaveBeenCalled();
+    expect(interruptNoticeElement().textContent).toContain("Ctrl+C ignored");
+    expect(interruptNoticeElement().hidden).toBe(false);
+    expect(terminal.writes.join("")).not.toContain("Ctrl+C ignored");
+  });
+
+  it("allows first Ctrl+C data and suppresses repeated Ctrl+C data in repeated mode", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    runtime.setInterruptProtectionMode("repeated");
+
+    mockState.dataHandlers[0]?.("\x03");
+    mockState.dataHandlers[0]?.("\x03");
+    await flushMicrotasks();
+
+    expect(mockState.sessionWrite).toHaveBeenCalledOnce();
+    expect(mockState.sessionWrite).toHaveBeenCalledWith({
+      sessionId: "shell-1",
+      data: "\x03",
+    });
+    expect(interruptNoticeElement().textContent).toContain("Second Ctrl+C ignored");
+    expect(interruptNoticeElement().hidden).toBe(false);
+    expect(terminal.writes.join("")).not.toContain("Second Ctrl+C ignored");
+  });
+
+  it("allows Ctrl+C again in repeated mode after non-interrupt input", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    runtime.setInterruptProtectionMode("repeated");
+
+    mockState.dataHandlers[0]?.("\x03");
+    mockState.dataHandlers[0]?.("x");
+    mockState.dataHandlers[0]?.("\x03");
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(mockState.sessionWrite).toHaveBeenCalledTimes(3);
+    expect(mockState.sessionWrite).toHaveBeenNthCalledWith(1, {
+      sessionId: "shell-1",
+      data: "\x03",
+    });
+    expect(mockState.sessionWrite).toHaveBeenNthCalledWith(2, {
+      sessionId: "shell-1",
+      data: "x",
+    });
+    expect(mockState.sessionWrite).toHaveBeenNthCalledWith(3, {
+      sessionId: "shell-1",
+      data: "\x03",
+    });
+  });
+
+  it("blocks first Ctrl+C at keydown in all interrupt protection mode", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    runtime.setInterruptProtectionMode("all");
+
+    const handled = terminal.customKeyEventHandler?.(
+      new KeyboardEvent("keydown", { key: "c", ctrlKey: true }),
+    );
+
+    expect(handled).toBe(false);
+    expect(interruptNoticeElement().textContent).toContain("Ctrl+C ignored");
+    expect(interruptNoticeElement().hidden).toBe(false);
+    expect(terminal.writes.join("")).not.toContain("Ctrl+C ignored");
+  });
+
+  it("allows first Ctrl+C keydown and blocks repeated Ctrl+C keydown in repeated mode", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    runtime.setInterruptProtectionMode("repeated");
+
+    const first = terminal.customKeyEventHandler?.(
+      new KeyboardEvent("keydown", { key: "c", ctrlKey: true }),
+    );
+    terminal.customKeyEventHandler?.(new KeyboardEvent("keyup", { key: "c", ctrlKey: true }));
+    const second = terminal.customKeyEventHandler?.(
+      new KeyboardEvent("keydown", { key: "c", ctrlKey: true }),
+    );
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(interruptNoticeElement().textContent).toContain("Second Ctrl+C ignored");
+    expect(interruptNoticeElement().hidden).toBe(false);
+    expect(terminal.writes.join("")).not.toContain("Second Ctrl+C ignored");
   });
 
   it("/clear は xterm の可視画面を消さず scrollback だけ消す", () => {

--- a/src/runtime/terminal-runtime/terminal-runtime.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.ts
@@ -22,6 +22,7 @@ import {
 } from "./osc-notification";
 import { extractRegionText, polygonBounds, type RegionPoint } from "./region-selection";
 import type {
+  InterruptProtectionMode,
   PtyParams,
   TerminalCursorClientPosition,
   TerminalLineRect,
@@ -34,6 +35,8 @@ import type {
 
 const TYPING_CURSOR_ACTIVE_MS = 2000;
 const IME_POST_COMMIT_SUPPRESS_MS = 80;
+const INTERRUPT_NOTICE_THROTTLE_MS = 1000;
+const INTERRUPT_NOTICE_VISIBLE_MS = 1800;
 
 /** xterm.js の初期カラーテーマ。scene が未設定の時のフォールバック。 */
 export const DEFAULT_TERMINAL_THEME: XTermTheme = {
@@ -77,6 +80,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   private readonly term: XTerm;
   private readonly fitAddon: FitAddon;
   private readonly xtermContainer: HTMLDivElement;
+  private readonly interruptNoticeElement: HTMLDivElement;
   private readonly regionCanvas: HTMLCanvasElement | null;
   private readonly regionCtx: CanvasRenderingContext2D | null;
   private readonly channel: Channel<ArrayBuffer>;
@@ -90,6 +94,11 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   private lastFitW = 0;
   private lastFitH = 0;
   private lastUserInputAt = -Infinity;
+  private lastInterruptNoticeAt = -Infinity;
+  private interruptNoticeHideTimer: number | null = null;
+  private repeatedInterruptKeyArmed = false;
+  private repeatedInterruptInputArmed = false;
+  private interruptProtectionMode: InterruptProtectionMode = "none";
   private recentInput = "";
   private readonly ptyDataListeners = new Set<() => void>();
   private readonly notificationListeners = new Set<(event: TerminalNotificationEvent) => void>();
@@ -146,6 +155,8 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     document.body.appendChild(this.xtermContainer);
 
     this.term.open(this.xtermContainer);
+    this.interruptNoticeElement = this.createInterruptNoticeElement();
+    this.xtermContainer.appendChild(this.interruptNoticeElement);
     this.installImeCompositionGuard();
     this.installNotificationOscHandlers();
 
@@ -313,6 +324,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
       window.clearTimeout(this.clearRegionCanvasTimeout);
       this.clearRegionCanvasTimeout = null;
     }
+    this.clearInterruptNoticeTimer();
     this.clearImePendingCommitTimer();
     this.term.dispose();
     if (this.xtermContainer.parentElement) {
@@ -680,6 +692,15 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     this.term.focus();
   }
 
+  setInterruptProtectionMode(mode: InterruptProtectionMode): void {
+    this.interruptProtectionMode = mode;
+    if (mode === "none") {
+      this.repeatedInterruptKeyArmed = false;
+      this.repeatedInterruptInputArmed = false;
+      this.lastInterruptNoticeAt = -Infinity;
+    }
+  }
+
   forceRespawn(): void {
     if (this.disposed) return;
     if (!this.currentParams) return;
@@ -757,9 +778,37 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     });
 
     this.term.attachCustomKeyEventHandler((event) => {
+      if (this.shouldSuppressProtectedInterruptKeyEvent(event)) return false;
       if (this.shouldSuppressImeKeyEvent(event)) return false;
       return true;
     });
+  }
+
+  private shouldSuppressProtectedInterruptKeyEvent(event: KeyboardEvent): boolean {
+    if (this.interruptProtectionMode === "none") return false;
+    if (!this.isInterruptKeyEvent(event)) {
+      if (this.interruptProtectionMode === "repeated" && event.type === "keydown") {
+        this.repeatedInterruptKeyArmed = false;
+      }
+      return false;
+    }
+    if (this.interruptProtectionMode === "all") {
+      this.showInterruptProtectedNotice("all");
+      return true;
+    }
+
+    if (!this.repeatedInterruptKeyArmed) {
+      this.repeatedInterruptKeyArmed = true;
+      return false;
+    }
+    this.showInterruptProtectedNotice("repeated");
+    return true;
+  }
+
+  private isInterruptKeyEvent(event: KeyboardEvent): boolean {
+    if (event.type !== "keydown") return false;
+    if (!event.ctrlKey || event.metaKey || event.altKey) return false;
+    return event.key.toLowerCase() === "c";
   }
 
   private shouldSuppressImeKeyEvent(event: KeyboardEvent): boolean {
@@ -824,6 +873,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   }
 
   private acceptUserInputData(data: string): void {
+    if (this.shouldSuppressProtectedInterruptData(data)) return;
     this.lastUserInputAt = performance.now();
     this.perceptionRef.current?.onUserInput(data);
     this.notifyUserInputListeners(data);
@@ -835,6 +885,62 @@ class TerminalRuntimeImpl implements TerminalRuntime {
         // PTY already closed — silent
       }
     });
+  }
+
+  private shouldSuppressProtectedInterruptData(data: string): boolean {
+    if (this.interruptProtectionMode === "none") return false;
+    if (!data.includes("\x03")) {
+      if (this.interruptProtectionMode === "repeated") {
+        this.repeatedInterruptInputArmed = false;
+      }
+      return false;
+    }
+    if (this.interruptProtectionMode === "all") {
+      this.showInterruptProtectedNotice("all");
+      return true;
+    }
+
+    if (!this.repeatedInterruptInputArmed) {
+      this.repeatedInterruptInputArmed = true;
+      return false;
+    }
+    this.showInterruptProtectedNotice("repeated");
+    return true;
+  }
+
+  private createInterruptNoticeElement(): HTMLDivElement {
+    const element = document.createElement("div");
+    element.className = "terminal-runtime-notice";
+    element.hidden = true;
+    element.setAttribute("role", "status");
+    element.setAttribute("aria-live", "polite");
+    element.setAttribute("aria-atomic", "true");
+    return element;
+  }
+
+  private showInterruptProtectedNotice(mode: Exclude<InterruptProtectionMode, "none">): void {
+    const now = performance.now();
+    if (now - this.lastInterruptNoticeAt <= INTERRUPT_NOTICE_THROTTLE_MS) return;
+    this.lastInterruptNoticeAt = now;
+    const message =
+      mode === "all"
+        ? "[Ctrl+C ignored in the main agent tab]"
+        : "[Second Ctrl+C ignored to keep the main agent running]";
+    this.interruptNoticeElement.textContent = message;
+    this.interruptNoticeElement.hidden = false;
+    this.interruptNoticeElement.classList.add("is-visible");
+    this.clearInterruptNoticeTimer();
+    this.interruptNoticeHideTimer = window.setTimeout(() => {
+      this.interruptNoticeHideTimer = null;
+      this.interruptNoticeElement.classList.remove("is-visible");
+      this.interruptNoticeElement.hidden = true;
+    }, INTERRUPT_NOTICE_VISIBLE_MS);
+  }
+
+  private clearInterruptNoticeTimer(): void {
+    if (this.interruptNoticeHideTimer === null) return;
+    window.clearTimeout(this.interruptNoticeHideTimer);
+    this.interruptNoticeHideTimer = null;
   }
 
   private readonly handleViewportResize = (): void => {

--- a/src/runtime/terminal-runtime/types.ts
+++ b/src/runtime/terminal-runtime/types.ts
@@ -65,6 +65,8 @@ export interface TerminalNotificationEvent {
   readonly receivedAt: number;
 }
 
+export type InterruptProtectionMode = "none" | "repeated" | "all";
+
 export interface TerminalRegionContext {
   readonly kind: "terminal-region-context";
   readonly sessionId: string;
@@ -255,6 +257,12 @@ export interface TerminalRuntime {
 
   /** xterm にキーボードフォーカスを移す。タブ切り替え時に使う。 */
   focus(): void;
+
+  /**
+   * Ctrl+C を PTY に送るか制御する。
+   * main agent の accidental exit 防止用で、shell session には使わない。
+   */
+  setInterruptProtectionMode(mode: InterruptProtectionMode): void;
 
   /** currentParams を無効化し updatePtyParams を再実行する。auto-respawn 用。 */
   forceRespawn(): void;

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -7,7 +7,7 @@ import {
   getSessionStatusStore,
   isAttentionClearingInput,
 } from "./runtime/session-status";
-import { getTerminalRuntime } from "./runtime/terminal-runtime";
+import { getTerminalRuntime, type InterruptProtectionMode } from "./runtime/terminal-runtime";
 import { getCurrentTerminalTheme } from "./runtime/terminal-theme";
 
 const OUTPUT_SETTLE_MS = 800;
@@ -20,6 +20,7 @@ interface TerminalProps {
   readonly cwd: string | null;
   readonly perception: Perception | null;
   readonly attachFirst?: boolean;
+  readonly interruptProtectionMode?: InterruptProtectionMode;
 }
 
 export default function Terminal({
@@ -29,6 +30,7 @@ export default function Terminal({
   cwd,
   perception,
   attachFirst = false,
+  interruptProtectionMode = "none",
 }: TerminalProps) {
   const placeholderRef = useRef<HTMLDivElement>(null);
   const outputSettleTimerRef = useRef<number | null>(null);
@@ -121,6 +123,10 @@ export default function Terminal({
   useEffect(() => {
     getTerminalRuntime(sessionId).setPerception(perception);
   }, [sessionId, perception]);
+
+  useEffect(() => {
+    getTerminalRuntime(sessionId).setInterruptProtectionMode(interruptProtectionMode);
+  }, [sessionId, interruptProtectionMode]);
 
   return (
     <div


### PR DESCRIPTION
## Summary

- Add an agent runtime policy for main-agent Ctrl+C handling: Claude allows the first interrupt and blocks repeated interrupts, while Codex and OpenCode block the first interrupt.
- Apply the interrupt protection mode to the default terminal session only; shell sessions keep normal Ctrl+C behavior.
- Show the interrupt-blocked message as a terminal overlay instead of writing into the xterm buffer, avoiding TUI input-line/cursor corruption.

## Validation

- npm test -- src/runtime/sessions/agent-runtime-policy.test.ts src/runtime/terminal-runtime/terminal-runtime.test.ts src/runtime/session-tabs/session-tab-manager.test.ts --run
- npm run build
- npm run check
- pre-push hook: tsc-no-emit, biome-check, cargo-fmt, cargo-clippy, typedoc-validate