### PR TITLE
README: Homebrew インストール手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Charminal automatically launches Claude Code or Codex installed on your local ma
 Charminal currently targets macOS. Install with Homebrew:
 
 ```sh
-brew install --cask sktkkoo/tap/charminal
+brew install --cask sktkkoo/charminal/charminal
 ```
 
 Or download the latest build below.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ Charminal automatically launches Claude Code or Codex installed on your local ma
 
 ### Install (macOS)
 
-Charminal currently targets macOS. Download the latest build below.
+Charminal currently targets macOS. Install with Homebrew:
+
+```sh
+brew install --cask sktkkoo/tap/charminal
+```
+
+Or download the latest build below.
 
 <p>
   <a href="https://github.com/sktkkoo/Charminal/releases/latest/download/Charminal-Apple-Silicon.dmg"><img src="https://img.shields.io/badge/Apple%20Silicon-0A84FF?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Apple Silicon" /></a>

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -40,6 +40,11 @@ Notes:
   receive updates again — keep the original backed up.
 - Releases before v0.5.3 do not contain the in-app updater, so those installs
   only update via Homebrew (`brew upgrade`) or manual download.
+- The tap needs no per-release work. It only needs manual edits if the `.dmg`
+  naming scheme or the `charminal.app` bundle name changes. Also note GitHub
+  disables cron workflows in repos with no activity for 60 days; if releases
+  pause that long, re-enable the tap's bump workflow with
+  `gh workflow enable bump-charminal.yml -R sktkkoo/homebrew-charminal`.
 
 ## 1. Build artifacts
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,43 @@ This checklist is the pre-release smoke test for Charminal release builds. Run
 it from a fresh user profile when possible, or move the existing `~/.charminal/`
 aside before testing.
 
+## 0. Publish procedure
+
+The mechanical steps for cutting a release. Everything after the tag push is
+automated; the only required manual actions are the version bump, the tag, and
+publishing the draft release.
+
+1. **Bump the version** in `package.json`, `src-tauri/tauri.conf.json`, and
+   `src-tauri/Cargo.toml`, then run `npm install` and `cargo build` (updates
+   `package-lock.json` / `Cargo.lock`). Update README status/badges if needed.
+   Commit as `Release vX.Y.Z`.
+2. **Tag and push**: `git tag vX.Y.Z && git push origin main vX.Y.Z`. The tag
+   push triggers `.github/workflows/release.yml`, which builds both macOS
+   architectures and creates a **draft** GitHub Release with:
+   - versioned and stable-named `.dmg` files
+   - in-app updater artifacts (`charminal_<arch>.app.tar.gz` + signatures)
+   - `latest.json` (the update manifest the in-app updater polls)
+3. **Publish the draft release.** This is the switch that delivers the update:
+   the moment the release is published, `releases/latest/download/latest.json`
+   resolves and existing installs (v0.5.3+) will offer the update in Settings.
+4. **Homebrew: no action required.** The
+   [homebrew-charminal](https://github.com/sktkkoo/homebrew-charminal) tap
+   checks for new releases every 6 hours and updates the cask automatically.
+   To sync it immediately:
+
+   ```bash
+   gh workflow run bump-charminal.yml -R sktkkoo/homebrew-charminal
+   ```
+
+Notes:
+
+- The updater signing key lives in the `TAURI_SIGNING_PRIVATE_KEY` repo secret
+  (empty passphrase; CI sets `TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""`
+  explicitly). Losing the private key means existing installs can never
+  receive updates again — keep the original backed up.
+- Releases before v0.5.3 do not contain the in-app updater, so those installs
+  only update via Homebrew (`brew upgrade`) or manual download.
+
 ## 1. Build artifacts
 
 - Run `npm run build`.


### PR DESCRIPTION
## Summary

sktkkoo/homebrew-tap 公開に伴い、README の Install (macOS) に `brew install --cask sktkkoo/tap/charminal` を追加。既存の .dmg 直リンクは代替手段として残す。

tap 側（cask + 新リリース自動追従 workflow）は https://github.com/sktkkoo/homebrew-tap 。

注意: cask が実際に機能するのは Charminal repo が public になってから（現状 private のため anonymous の release ダウンロードが 404）。マージ自体は先行して問題ない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)