### PR TITLE
In-app updater: 設定画面から1ボタンで自己更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,11 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
 
+      # tauri.updater.conf.json overlay で createUpdaterArtifacts を CI だけ有効化する。
+      # base conf に置くと署名鍵を持たない contributor のローカル `tauri build` が
+      # 失敗するため（TAURI_SIGNING_PRIVATE_KEY 必須になる）、意図的に分離している。
       - name: Build and sign
-        run: npm run tauri build -- --target ${{ matrix.target }}
+        run: npm run tauri build -- --target ${{ matrix.target }} --config src-tauri/tauri.updater.conf.json
         env:
           CI: "true"
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -87,12 +90,32 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # in-app updater 用のパッケージ署名（Apple codesign とは別系統の minisign）。
+          # 鍵はパスワードなしで生成しているため PASSWORD env は設定しない。
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+
+      # updater artifact（.app.tar.gz + .sig）は両アーキで同名（charminal.app.tar.gz）に
+      # なるため、arch を含む名前にリネームしてから artifact 化する。この名前が
+      # そのまま Release asset 名になり、latest.json の url が指す。
+      - name: Stage updater artifacts
+        run: |
+          BUNDLE_DIR="src-tauri/target/${{ matrix.target }}/release/bundle/macos"
+          mkdir -p updater-assets
+          cp "$BUNDLE_DIR"/*.app.tar.gz "updater-assets/charminal_${{ matrix.arch }}.app.tar.gz"
+          cp "$BUNDLE_DIR"/*.app.tar.gz.sig "updater-assets/charminal_${{ matrix.arch }}.app.tar.gz.sig"
+          ls -la updater-assets
 
       - name: Upload .dmg
         uses: actions/upload-artifact@v6
         with:
           name: charminal-macos-${{ matrix.arch }}
           path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+
+      - name: Upload updater artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: charminal-updater-${{ matrix.arch }}
+          path: updater-assets/*
 
   publish-release:
     needs: [build-macos]
@@ -118,6 +141,32 @@ jobs:
           for f in *x64*.dmg; do [ -e "$f" ] && cp "$f" Charminal-Intel.dmg; done
           ls -la
 
+      # in-app updater（tauri-plugin-updater）が参照する更新 manifest。
+      # アプリは releases/latest/download/latest.json を見るため、リリースを
+      # publish した瞬間から既存インストールに更新が配信される。
+      # 片アーキ失敗時（fail-fast: false）は成功した分だけを manifest に載せる。
+      - name: Stage updater artifacts and generate latest.json
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          BASE="https://github.com/${{ github.repository }}/releases/download/${TAG}"
+          find artifacts -name '*.app.tar.gz' -exec cp {} release-assets/ \;
+          find artifacts -name '*.app.tar.gz.sig' -exec cp {} release-assets/ \;
+          SIG_ARM=$(cat release-assets/charminal_aarch64.app.tar.gz.sig 2>/dev/null || true)
+          SIG_X64=$(cat release-assets/charminal_x86_64.app.tar.gz.sig 2>/dev/null || true)
+          jq -n \
+            --arg version "$VERSION" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg sig_arm "$SIG_ARM" \
+            --arg url_arm "$BASE/charminal_aarch64.app.tar.gz" \
+            --arg sig_x64 "$SIG_X64" \
+            --arg url_x64 "$BASE/charminal_x86_64.app.tar.gz" \
+            '{version: $version, pub_date: $pub_date, platforms: ({}
+              + (if $sig_arm != "" then {"darwin-aarch64": {signature: $sig_arm, url: $url_arm}} else {} end)
+              + (if $sig_x64 != "" then {"darwin-x86_64": {signature: $sig_x64, url: $url_x64}} else {} end))}' \
+            > release-assets/latest.json
+          cat release-assets/latest.json
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -126,3 +175,5 @@ jobs:
           generate_release_notes: true
           files: |
             release-assets/*.dmg
+            release-assets/*.app.tar.gz
+            release-assets/latest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,10 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # in-app updater 用のパッケージ署名（Apple codesign とは別系統の minisign）。
-          # 鍵はパスワードなしで生成しているため PASSWORD env は設定しない。
+          # 鍵は空パスワードで生成している。PASSWORD を明示しないと TTY プロンプトを
+          # 出そうとして CI では "Device not configured" で失敗する。
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
 
       # updater artifact（.app.tar.gz + .sig）は両アーキで同名（charminal.app.tar.gz）に
       # なるため、arch を含む名前にリネームしてから artifact 化する。この名前が

--- a/bundled-packs/ui/charminal-settings/ui.tsx
+++ b/bundled-packs/ui/charminal-settings/ui.tsx
@@ -47,6 +47,7 @@ import {
 } from "../../../src/i18n/strings";
 import { buildRestoreRows } from "../../../src/runtime/history/describe-snapshot";
 import { getBrowserLocales, resolveLanguage } from "../../../src/runtime/language/language";
+import { type AvailableUpdate, checkForUpdate } from "../../../src/runtime/updater/app-updater";
 import {
   isBundledClaiPersonaId,
   localizedClaiPersonaId,
@@ -2036,6 +2037,14 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
   const languageChangeSeq = useRef(0);
   const [voiceFrequency, setVoiceFrequency] = useState<"on" | "off">("on");
   const [configLoaded, setConfigLoaded] = useState(false);
+  // in-app update。設定を開いたときに一度だけ確認し、更新があればバナーを出す。
+  // idle = 更新なし（確認前・確認失敗を含む）。downloading の ratio は 0-1 / null（不定）。
+  const [updateState, setUpdateState] = useState<
+    | { phase: "idle" }
+    | { phase: "available"; update: AvailableUpdate }
+    | { phase: "downloading"; ratio: number | null }
+    | { phase: "error" }
+  >({ phase: "idle" });
   const personas = ctx.app.listPersonas();
   const visiblePersonas = filterPersonaOptionsForLanguage(personas, resolvedLanguage);
   const personaSelectValue = configLoaded
@@ -2066,6 +2075,28 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
       aborted = true;
     };
   }, [ctx]);
+
+  useEffect(() => {
+    let aborted = false;
+    void checkForUpdate().then((update) => {
+      if (!aborted && update) setUpdateState({ phase: "available", update });
+    });
+    return () => {
+      aborted = true;
+    };
+  }, []);
+
+  /** 更新バナーの1ボタン。ダウンロード・適用して relaunch する（成功時は戻ってこない）。 */
+  const onInstallUpdate = useCallback((update: AvailableUpdate) => {
+    setUpdateState({ phase: "downloading", ratio: null });
+    update
+      .installAndRelaunch((ratio) => {
+        setUpdateState({ phase: "downloading", ratio });
+      })
+      .catch(() => {
+        setUpdateState({ phase: "error" });
+      });
+  }, []);
 
   const onPersonaChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const next = configPrimaryPersonaForSelection(e.target.value);
