### PR TITLE
[codex] Sync terminal glow with attention light cues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -606,6 +606,41 @@ body,
   height: 100%;
 }
 
+.xterm-singleton-container {
+  --terminal-attention-cue-intensity: 0;
+}
+
+.xterm-singleton-container.xterm-attention-cue-active {
+  box-shadow:
+    0 0 calc(18px * var(--terminal-attention-cue-intensity))
+    rgba(255, 176, 138, calc(0.14 * var(--terminal-attention-cue-intensity))),
+    inset 0 0 calc(26px * var(--terminal-attention-cue-intensity))
+    rgba(255, 176, 138, calc(0.11 * var(--terminal-attention-cue-intensity)));
+}
+
+.xterm-singleton-container.xterm-attention-cue-active::before {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: block;
+  pointer-events: none;
+  content: "";
+  background:
+    linear-gradient(
+      90deg,
+      rgba(255, 176, 138, calc(0.1 * var(--terminal-attention-cue-intensity))),
+      transparent 18%,
+      transparent 82%,
+      rgba(255, 176, 138, calc(0.07 * var(--terminal-attention-cue-intensity)))
+    ),
+    radial-gradient(
+      circle at 28% 18%,
+      rgba(255, 176, 138, calc(0.12 * var(--terminal-attention-cue-intensity))),
+      transparent 34%
+    );
+  mix-blend-mode: screen;
+}
+
 .xterm-singleton-container .terminal-runtime-notice {
   position: absolute;
   left: 12px;

--- a/src/runtime/terminal-runtime/terminal-runtime.test.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.test.ts
@@ -1199,4 +1199,27 @@ describe("TerminalRuntime", () => {
     expect(themeBg()).toBe("#141619");
     expect(xtermSingleton().classList.contains("xterm-bg-transparent")).toBe(false);
   });
+
+  it("setAttentionCueIntensity は発光 CSS 変数と class を更新する", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    runtime.setAttentionCueIntensity(0.42);
+
+    expect(xtermSingleton().style.getPropertyValue("--terminal-attention-cue-intensity")).toBe(
+      "0.42",
+    );
+    expect(xtermSingleton().classList.contains("xterm-attention-cue-active")).toBe(true);
+
+    runtime.setAttentionCueIntensity(0);
+    expect(xtermSingleton().style.getPropertyValue("--terminal-attention-cue-intensity")).toBe("0");
+    expect(xtermSingleton().classList.contains("xterm-attention-cue-active")).toBe(false);
+  });
+
+  it("setAttentionCueIntensity は 0-1 に clamp する", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    runtime.setAttentionCueIntensity(2);
+    expect(xtermSingleton().style.getPropertyValue("--terminal-attention-cue-intensity")).toBe("1");
+
+    runtime.setAttentionCueIntensity(-1);
+    expect(xtermSingleton().style.getPropertyValue("--terminal-attention-cue-intensity")).toBe("0");
+  });
 });

--- a/src/runtime/terminal-runtime/terminal-runtime.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.ts
@@ -42,6 +42,12 @@ const IME_POST_COMMIT_SUPPRESS_MS = 80;
 const INTERRUPT_NOTICE_THROTTLE_MS = 1000;
 const INTERRUPT_NOTICE_VISIBLE_MS = 1800;
 
