### PR TITLE
Make awaiting-input badge detection deterministic

### DIFF
--- a/src/runtime/session-status/screen-attention-detector.test.ts
+++ b/src/runtime/session-status/screen-attention-detector.test.ts
@@ -1,16 +1,55 @@
 import { describe, expect, it } from "vitest";
 import { detectScreenAttentionRequest } from "./screen-attention-detector";
 
+const CLAUDE_MODEL_MENU_TAIL = `
+ ⚠ 3 MCP servers need authentication · run /mcp
+ ▎ Fable 5 is back.
+ ▎ Until July 7, you can use up to 50% of your plan's weekly usage limit on Fable 5. If you hit your limit, you can
+ ▎ continue on Fable 5 with usage credits. Fable 5 draws down usage faster than Opus 4.8. Learn more
+ ▎ (https://support.claude.com/en/articles/15424964-claude-fable-5-promotional-access)
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+   Select model
+   Switch between Claude models. Your pick becomes the default for new sessions. For other/previous model names,
+   specify with --model.
+     1. Default (recommended)  Opus 4.8 with 1M context · Best for everyday, complex tasks
+     2. Opus                   Opus 4.8 with 1M context · Best for everyday, complex tasks
+   ❯ 3. Fable ✔                Fable 5 · Most capable for your hardest and longest-running tasks
+     4. Sonnet                 Sonnet 5 · Efficient for routine tasks
+     5. Haiku                  Haiku 4.5 · Fastest for quick answers
+   ◉ xHigh effort ←/→ to adjust
+   Use /fast to turn on Fast mode (Opus 4.8).
+   Enter to set as default · s to use this session only · Esc to cancel
+`;
+
+const CLAUDE_RUNNING_SPINNER_TAIL = `
+ ⚠ 3 MCP servers need authentication · run /mcp
+ ▎ Fable 5 is back.
+ ▎ Until July 7, you can use up to 50% of your plan's weekly usage limit on Fable 5. If you hit your limit, you can
+ ▎ continue on Fable 5 with usage credits. Fable 5 draws down usage faster than Opus 4.8. Learn more
+ ▎ (https://support.claude.com/en/articles/15424964-claude-fable-5-promotional-access)
+❯ Run exactly this bash command and nothing else: echo hello
+✽ Boogieing…
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  esc to interrupt · ← for agents
+`;
+
+// 2026-07-03 の PTY 採取では Bash が auto-allow され実許可 prompt が出なかったため、
+// 設計 doc §5 の Yes/No 選択肢 + Bash/run 語彙の合成形を fixture とする。
+const SYNTHETIC_BASH_PERMISSION_PROMPT = `
+  Claude needs your permission to use Bash
+  Bash(cat /etc/hosts)
+  Do you want Claude to run this command?
+
+  ❯ 1. Yes
+    2. Yes, and don't ask again
+    3. No
+`;
+
 describe("detectScreenAttentionRequest", () => {
   it("detects Claude Code permission prompts from the screen tail", () => {
-    const detection = detectScreenAttentionRequest(`
-      Claude needs your permission to use Bash
-      command: npm run build
-
-      ❯ 1. Yes
-        2. Yes, and don't ask again
-        3. No
-    `);
+    const detection = detectScreenAttentionRequest(SYNTHETIC_BASH_PERMISSION_PROMPT);
 
     expect(detection).toMatchObject({
       title: "Claude Code",
@@ -110,6 +149,28 @@ describe("detectScreenAttentionRequest", () => {
       detectScreenAttentionRequest(`
         running build...
         permission docs generated successfully
+        done
+      `),
+    ).toBeNull();
+  });
+
+  it("does not detect Claude model picker menus as attention", () => {
+    expect(detectScreenAttentionRequest(CLAUDE_MODEL_MENU_TAIL)).toBeNull();
+  });
+
+  it("does not detect Claude running spinner interrupt hint as attention", () => {
+    expect(detectScreenAttentionRequest(CLAUDE_RUNNING_SPINNER_TAIL)).toBeNull();
+  });
+
+  it("does not detect quoted Yes/No menus when the choice block is not at the tail bottom", () => {
+    expect(
+      detectScreenAttentionRequest(`
+        Bash(npm run build)
+        1. Yes
+        2. No
+        later build output line 1
+        later build output line 2
+        later build output line 3
         done
       `),
     ).toBeNull();

--- a/src/runtime/session-status/screen-attention-detector.ts
+++ b/src/runtime/session-status/screen-attention-detector.ts
@@ -5,6 +5,8 @@ export interface ScreenAttentionDetection {
 }
 
 const MAX_BODY_LENGTH = 180;
+const CHOICE_CONTEXT_RADIUS = 4;
+const CHOICE_TAIL_MAX_TRAILING_LINES = 3;
 
 /**
  * xterm screen buffer の末尾から、agent がユーザー入力/許可を待っている prompt を
@@ -118,23 +120,48 @@ function isInteractiveChoicePrompt(lines: ReadonlyArray<string>): boolean {
     /^(?:yes|no|allow|approve|deny|reject|cancel|proceed|always|skip|abort)\b/i.test(line);
   const affirmative = /\b(?:yes|allow|approve|proceed|confirm|apply|run it)\b/i;
   const negative = /\b(?:no|deny|reject|cancel|don'?t|do not|stop|skip|abort|keep current)\b/i;
-  const ynHint =
-    /\(y\/n\)|\[y\/n\]|\by\/n\b|press\s+y\b|esc\s+to\s+(?:cancel|reject|deny|go back|interrupt)/i;
+  const ynHint = /\(y\/n\)|\[y\/n\]|\by\/n\b|press\s+y\b|esc\s+to\s+(?:reject|deny)/i;
 
   let aff = false;
   let neg = false;
-  let options = 0;
-  for (const line of lines) {
-    if (ynHint.test(line)) return true;
+  const optionLineIndexes: number[] = [];
+  for (const [index, line] of lines.entries()) {
+    if (ynHint.test(line) && hasAttentionContextNear(lines, index)) return true;
     if (numbered.test(line) || bareChoice(line)) {
-      options += 1;
+      optionLineIndexes.push(index);
       if (affirmative.test(line)) aff = true;
       if (negative.test(line)) neg = true;
     }
   }
-  if (aff && neg) return true;
+  if (aff && neg) return isChoiceBlockAtTailBottom(lines, optionLineIndexes);
   // 「Yes」系が複数並ぶ（Yes / Yes, always …）形も入力待ちと見なす。
-  return aff && options >= 2;
+  return (
+    aff && optionLineIndexes.length >= 2 && isChoiceBlockAtTailBottom(lines, optionLineIndexes)
+  );
+}
+
+function hasAttentionContextNear(lines: ReadonlyArray<string>, index: number): boolean {
+  const start = Math.max(0, index - CHOICE_CONTEXT_RADIUS);
+  const end = Math.min(lines.length - 1, index + CHOICE_CONTEXT_RADIUS);
+  for (let lineIndex = start; lineIndex <= end; lineIndex++) {
+    if (hasAttentionContext(lines[lineIndex])) return true;
+  }
+  return false;
+}
+
+function hasAttentionContext(line: string): boolean {
+  return /\b(?:permission|approval|allow|deny|run|execute|command|tool|bash|edit|file|network|write|read|operation|action|proceed|continue|use|apply|requires?|needs?|requests?|requested)\b/i.test(
+    line,
+  );
+}
+
+function isChoiceBlockAtTailBottom(
+  lines: ReadonlyArray<string>,
+  optionLineIndexes: ReadonlyArray<number>,
+): boolean {
+  const lastOptionLineIndex = optionLineIndexes[optionLineIndexes.length - 1];
+  if (lastOptionLineIndex === undefined) return false;
+  return lines.length - 1 - lastOptionLineIndex <= CHOICE_TAIL_MAX_TRAILING_LINES;
 }
 
 function extractPromptBody(lines: ReadonlyArray<string>, joined: string): string {

--- a/src/runtime/session-status/session-status-store.test.ts
+++ b/src/runtime/session-status/session-status-store.test.ts
@@ -406,6 +406,27 @@ describe("SessionStatusStore", () => {
     expect(store.get("s1")).toMatchObject({ activity: "idle", attention: null });
   });
 
+  it("allows the same screen attention after prompt disappearance was observed", () => {
+    const { store, tick } = createStore();
+
+    store.markScreenAttentionRequest("s1", { title: "Claude Code", body: "Allow command?" });
+    tick(100);
+    store.clearAttention("s1");
+    tick(100);
+    store.clearScreenAttention("s1");
+    tick(100);
+    store.markScreenAttentionRequest("s1", { title: "Claude Code", body: "Allow command?" });
+
+    expect(store.get("s1")).toMatchObject({
+      activity: "awaiting-input",
+      attention: {
+        title: "Claude Code",
+        body: "Allow command?",
+        source: "screen",
+      },
+    });
+  });
+
   it("allows a different screen attention after user cleared a previous prompt", () => {
     const { store, tick } = createStore();
 

--- a/src/runtime/session-status/session-status-store.test.ts
+++ b/src/runtime/session-status/session-status-store.test.ts
@@ -427,6 +427,24 @@ describe("SessionStatusStore", () => {
     });
   });
 
+  it("suppresses late hook attention after prompt disappearance was observed", () => {
+    const { store, tick } = createStore();
+
+    store.markScreenAttentionRequest("s1", { title: "Claude Code", body: "Allow command?" });
+    tick(100);
+    store.clearAttention("s1");
+    tick(100);
+    store.clearScreenAttention("s1");
+    tick(100);
+    store.markAttentionRequest("s1", {
+      title: "Claude Code",
+      body: "Allow command?",
+      source: "hook",
+    });
+
+    expect(store.get("s1")).toMatchObject({ activity: "idle", attention: null });
+  });
+
   it("allows a different screen attention after user cleared a previous prompt", () => {
     const { store, tick } = createStore();
 

--- a/src/runtime/session-status/session-status-store.ts
+++ b/src/runtime/session-status/session-status-store.ts
@@ -316,8 +316,13 @@ export class SessionStatusStore {
    */
   clearScreenAttention(sessionId: SessionId): void {
     const current = this.statuses.get(sessionId);
-    if (!current || current.attention?.source !== "screen") return;
-    this.clearAttention(sessionId);
+    if (current?.attention?.source === "screen") {
+      this.clearAttention(sessionId);
+    }
+    const lastCleared = this.lastAttentionCleared.get(sessionId);
+    if (lastCleared?.source === "screen") {
+      this.lastAttentionCleared.delete(sessionId);
+    }
   }
 
   /** loop lifecycle が進行/終了したとき、loop 由来の sticky attention だけを解除する。 */

--- a/src/runtime/session-status/session-status-store.ts
+++ b/src/runtime/session-status/session-status-store.ts
@@ -74,6 +74,7 @@ interface ClearedAttention {
   readonly body: string;
   readonly source: SessionAttention["source"];
   readonly clearedAt: number;
+  readonly screenDisappearanceObserved: boolean;
 }
 
 /**
@@ -263,7 +264,15 @@ export class SessionStatusStore {
         lastCleared.source === "screen" &&
         lastCleared.title === (title.length > 0 ? title : null) &&
         lastCleared.body === body;
-      if (inSuppressionWindow && (source !== "screen" || sameScreenPrompt)) return;
+      const shouldAllowObservedScreenPrompt =
+        source === "screen" && lastCleared.screenDisappearanceObserved;
+      if (
+        inSuppressionWindow &&
+        !shouldAllowObservedScreenPrompt &&
+        (source !== "screen" || sameScreenPrompt)
+      ) {
+        return;
+      }
     }
 
     if (
@@ -321,7 +330,10 @@ export class SessionStatusStore {
     }
     const lastCleared = this.lastAttentionCleared.get(sessionId);
     if (lastCleared?.source === "screen") {
-      this.lastAttentionCleared.delete(sessionId);
+      this.lastAttentionCleared.set(sessionId, {
+        ...lastCleared,
+        screenDisappearanceObserved: true,
+      });
     }
   }
 
@@ -365,6 +377,7 @@ export class SessionStatusStore {
       body: previousAttention.body,
       source: previousAttention.source,
       clearedAt,
+      screenDisappearanceObserved: false,
     });
     this.commit({
       ...current,


### PR DESCRIPTION
## Summary

- The screen attention detector no longer treats generic TUI footer vocabulary (`esc to cancel` / `esc to interrupt` / `esc to go back`) as a permission prompt. Explicit y/n hints now require approval vocabulary in nearby lines (±4), and Yes/No choice menus must sit at the bottom of the screen tail. As a result, user-invoked pickers (`/model`) and the running spinner no longer light the tab's awaiting-input badge; screen tails captured from the real Claude Code TUI (including a scrollback line containing "run /mcp", which used to flip the verdict) are pinned as regression fixtures.
- Suppression lifecycle fix: once a scan observes the prompt has disappeared from the screen, an identical re-shown prompt lights the badge again (previously swallowed for 10s — the "Esc then reopen" bug). Late hook/OSC signals remain suppressed within the window via a `screenDisappearanceObserved` flag, so answering a prompt faster than the delayed hook no longer risks a false badge either way.

## Validation

- `npm run check` (tsc + biome + cargo fmt --check + clippy) exit 0
- `npx vitest run`: 1655 tests passed
- Detection verified against real captured Claude Code screens (PTY capture → xterm-headless render → detector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)