@@ -2301,6 +2332,58 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
           overflowY: "auto",
         }}
       >
+        {/* 更新バナー: 更新があるときだけ現れる控えめな1行。1ボタンで適用して再起動する */}
+        {updateState.phase !== "idle" && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: SPACING.md,
+              marginBottom: SPACING.lg,
+              padding: `${SPACING.sm} ${SPACING.md}`,
+              borderRadius: RADIUS.sm,
+              background: COLORS.accentSoft,
+              border: `1px solid ${COLORS.accentBorder}`,
+              fontSize: FONT.sizeXs,
+            }}
+          >
+            {updateState.phase === "available" && (
+              <>
+                <span style={{ opacity: 0.85 }}>
+                  {strings.updateAvailable.replace("{version}", updateState.update.version)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onInstallUpdate(updateState.update)}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: COLORS.accent,
+                    font: "inherit",
+                    fontSize: "inherit",
+                    cursor: "pointer",
+                    padding: 0,
+                    textDecoration: "underline",
+                    textDecorationColor: "currentColor",
+                    textUnderlineOffset: "2px",
+                  }}
+                >
+                  {strings.updateAndRestart}
+                </button>
+              </>
+            )}
+            {updateState.phase === "downloading" && (
+              <span style={{ opacity: 0.85 }}>
+                {strings.updateDownloading}
+                {updateState.ratio !== null && ` ${Math.round(updateState.ratio * 100)}%`}
+              </span>
+            )}
+            {updateState.phase === "error" && (
+              <span style={{ opacity: 0.7 }}>{strings.updateFailed}</span>
+            )}
+          </div>
+        )}
+
         {/* Quick Actions */}
         <div
           style={{

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
@@ -2846,6 +2848,24 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +542,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -771,6 +782,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1076,6 +1098,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1735,6 +1767,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,6 +2406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,6 +2726,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +2794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2813,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3428,15 +3513,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3470,6 +3560,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3545,6 +3649,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,6 +3740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3635,6 +3821,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4121,6 +4330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4233,6 +4448,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4435,6 +4661,49 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -4687,6 +4956,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -5007,6 +5286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5311,6 +5596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5538,6 +5832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5977,6 +6280,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6108,6 +6421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6138,6 +6457,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,10 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+# in-app updater: GitHub Releases の latest.json を参照して署名検証つきで自己更新する。
+# process は更新適用後の relaunch に使う。
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 portable-pty = "0.8"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
     "core:window:allow-set-title",
     "core:window:allow-start-dragging",
     "opener:default",
-    "dialog:default"
+    "dialog:default",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2132,6 +2132,8 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .manage(pty_state)
         .manage(registry)
         .manage(WatcherState::new())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,9 +30,16 @@
       }
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhGNjVCQUEzMUUzMTQ1NTkKUldSWlJURWVvN3BsajJLdWRiVjYycmpacW1hSVNLUXUvYVpsNHpkcUh4MlJST3ZYZWR0WFdsQ08K",
+      "endpoints": ["https://github.com/sktkkoo/Charminal/releases/latest/download/latest.json"]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "macOS": {
       "entitlements": "Entitlements.plist"
     },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": true,
     "macOS": {
       "entitlements": "Entitlements.plist"
     },

--- a/src-tauri/tauri.updater.conf.json
+++ b/src-tauri/tauri.updater.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": true
+  }
+}

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -101,6 +101,11 @@ export interface UiStrings {
   readonly quickPomodoro: string;
   /** 設定画面 Quick Actions の CREDITS ボタン。overlay の中身は英語固定（ui.tsx）。 */
   readonly labelCredits: string;
+  /** 設定画面の更新バナー。{version} を新 version で置換する。 */
+  readonly updateAvailable: string;
+  readonly updateAndRestart: string;
+  readonly updateDownloading: string;
+  readonly updateFailed: string;
 }
 
 const EN: UiStrings = {
@@ -203,6 +208,10 @@ const EN: UiStrings = {
   quickCreatePack: "Create Pack",
   quickPomodoro: "Pomodoro",
   labelCredits: "CREDITS",
+  updateAvailable: "v{version} available",
+  updateAndRestart: "Update and restart",
+  updateDownloading: "Updating…",
+  updateFailed: "Update failed. Please try again later.",
 };
 
 const JA: UiStrings = {
@@ -305,6 +314,10 @@ const JA: UiStrings = {
   quickCreatePack: "パック作成",
   quickPomodoro: "ポモドーロ",
   labelCredits: "CREDITS",
+  updateAvailable: "v{version} が利用可能です",
+  updateAndRestart: "更新して再起動",
+  updateDownloading: "更新中…",
+  updateFailed: "更新に失敗しました。時間をおいて再試行してください。",
 };
 
 export function getStrings(language: ResolvedLanguage): UiStrings {

--- a/src/runtime/updater/app-updater.test.ts
+++ b/src/runtime/updater/app-updater.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { checkForUpdate } from "./app-updater";
+
+// tauri-plugin-updater / plugin-process は Tauri runtime が前提なので module ごと mock する。
+const mockCheck = vi.fn();
+const mockRelaunch = vi.fn();
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: (...args: unknown[]) => mockCheck(...args),
+}));
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: (...args: unknown[]) => mockRelaunch(...args),
+}));
+
+/** downloadAndInstall に渡された progress callback へ event 列を流す update stub を作る。 */
+function makeUpdateStub(
+  version: string,
+  events: ReadonlyArray<Record<string, unknown>>,
+): { version: string; downloadAndInstall: ReturnType<typeof vi.fn> } {
+  return {
+    version,
+    downloadAndInstall: vi.fn(async (onEvent?: (e: unknown) => void) => {
+      for (const e of events) onEvent?.(e);
+    }),
+  };
+}
+
+beforeEach(() => {
+  mockCheck.mockReset();
+  mockRelaunch.mockReset();
+  mockRelaunch.mockResolvedValue(undefined);
+});
+
+describe("checkForUpdate", () => {
+  it("更新がなければ null を返す", async () => {
+    mockCheck.mockResolvedValue(null);
+    expect(await checkForUpdate()).toBeNull();
+  });
+
+  it("check が失敗したら（非 Tauri 文脈 / ネットワーク不達）静かに null を返す", async () => {
+    mockCheck.mockRejectedValue(new Error("no tauri"));
+    expect(await checkForUpdate()).toBeNull();
+  });
+
+  it("更新があれば version を公開する", async () => {
+    mockCheck.mockResolvedValue(makeUpdateStub("0.6.0", []));
+    const update = await checkForUpdate();
+    expect(update?.version).toBe("0.6.0");
+  });
+});
+
+describe("installAndRelaunch", () => {
+  it("downloadAndInstall 完了後に relaunch する", async () => {
+    const stub = makeUpdateStub("0.6.0", [{ event: "Finished" }]);
+    mockCheck.mockResolvedValue(stub);
+    const update = await checkForUpdate();
+    await update?.installAndRelaunch();
+    expect(stub.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(mockRelaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it("contentLength が既知なら進捗を 0-1 の比率で通知する", async () => {
+    const stub = makeUpdateStub("0.6.0", [
+      { event: "Started", data: { contentLength: 100 } },
+      { event: "Progress", data: { chunkLength: 25 } },
+      { event: "Progress", data: { chunkLength: 50 } },
+      { event: "Finished" },
+    ]);
+    mockCheck.mockResolvedValue(stub);
+    const update = await checkForUpdate();
+    const ratios: Array<number | null> = [];
+    await update?.installAndRelaunch((r) => ratios.push(r));
+    expect(ratios).toEqual([0, 0.25, 0.75, 1]);
+  });
+
+  it("contentLength が不明なら進捗は null（不定）として通知する", async () => {
+    const stub = makeUpdateStub("0.6.0", [
+      { event: "Started", data: {} },
+      { event: "Progress", data: { chunkLength: 25 } },
+      { event: "Finished" },
+    ]);
+    mockCheck.mockResolvedValue(stub);
+    const update = await checkForUpdate();
+    const ratios: Array<number | null> = [];
+    await update?.installAndRelaunch((r) => ratios.push(r));
+    expect(ratios).toEqual([null, null, 1]);
+  });
+
+  it("downloadAndInstall が失敗したら reject し、relaunch は呼ばない", async () => {
+    const stub = {
+      version: "0.6.0",
+      downloadAndInstall: vi.fn(async () => {
+        throw new Error("signature mismatch");
+      }),
+    };
+    mockCheck.mockResolvedValue(stub);
+    const update = await checkForUpdate();
+    await expect(update?.installAndRelaunch()).rejects.toThrow("signature mismatch");
+    expect(mockRelaunch).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/updater/app-updater.ts
+++ b/src/runtime/updater/app-updater.ts
@@ -1,0 +1,57 @@
+/**
+ * app-updater — tauri-plugin-updater の薄い wrapper。
+ *
+ * GitHub Releases に添付された latest.json（.github/workflows/release.yml が生成）を
+ * 確認し、更新があれば署名検証つきでダウンロード・適用して relaunch する。
+ * plugin module は動的 import で遅延読み込みし、check の失敗
+ * （非 Tauri 文脈 / ネットワーク不達）は「更新なし」として静かに扱う——
+ * 更新確認は user の作業を邪魔しない背景動作であって、失敗を騒ぐ種類のものではない。
+ * 一方 installAndRelaunch の失敗は user が押したボタンの結果なので caller に伝播させる。
+ */
+
+export interface AvailableUpdate {
+  /** 更新先の version（例: "0.6.0"）。 */
+  readonly version: string;
+  /**
+   * ダウンロード・適用して再起動する。進捗は 0-1 の比率で通知
+   * （contentLength 不明時は null = 不定表示）。
+   */
+  installAndRelaunch(onProgress?: (ratio: number | null) => void): Promise<void>;
+}
+
+export async function checkForUpdate(): Promise<AvailableUpdate | null> {
+  let update: Awaited<ReturnType<typeof import("@tauri-apps/plugin-updater").check>>;
+  try {
+    const { check } = await import("@tauri-apps/plugin-updater");
+    update = await check();
+  } catch {
+    return null;
+  }
+  if (!update) return null;
+
+  const { version } = update;
+  return {
+    version,
+    async installAndRelaunch(onProgress) {
+      let total: number | null = null;
+      let received = 0;
+      await update.downloadAndInstall((event) => {
+        switch (event.event) {
+          case "Started":
+            total = event.data.contentLength ?? null;
+            onProgress?.(total === null ? null : 0);
+            break;
+          case "Progress":
+            received += event.data.chunkLength;
+            onProgress?.(total === null ? null : Math.min(received / total, 1));
+            break;
+          case "Finished":
+            onProgress?.(1);
+            break;
+        }
+      });
+      const { relaunch } = await import("@tauri-apps/plugin-process");
+      await relaunch();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

tauri-plugin-updater による in-app 自動アップデート機能。設定画面を開いたときに GitHub Releases の latest.json を確認し、更新があればバナーを表示。1ボタンで署名検証つきダウンロード → 適用 → 再起動まで行う。

- **Rust**: tauri-plugin-updater / tauri-plugin-process の配線、capabilities に updater:default / process:default
- **conf**: plugins.updater（pubkey + endpoints）。createUpdaterArtifacts は CI 専用 overlay（tauri.updater.conf.json）に分離——base に置くと署名鍵を持たない contributor のローカル tauri build が失敗するため
- **Frontend**: app-updater wrapper（check 失敗は静かに「更新なし」扱い、install 失敗は伝播）+ 設定パネルの更新バナー + i18n（en/ja）
- **CI**: release.yml で .app.tar.gz / .sig を arch 別名で Release に添付、latest.json を生成。片アーキ失敗時は成功分だけで manifest を作る（fail-fast: false と対）

秘密鍵は repo secret TAURI_SIGNING_PRIVATE_KEY に設定済み。鍵は空パスワード生成のため TAURI_SIGNING_PRIVATE_KEY_PASSWORD="" を CI env で明示（未設定だと TTY プロンプトで CI が死ぬ——ローカル検証で発覚）。

## Verification

- vitest 1765 pass（app-updater wrapper の unit test 7 件含む）/ tsc / biome / clippy 全 green
- **実機 E2E**: localhost に latest.json を配信する検証環境を作り、v0.5.1 テストビルド → 設定画面バナー表示 → 1ボタン → ダウンロード → minisign 署名検証 → v0.9.9 への置き換えまで実フローで確認済み

## Notes

- 既存リリース（v0.5.1 以前）には updater が入っていないため、この機能が効くのは次リリース以降のインストールから
- Windows の latest.json 対応（windows-x86_64 key + nsis artifact）は未対応、macOS 先行
- 次ステップ: Homebrew tap（cask に auto_updates true を書く前提が整った）

🤖 Generated with [Claude Code](https://claude.com/claude-code)