+function clamp01(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
 /** xterm.js の初期カラーテーマ。scene が未設定の時のフォールバック。 */
 export const DEFAULT_TERMINAL_THEME: XTermTheme = {
   background: "#141619",
@@ -124,6 +130,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   private hidden = false;
   private opacity = 1;
   private bgTransparent = false;
+  private attentionCueIntensity = 0;
   /** 直近 setTheme でマージされた背景色。bgTransparent 解除時の復帰先。 */
   private currentThemeBackground: string | undefined;
   private startGeneration = 0;
@@ -322,6 +329,15 @@ class TerminalRuntimeImpl implements TerminalRuntime {
       this.xtermContainer.style.background = "";
     }
     this.xtermContainer.classList.toggle("xterm-bg-transparent", this.bgTransparent);
+  }
+
+  setAttentionCueIntensity(intensity: number): void {
+    if (this.disposed) return;
+    const clamped = clamp01(intensity);
+    if (Math.abs(clamped - this.attentionCueIntensity) < 0.001) return;
+    this.attentionCueIntensity = clamped;
+    this.xtermContainer.style.setProperty("--terminal-attention-cue-intensity", String(clamped));
+    this.xtermContainer.classList.toggle("xterm-attention-cue-active", clamped > 0.001);
   }
 
   /**

--- a/src/runtime/terminal-runtime/types.ts
+++ b/src/runtime/terminal-runtime/types.ts
@@ -174,6 +174,12 @@ export interface TerminalRuntime {
   setBackgroundTransparent(transparent: boolean): void;
 
   /**
+   * attention light cue と同期する terminal 側の発光強度（0-1）。
+   * scene light と同じ cue envelope から呼ばれ、文字描画や PTY には触れない。
+   */
+  setAttentionCueIntensity(intensity: number): void;
+
+  /**
    * Session が close されるときに呼ぶ。xterm を dispose、xterm container DOM を
    * document から外し、ResizeObserver / RAF を停止する。dispose 後の
    * runtime instance は再利用しない（再 attach / 再 spawn 不可）。

--- a/src/terminal.test.tsx
+++ b/src/terminal.test.tsx
@@ -27,6 +27,7 @@ const mockState = vi.hoisted(() => {
     detachContainer: vi.fn(),
     focus: vi.fn(),
     readScreenTailText: vi.fn(() => ""),
+    setAttentionCueIntensity: vi.fn(),
     setInterruptProtectionMode: vi.fn(),
     setPerception: vi.fn(),
     setTheme: vi.fn(),
@@ -39,7 +40,20 @@ const mockState = vi.hoisted(() => {
     subscribeUserInput: vi.fn(() => disposables.userInput),
     updatePtyParams: vi.fn(),
   };
+  const cueListeners = new Set<() => void>();
+  const cueStore = {
+    current: null as { seq: number; startedAt: number; reason: "session-attention" | "mcp" } | null,
+    getCurrent: vi.fn(() => cueStore.current),
+    subscribe: vi.fn((listener: () => void) => {
+      cueListeners.add(listener);
+      return () => {
+        cueListeners.delete(listener);
+      };
+    }),
+  };
   const state = {
+    cueListeners,
+    cueStore,
     disposables,
     ptyListener: null as (() => void) | null,
     runtime,
@@ -50,6 +64,10 @@ const mockState = vi.hoisted(() => {
 
 vi.mock("./runtime/terminal-runtime", () => ({
   getTerminalRuntime: vi.fn(() => mockState.runtime),
+}));
+
+vi.mock("./runtime/attention-light-cue", () => ({
+  getAttentionLightCueStore: vi.fn(() => mockState.cueStore),
 }));
 
 vi.mock("./runtime/session-status", () => ({
@@ -77,6 +95,8 @@ describe("Terminal", () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    mockState.cueListeners.clear();
+    mockState.cueStore.current = null;
     mockState.ptyListener = null;
     vi.clearAllMocks();
   });
@@ -115,5 +135,42 @@ describe("Terminal", () => {
 
     vi.advanceTimersByTime(720);
     expect(mockState.status.settleOutput).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay an elapsed attention light cue when a tab becomes visible again", () => {
+    vi.setSystemTime(10_000);
+    mockState.cueStore.current = {
+      seq: 1,
+      startedAt: 1_000,
+      reason: "session-attention",
+    };
+
+    const { rerender } = render(
+      <Terminal
+        sessionId="main"
+        visible={false}
+        active={false}
+        spec={spec}
+        cwd="/work/old"
+        perception={null}
+      />,
+    );
+    rerender(
+      <Terminal
+        sessionId="main"
+        visible={true}
+        active={true}
+        spec={spec}
+        cwd="/work/old"
+        perception={null}
+      />,
+    );
+
+    vi.advanceTimersByTime(500);
+
+    const intensities = mockState.runtime.setAttentionCueIntensity.mock.calls.map(
+      ([value]) => value,
+    );
+    expect(intensities.every((value) => value === 0)).toBe(true);
   });
 });

--- a/src/terminal.tsx
+++ b/src/terminal.tsx
@@ -2,6 +2,7 @@ import { type MutableRefObject, useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { type SpawnSpec, sessionRefreshTheme } from "./bindings/tauri-commands";
 import type { Perception } from "./core/perception";
+import { type AttentionLightCue, getAttentionLightCueStore } from "./runtime/attention-light-cue";
 import {
   detectScreenAttentionRequest,
   getSessionStatusStore,
@@ -10,9 +11,14 @@ import {
 } from "./runtime/session-status";
 import { getTerminalRuntime, type InterruptProtectionMode } from "./runtime/terminal-runtime";
 import { getCurrentTerminalTheme } from "./runtime/terminal-theme";
+import {
+  ATTENTION_CUE_DURATION_SECONDS,
+  computeAttentionCueLightIntensity,
+} from "./runtime/three-runtime/attention-cue-envelope";
 
 const OUTPUT_SETTLE_MS = 800;
 const SCREEN_ATTENTION_SCAN_MS = 80;
+const TERMINAL_ATTENTION_CUE_SCALE = 3.6;
 
 interface TerminalProps {
   readonly sessionId: string;
@@ -158,6 +164,51 @@ export default function Terminal({
   useEffect(() => {
     getTerminalRuntime(sessionId).setInterruptProtectionMode(interruptProtectionMode);
   }, [sessionId, interruptProtectionMode]);
+
+  useEffect(() => {
+    const runtime = getTerminalRuntime(sessionId);
+    const cueStore = getAttentionLightCueStore();
+    let rafId = 0;
+    let activeCue: AttentionLightCue | null = null;
+
+    const clearFrame = () => {
+      if (rafId === 0) return;
+      window.cancelAnimationFrame(rafId);
+      rafId = 0;
+    };
+    const setIntensity = (intensity: number) => {
+      runtime.setAttentionCueIntensity(visible ? intensity : 0);
+    };
+    const tick = () => {
+      rafId = 0;
+      if (!activeCue || !visible) {
+        runtime.setAttentionCueIntensity(0);
+        return;
+      }
+      const elapsedSeconds = Math.max(0, (Date.now() - activeCue.startedAt) / 1000);
+      if (elapsedSeconds >= ATTENTION_CUE_DURATION_SECONDS) {
+        activeCue = null;
+        runtime.setAttentionCueIntensity(0);
+        return;
+      }
+      const intensity = computeAttentionCueLightIntensity(elapsedSeconds);
+      setIntensity(Math.min(1, (intensity.point + intensity.spot) * TERMINAL_ATTENTION_CUE_SCALE));
+      rafId = window.requestAnimationFrame(tick);
+    };
+    const restart = () => {
+      activeCue = cueStore.getCurrent();
+      clearFrame();
+      tick();
+    };
+
+    restart();
+    const unsubscribe = cueStore.subscribe(restart);
+    return () => {
+      unsubscribe();
+      clearFrame();
+      runtime.setAttentionCueIntensity(0);
+    };
+  }, [sessionId, visible]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Connect terminal glow to the existing attention light cue store.
- Drive terminal intensity from the same attention cue envelope used by scene lighting.
- Add regression coverage so tab visibility changes do not replay elapsed cues.

## Why
The terminal should only glow when the scene attention light is actively glowing. The previous implementation restarted the terminal pulse when a tab became visible, which made tab switching look like a new notification.

## Validation
- npm test -- --run src/terminal.test.tsx src/runtime/terminal-runtime/terminal-runtime.test.ts
- npm run build -- --mode development
- pre-push: tsc-no-emit, biome-check, cargo-fmt, cargo-clippy, typedoc-validate