### PR TITLE
Journal callback P1 — セッション開始時の記憶想起

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,11 @@ Charminal は起動時に `~/.charminal/config.json` を読み、壊れている
 | `motionIntensity` | `number` (`0.0`–`3.0`) | `1.0` | idle procedural motion（呼吸 / sway / head drift / posture）の振幅ノブ。`1.0` は従来どおり、`0` 付近はほぼ静止、上端は opt-in のオーバーアクション |
 | `mcpPort` | `number` | `18743` | Rust MCP server の listen port |
 | `disabledPacks` | `string[]` | `[]` | rescue 用。指定 id の user pack を load しない |
+| `journalCallback` | `"normal"`, `"rare"`, or `"off"` | `"normal"` | journal callback（セッション開始時の記憶想起）の頻度ノブ。`rare` は発火条件と cooldown を広げ、`off` で無効化。Rust 側が config.json を直接読む |
+
+### Journal callback
+
+`journalCallback` は、agent session の開始時に住人の過去の journal（`~/.charminal/journal/`）から記憶を最大 1 件、会話の背景情報として届ける機能の頻度ノブ。発火は決定論的ルール（ちょうど一年前 / ちょうどひと月前の記憶、数日ぶりの起動）で、届いた記憶に触れるかどうかは住人が判断する。`normal` でも発火はセッションあたり最大 1 回・1 日 1 回・同じ記憶は約 3 週間空く。
 
 ### Motion intensity
 

--- a/src-tauri/src/journal/callback.rs
+++ b/src-tauri/src/journal/callback.rs
@@ -1,0 +1,494 @@
+//! Journal callback — セッション開始時の記憶想起（P1）。
+//!
+//! app 起動時に決定論的ルール（日付の節目・久しぶりの起動）で記憶を最大 1 件
+//! 選び、`~/.charminal/journal/callback-pending.txt` に書く。Claude の
+//! UserPromptSubmit hook script がワンショットで消費して削除する。
+//! 口にするかどうかは住人（LLM）の判断で、黙って流してよい。
+//!
+//! 設計判断（design-record: 2026-07-03-journal-callback-redesign.md）:
+//! - 発火は決定論・選別は LLM。注入文言に想起の様態（「ふと思い出した」等）を
+//!   主張させない。中立的な背景情報 + 日付ポインタのみ。
+//! - PTY 由来テキストは扱わない（P1 は話題トリガーなし）。
+//! - 状態ファイルは記憶の日付と発火日のみ保持し、本文は残さない。
+//! - 壊れた状態ファイルで起動を止めない。fail-safe は「callback がやや多めに
+//!   出る」方向（状態リセット）に倒す。
+//! - 複数セッションの競合は「最後の書き込みが勝つ / まれな二重発火は許容」。
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// 「久しぶりの起動」とみなす空白日数（normal）。帰納的調整の対象。
+const LONG_ABSENCE_DAYS_NORMAL: i64 = 3;
+/// 同・rare。
+const LONG_ABSENCE_DAYS_RARE: i64 = 7;
+/// callback 全体の最小間隔（日）。normal は 1 日 1 回まで。
+const GLOBAL_MIN_GAP_DAYS_NORMAL: i64 = 1;
+/// 同・rare。
+const GLOBAL_MIN_GAP_DAYS_RARE: i64 = 7;
+/// 同じ記憶を再発火させない cooldown（日）。
+const MEMORY_COOLDOWN_DAYS_NORMAL: i64 = 21;
+/// 同・rare。
+const MEMORY_COOLDOWN_DAYS_RARE: i64 = 42;
+
+/// config.json `journalCallback` の頻度ノブ。off スイッチ + 一ノブ。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Knob {
+    Off,
+    Rare,
+    Normal,
+}
+
+impl Knob {
+    fn from_config_value(value: Option<&str>) -> Self {
+        match value {
+            Some("off") => Knob::Off,
+            Some("rare") => Knob::Rare,
+            _ => Knob::Normal,
+        }
+    }
+
+    fn long_absence_days(self) -> i64 {
+        match self {
+            Knob::Rare => LONG_ABSENCE_DAYS_RARE,
+            _ => LONG_ABSENCE_DAYS_NORMAL,
+        }
+    }
+
+    fn global_min_gap_days(self) -> i64 {
+        match self {
+            Knob::Rare => GLOBAL_MIN_GAP_DAYS_RARE,
+            _ => GLOBAL_MIN_GAP_DAYS_NORMAL,
+        }
+    }
+
+    fn memory_cooldown_days(self) -> i64 {
+        match self {
+            Knob::Rare => MEMORY_COOLDOWN_DAYS_RARE,
+            _ => MEMORY_COOLDOWN_DAYS_NORMAL,
+        }
+    }
+}
+
+/// memories.md の 1 行（`YYYY-MM-DD: 本文`）。壊れた行はパース時に skip する。
+#[derive(Debug, Clone)]
+struct MemoryLine {
+    date: String,
+    days: i64,
+    text: String,
+}
+
+/// 発火履歴。記憶の日付と発火日のみを持つ（本文は残さない）。
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CallbackState {
+    /// 最後に callback を発火させた日（YYYY-MM-DD）。
+    #[serde(default)]
+    last_fired_on: Option<String>,
+    /// 記憶の日付 → その記憶を最後に発火させた日。
+    #[serde(default)]
+    fired: BTreeMap<String, String>,
+}
+
+/// 発火判定の結果。
+#[derive(Debug, PartialEq)]
+struct Decision {
+    memory_date: String,
+    message: String,
+}
+
+fn journal_dir() -> Result<PathBuf, String> {
+    Ok(crate::home_dir_or_err()?.join(".charminal").join("journal"))
+}
+
+fn state_path() -> Result<PathBuf, String> {
+    Ok(journal_dir()?.join("callback-state.json"))
+}
+
+fn pending_path() -> Result<PathBuf, String> {
+    Ok(journal_dir()?.join("callback-pending.txt"))
+}
+
+/// Howard Hinnant の days_from_civil。cohabitation.rs の civil_from_days の逆。
+fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = if m > 2 { m as i64 - 3 } else { m as i64 + 9 };
+    let doy = (153 * mp + 2) / 5 + d as i64 - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+/// `YYYY-MM-DD`（先頭 10 文字）を (y, m, d) にパースする。壊れていれば None。
+fn parse_date(text: &str) -> Option<(i64, u32, u32)> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+    let digits = |range: std::ops::Range<usize>| -> Option<i64> {
+        let s = text.get(range)?;
+        if !s.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        s.parse().ok()
+    };
+    let y = digits(0..4)?;
+    let m = digits(5..7)? as u32;
+    let d = digits(8..10)? as u32;
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    Some((y, m, d))
+}
+
+fn date_to_days(text: &str) -> Option<i64> {
+    parse_date(text).map(|(y, m, d)| days_from_civil(y, m, d))
+}
+
+/// memories.md の本文から日付付きの行を抽出する。壊れた行は黙って skip。
+fn parse_memories(content: &str) -> Vec<MemoryLine> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let (date_part, rest) = (line.get(0..10)?, line.get(10..)?);
+            let days = date_to_days(date_part)?;
+            let text = rest.trim_start_matches(':').trim();
+            if text.is_empty() {
+                return None;
+            }
+            Some(MemoryLine {
+                date: date_part.to_string(),
+                days,
+                text: text.to_string(),
+            })
+        })
+        .collect()
+}
+
+/// 発火判定の純関数本体。
+///
+/// 優先順位: 一年前の節目 > ひと月前の節目 > 久しぶりの起動（直近の記憶）。
+/// cooldown 中の記憶は次の候補に譲る。すべて gate に落ちたら None。
+fn decide(
+    memories: &[MemoryLine],
+    state: &CallbackState,
+    today: (i64, u32, u32),
+    last_shutdown_days: Option<i64>,
+    knob: Knob,
+) -> Option<Decision> {
+    if knob == Knob::Off || memories.is_empty() {
+        return None;
+    }
+    let (ty, tm, td) = today;
+    let today_days = days_from_civil(ty, tm, td);
+
+    // 全体 gate: 最小間隔内に発火済みなら沈黙。
+    if let Some(last) = state.last_fired_on.as_deref().and_then(date_to_days) {
+        if today_days - last < knob.global_min_gap_days() {
+            return None;
+        }
+    }
+
+    let cooled = |memory: &MemoryLine| -> bool {
+        state
+            .fired
+            .get(&memory.date)
+            .and_then(|fired_on| date_to_days(fired_on))
+            .is_some_and(|fired| today_days - fired < knob.memory_cooldown_days())
+    };
+
+    // 候補を優先順位順に集める。
+    let mut candidates: Vec<(&MemoryLine, String)> = Vec::new();
+
+    let year_ago = format!("{:04}-{:02}-{:02}", ty - 1, tm, td);
+    let (my, mm) = if tm == 1 { (ty - 1, 12) } else { (ty, tm - 1) };
+    let month_ago = format!("{:04}-{:02}-{:02}", my, mm, td);
+
+    for memory in memories {
+        if memory.date == year_ago {
+            candidates.push((memory, "ちょうど一年前".to_string()));
+        }
+    }
+    for memory in memories {
+        if memory.date == month_ago {
+            candidates.push((memory, "ちょうどひと月前".to_string()));
+        }
+    }
+
+    // 久しぶりの起動: 前回終了から一定日数空いたら、最も新しい記憶を候補にする。
+    if let Some(shutdown_days) = last_shutdown_days {
+        let gap = today_days - shutdown_days;
+        if gap >= knob.long_absence_days() {
+            if let Some(latest) = memories.iter().max_by_key(|m| m.days) {
+                candidates.push((latest, format!("{}日ぶりの起動", gap)));
+            }
+        }
+    }
+
+    let (memory, reason) = candidates.into_iter().find(|(m, _)| !cooled(m))?;
+
+    // 中立的な背景情報として組み立てる。想起の様態（「ふと思い出した」等）は
+    // 主張しない。本文は住人自身が書いた memories.md の一行のみで、PTY 由来
+    // テキストは含まれない。
+    let message = format!(
+        "過去の journal（{}、{}）: {}\n関係があれば触れてよいし、なければ流してかまわない。詳細は journal_read で {} を読める。",
+        memory.date, reason, memory.text, memory.date
+    );
+    Some(Decision {
+        memory_date: memory.date.clone(),
+        message,
+    })
+}
+
+/// 状態ファイルを読む。壊れていたら default（= cooldown リセット）で続行。
+fn read_state(path: &std::path::Path) -> CallbackState {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return CallbackState::default();
+    };
+    serde_json::from_str(&text).unwrap_or_default()
+}
+
+fn write_state_atomic(path: &std::path::Path, state: &CallbackState) -> Result<(), String> {
+    let serialized = serde_json::to_string_pretty(state)
+        .map_err(|e| format!("callback-state.json シリアライズ失敗: {}", e))?;
+    let tmp_path = path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, &serialized)
+        .map_err(|e| format!("callback-state.json.tmp 書き込み失敗: {}", e))?;
+    std::fs::rename(&tmp_path, path).map_err(|e| format!("callback-state.json rename 失敗: {}", e))
+}
+
+/// config.json の `journalCallback` を読む。読めなければ default（normal）。
+fn read_knob() -> Knob {
+    let value = crate::home_dir_or_err()
+        .ok()
+        .and_then(|home| std::fs::read_to_string(home.join(".charminal").join("config.json")).ok())
+        .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
+        .and_then(|config| config.get("journalCallback")?.as_str().map(String::from));
+    Knob::from_config_value(value.as_deref())
+}
+
+/// cohabitation.json の last_shutdown（ISO 8601）を日数に変換して返す。
+fn last_shutdown_days() -> Option<i64> {
+    let home = crate::home_dir_or_err().ok()?;
+    let text = std::fs::read_to_string(home.join(".charminal").join("cohabitation.json")).ok()?;
+    let value = serde_json::from_str::<serde_json::Value>(&text).ok()?;
+    let iso = value.get("last_shutdown")?.as_str()?;
+    date_to_days(iso)
+}
+
+/// app 起動時に呼ぶ。発火すれば pending file を書き、しなければ古い pending を消す。
+pub fn evaluate_on_boot() -> Result<(), String> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("SystemTime エラー: {}", e))?;
+    let today = super::cohabitation::civil_from_days((now.as_secs() / 86400) as i64);
+    evaluate_on_boot_at((today.0, today.1, today.2))
+}
+
+fn evaluate_on_boot_at(today: (i64, u32, u32)) -> Result<(), String> {
+    let pending = pending_path()?;
+    let knob = read_knob();
+    let memories_text = super::read_memories().unwrap_or_default();
+    let memories = parse_memories(&memories_text);
+    let state_file = state_path()?;
+    let mut state = read_state(&state_file);
+
+    match decide(&memories, &state, today, last_shutdown_days(), knob) {
+        Some(decision) => {
+            let today_str = format!("{:04}-{:02}-{:02}", today.0, today.1, today.2);
+            std::fs::create_dir_all(pending.parent().unwrap())
+                .map_err(|e| format!("journal ディレクトリの作成に失敗: {}", e))?;
+            std::fs::write(&pending, &decision.message)
+                .map_err(|e| format!("callback-pending.txt 書き込み失敗: {}", e))?;
+            state
+                .fired
+                .insert(decision.memory_date.clone(), today_str.clone());
+            state.last_fired_on = Some(today_str);
+            write_state_atomic(&state_file, &state)?;
+            eprintln!("[journal-callback] fired: {}", decision.memory_date);
+        }
+        None => {
+            // 前回消費されなかった pending は文脈が古いので捨てる（保留キューは作らない）。
+            let _ = std::fs::remove_file(&pending);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn memory(date: &str, text: &str) -> MemoryLine {
+        MemoryLine {
+            date: date.to_string(),
+            days: date_to_days(date).expect("valid date"),
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_memories_skips_broken_lines() {
+        let content =
+            "2026-06-27: 花火を見た日。\nこわれた行\n2026-06-28:\n2026-06-30: 鳥の群れ。\n";
+        let parsed = parse_memories(content);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].date, "2026-06-27");
+        assert_eq!(parsed[0].text, "花火を見た日。");
+        assert_eq!(parsed[1].date, "2026-06-30");
+    }
+
+    #[test]
+    fn decide_off_never_fires() {
+        let memories = vec![memory("2026-06-04", "節目の記憶。")];
+        let state = CallbackState::default();
+        let result = decide(&memories, &state, (2026, 7, 4), Some(0), Knob::Off);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn decide_fires_on_month_anniversary() {
+        let memories = vec![memory("2026-06-04", "ひと月前の記憶。")];
+        let state = CallbackState::default();
+        let result = decide(&memories, &state, (2026, 7, 4), None, Knob::Normal).expect("fires");
+        assert_eq!(result.memory_date, "2026-06-04");
+        assert!(result.message.contains("ちょうどひと月前"));
+        assert!(result.message.contains("journal_read"));
+        // 想起の様態を主張しない
+        assert!(!result.message.contains("思い出した"));
+    }
+
+    #[test]
+    fn decide_prefers_year_anniversary_over_month() {
+        let memories = vec![
+            memory("2026-06-04", "ひと月前。"),
+            memory("2025-07-04", "一年前。"),
+        ];
+        let state = CallbackState::default();
+        let result = decide(&memories, &state, (2026, 7, 4), None, Knob::Normal).expect("fires");
+        assert_eq!(result.memory_date, "2025-07-04");
+        assert!(result.message.contains("ちょうど一年前"));
+    }
+
+    #[test]
+    fn decide_fires_latest_memory_after_long_absence() {
+        let memories = vec![
+            memory("2026-06-20", "古い記憶。"),
+            memory("2026-06-28", "新しい記憶。"),
+        ];
+        let state = CallbackState::default();
+        let shutdown = date_to_days("2026-06-30");
+        let result =
+            decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Normal).expect("fires");
+        assert_eq!(result.memory_date, "2026-06-28");
+        assert!(result.message.contains("4日ぶりの起動"));
+    }
+
+    #[test]
+    fn decide_short_gap_does_not_fire_absence() {
+        let memories = vec![memory("2026-06-28", "新しい記憶。")];
+        let state = CallbackState::default();
+        let shutdown = date_to_days("2026-07-03");
+        assert!(decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Normal).is_none());
+    }
+
+    #[test]
+    fn decide_respects_global_min_gap() {
+        let memories = vec![memory("2026-06-04", "ひと月前の記憶。")];
+        let state = CallbackState {
+            last_fired_on: Some("2026-07-04".to_string()),
+            fired: BTreeMap::new(),
+        };
+        assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Normal).is_none());
+    }
+
+    #[test]
+    fn decide_skips_cooled_memory_and_falls_back() {
+        let mut fired = BTreeMap::new();
+        fired.insert("2026-06-04".to_string(), "2026-06-25".to_string());
+        let memories = vec![
+            memory("2026-06-04", "ひと月前だが最近発火済み。"),
+            memory("2026-06-28", "新しい記憶。"),
+        ];
+        let state = CallbackState {
+            last_fired_on: Some("2026-06-25".to_string()),
+            fired,
+        };
+        // 節目候補は cooldown 中 → 久しぶり候補（直近の記憶）へ譲る。
+        let shutdown = date_to_days("2026-06-30");
+        let result =
+            decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Normal).expect("fires");
+        assert_eq!(result.memory_date, "2026-06-28");
+    }
+
+    #[test]
+    fn decide_rare_widens_gates() {
+        let memories = vec![memory("2026-06-28", "新しい記憶。")];
+        let state = CallbackState::default();
+        // gap 4 日は normal なら発火、rare（7 日）なら沈黙。
+        let shutdown = date_to_days("2026-06-30");
+        assert!(decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Normal).is_some());
+        assert!(decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Rare).is_none());
+    }
+
+    #[test]
+    fn read_state_survives_broken_file() {
+        let tmp = std::env::temp_dir().join(format!(
+            "charminal-callback-state-{}-broken.json",
+            std::process::id()
+        ));
+        std::fs::write(&tmp, "{ こわれた json").expect("write");
+        let state = read_state(&tmp);
+        assert!(state.last_fired_on.is_none());
+        assert!(state.fired.is_empty());
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn days_from_civil_roundtrips_with_civil_from_days() {
+        for date in ["1970-01-01", "2000-02-29", "2026-07-04", "2026-12-31"] {
+            let (y, m, d) = parse_date(date).expect("parse");
+            let days = days_from_civil(y, m, d);
+            assert_eq!(super::super::cohabitation::civil_from_days(days), (y, m, d));
+        }
+    }
+
+    #[test]
+    fn evaluate_on_boot_writes_and_cleans_pending() {
+        let _guard = crate::TEST_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!(
+            "charminal-callback-boot-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&home).expect("mkdir");
+        std::env::set_var("HOME", &home);
+
+        // ひと月前の記憶を仕込む → 発火して pending が書かれる。
+        super::super::append_memory("2026-06-04", "ひと月前の記憶。").expect("memory");
+        evaluate_on_boot_at((2026, 7, 4)).expect("boot eval");
+        let pending = home.join(".charminal/journal/callback-pending.txt");
+        let content = std::fs::read_to_string(&pending).expect("pending exists");
+        assert!(content.contains("2026-06-04"));
+
+        // 同日にもう一度起動 → 全体 gate で沈黙し、古い pending は消える。
+        evaluate_on_boot_at((2026, 7, 4)).expect("boot eval 2");
+        assert!(!pending.exists());
+
+        // 状態ファイルには日付のみで本文が残らない。
+        let state_text =
+            std::fs::read_to_string(home.join(".charminal/journal/callback-state.json"))
+                .expect("state");
+        assert!(state_text.contains("2026-06-04"));
+        assert!(!state_text.contains("ひと月前の記憶"));
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+}

--- a/src-tauri/src/journal/callback.rs
+++ b/src-tauri/src/journal/callback.rs
@@ -1,9 +1,10 @@
 //! Journal callback — セッション開始時の記憶想起（P1）。
 //!
-//! app 起動時に決定論的ルール（日付の節目・久しぶりの起動）で記憶を最大 1 件
-//! 選び、`~/.charminal/journal/callback-pending.txt` に書く。Claude の
-//! UserPromptSubmit hook script がワンショットで消費して削除する。
+//! agent session の spawn ごとに決定論的ルール（日付の節目・久しぶりの起動）で
+//! 記憶を最大 1 件選び、`~/.charminal/journal/callback-pending.txt` に書く。
+//! Claude の UserPromptSubmit hook script がワンショットで消費して削除する。
 //! 口にするかどうかは住人（LLM）の判断で、黙って流してよい。
+//! app 開きっぱなし運用でも、翌日の respawn / 新セッションで節目が評価される。
 //!
 //! 設計判断（design-record: 2026-07-03-journal-callback-redesign.md）:
 //! - 発火は決定論・選別は LLM。注入文言に想起の様態（「ふと思い出した」等）を
@@ -31,6 +32,9 @@ const GLOBAL_MIN_GAP_DAYS_RARE: i64 = 7;
 const MEMORY_COOLDOWN_DAYS_NORMAL: i64 = 21;
 /// 同・rare。
 const MEMORY_COOLDOWN_DAYS_RARE: i64 = 42;
+/// fired 履歴の保持期間（日）。最長 cooldown を超えた記録は意味を持たないので
+/// 書き込み時に掃除し、memories.md から消えた記憶の dead entry を残さない。
+const FIRED_RETENTION_DAYS: i64 = 63;
 
 /// config.json `journalCallback` の頻度ノブ。off スイッチ + 一ノブ。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -88,6 +92,10 @@ struct CallbackState {
     /// 記憶の日付 → その記憶を最後に発火させた日。
     #[serde(default)]
     fired: BTreeMap<String, String>,
+    /// 現在 pending file に載っている記憶の日付。次の評価時に pending が
+    /// まだ残っていれば（= 未消費なら）その記憶の cooldown を返金する。
+    #[serde(default)]
+    pending_memory: Option<String>,
 }
 
 /// 発火判定の結果。
@@ -146,6 +154,31 @@ fn date_to_days(text: &str) -> Option<i64> {
     parse_date(text).map(|(y, m, d)| days_from_civil(y, m, d))
 }
 
+fn is_leap_year(y: i64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+fn days_in_month(y: i64, m: u32) -> u32 {
+    match m {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        _ => {
+            if is_leap_year(y) {
+                29
+            } else {
+                28
+            }
+        }
+    }
+}
+
+/// 日番号を月の実在日数にクランプして `YYYY-MM-DD` を組み立てる。
+/// 3/31 のひと月前は 2/28（うるう年は 2/29）、2/29 の一年前は 2/28 になる。
+/// 文字列一致で "2026-02-31" のような非実在日付を作って静かに取りこぼさないため。
+fn clamped_date_string(y: i64, m: u32, d: u32) -> String {
+    format!("{:04}-{:02}-{:02}", y, m, d.min(days_in_month(y, m)))
+}
+
 /// memories.md の本文から日付付きの行を抽出する。壊れた行は黙って skip。
 fn parse_memories(content: &str) -> Vec<MemoryLine> {
     content
@@ -202,9 +235,9 @@ fn decide(
     // 候補を優先順位順に集める。
     let mut candidates: Vec<(&MemoryLine, String)> = Vec::new();
 
-    let year_ago = format!("{:04}-{:02}-{:02}", ty - 1, tm, td);
+    let year_ago = clamped_date_string(ty - 1, tm, td);
     let (my, mm) = if tm == 1 { (ty - 1, 12) } else { (ty, tm - 1) };
-    let month_ago = format!("{:04}-{:02}-{:02}", my, mm, td);
+    let month_ago = clamped_date_string(my, mm, td);
 
     for memory in memories {
         if memory.date == year_ago {
@@ -278,22 +311,58 @@ fn last_shutdown_days() -> Option<i64> {
     date_to_days(iso)
 }
 
-/// app 起動時に呼ぶ。発火すれば pending file を書き、しなければ古い pending を消す。
-pub fn evaluate_on_boot() -> Result<(), String> {
+/// 今日の日付を local time で返す。
+///
+/// 記憶の日付は住人（LLM）が体感の「今日」で書くため、突き合わせる側も local に
+/// 揃える。UTC のままだと JST では毎朝 9 時間の窓で節目判定が 1 日ずれる。
+/// chrono 非依存の方針のため unix では `date` コマンドに問い合わせ、
+/// 失敗時と非 unix は UTC 日へフォールバックする。
+fn local_today() -> Result<(i64, u32, u32), String> {
+    #[cfg(unix)]
+    {
+        if let Ok(output) = std::process::Command::new("date").arg("+%Y-%m-%d").output() {
+            if output.status.success() {
+                if let Some(parsed) = std::str::from_utf8(&output.stdout)
+                    .ok()
+                    .and_then(|s| parse_date(s.trim()))
+                {
+                    return Ok(parsed);
+                }
+            }
+        }
+    }
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| format!("SystemTime エラー: {}", e))?;
-    let today = super::cohabitation::civil_from_days((now.as_secs() / 86400) as i64);
-    evaluate_on_boot_at((today.0, today.1, today.2))
+    Ok(super::cohabitation::civil_from_days(
+        (now.as_secs() / 86400) as i64,
+    ))
 }
 
-fn evaluate_on_boot_at(today: (i64, u32, u32)) -> Result<(), String> {
+/// agent session の spawn 時に呼ぶ。発火すれば pending file を書き、
+/// しなければ古い pending を消す。
+pub fn evaluate_on_session_spawn() -> Result<(), String> {
+    evaluate_at(local_today()?)
+}
+
+fn evaluate_at(today: (i64, u32, u32)) -> Result<(), String> {
     let pending = pending_path()?;
     let knob = read_knob();
     let memories_text = super::read_memories().unwrap_or_default();
     let memories = parse_memories(&memories_text);
     let state_file = state_path()?;
     let mut state = read_state(&state_file);
+    let today_days = days_from_civil(today.0, today.1, today.2);
+
+    // 前回の pending が未消費のまま残っていたら、その記憶の cooldown を返金する。
+    // 選抜されただけで一度も届いていない記憶が 21 日焼かれるのを防ぐ
+    // （fail-safe は「多めに出る」側に倒す方針）。全体 gate（last_fired_on）は
+    // 発火ペースの上限なので返金しない。
+    if pending.exists() {
+        if let Some(unconsumed) = state.pending_memory.take() {
+            state.fired.remove(&unconsumed);
+        }
+    }
 
     match decide(&memories, &state, today, last_shutdown_days(), knob) {
         Some(decision) => {
@@ -306,14 +375,21 @@ fn evaluate_on_boot_at(today: (i64, u32, u32)) -> Result<(), String> {
                 .fired
                 .insert(decision.memory_date.clone(), today_str.clone());
             state.last_fired_on = Some(today_str);
-            write_state_atomic(&state_file, &state)?;
+            state.pending_memory = Some(decision.memory_date.clone());
             eprintln!("[journal-callback] fired: {}", decision.memory_date);
         }
         None => {
             // 前回消費されなかった pending は文脈が古いので捨てる（保留キューは作らない）。
             let _ = std::fs::remove_file(&pending);
+            state.pending_memory = None;
         }
     }
+
+    // 最長 cooldown を超えた fired 記録は判定に影響しないので掃除する。
+    state.fired.retain(|_, fired_on| {
+        date_to_days(fired_on).is_some_and(|fired| today_days - fired <= FIRED_RETENTION_DAYS)
+    });
+    write_state_atomic(&state_file, &state)?;
     Ok(())
 }
 
@@ -399,7 +475,7 @@ mod tests {
         let memories = vec![memory("2026-06-04", "ひと月前の記憶。")];
         let state = CallbackState {
             last_fired_on: Some("2026-07-04".to_string()),
-            fired: BTreeMap::new(),
+            ..CallbackState::default()
         };
         assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Normal).is_none());
     }
@@ -415,12 +491,48 @@ mod tests {
         let state = CallbackState {
             last_fired_on: Some("2026-06-25".to_string()),
             fired,
+            ..CallbackState::default()
         };
         // 節目候補は cooldown 中 → 久しぶり候補（直近の記憶）へ譲る。
         let shutdown = date_to_days("2026-06-30");
         let result =
             decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Normal).expect("fires");
         assert_eq!(result.memory_date, "2026-06-28");
+    }
+
+    #[test]
+    fn decide_month_anniversary_clamps_to_short_month_end() {
+        // 3/31 のひと月前 → 非実在の 2/31 ではなく 2/28 にクランプして一致させる。
+        let memories = vec![memory("2026-02-28", "二月末の記憶。")];
+        let state = CallbackState::default();
+        let result = decide(&memories, &state, (2026, 3, 31), None, Knob::Normal).expect("fires");
+        assert_eq!(result.memory_date, "2026-02-28");
+    }
+
+    #[test]
+    fn decide_january_rolls_over_to_previous_december() {
+        let memories = vec![memory("2025-12-31", "大晦日の記憶。")];
+        let state = CallbackState::default();
+        let result = decide(&memories, &state, (2026, 1, 31), None, Knob::Normal).expect("fires");
+        assert_eq!(result.memory_date, "2025-12-31");
+        assert!(result.message.contains("ちょうどひと月前"));
+    }
+
+    #[test]
+    fn decide_leap_day_year_anniversary_clamps() {
+        // うるう日 2028-02-29 の一年前 → 2027-02-28 にクランプ。
+        let memories = vec![memory("2027-02-28", "二月末の記憶。")];
+        let state = CallbackState::default();
+        let result = decide(&memories, &state, (2028, 2, 29), None, Knob::Normal).expect("fires");
+        assert_eq!(result.memory_date, "2027-02-28");
+        assert!(result.message.contains("ちょうど一年前"));
+    }
+
+    #[test]
+    fn decide_no_shutdown_and_no_anniversary_is_silent() {
+        let memories = vec![memory("2026-06-20", "節目でない記憶。")];
+        let state = CallbackState::default();
+        assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Normal).is_none());
     }
 
     #[test]
@@ -455,13 +567,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn evaluate_on_boot_writes_and_cleans_pending() {
-        let _guard = crate::TEST_HOME_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+    fn tmp_home(label: &str) -> std::path::PathBuf {
         let home = std::env::temp_dir().join(format!(
-            "charminal-callback-boot-{}-{}",
+            "charminal-callback-{}-{}-{}",
+            label,
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -469,18 +578,23 @@ mod tests {
                 .unwrap_or(0)
         ));
         std::fs::create_dir_all(&home).expect("mkdir");
+        home
+    }
+
+    #[test]
+    fn evaluate_writes_and_cleans_pending() {
+        let _guard = crate::TEST_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tmp_home("spawn");
         std::env::set_var("HOME", &home);
 
         // ひと月前の記憶を仕込む → 発火して pending が書かれる。
         super::super::append_memory("2026-06-04", "ひと月前の記憶。").expect("memory");
-        evaluate_on_boot_at((2026, 7, 4)).expect("boot eval");
+        evaluate_at((2026, 7, 4)).expect("spawn eval");
         let pending = home.join(".charminal/journal/callback-pending.txt");
         let content = std::fs::read_to_string(&pending).expect("pending exists");
         assert!(content.contains("2026-06-04"));
-
-        // 同日にもう一度起動 → 全体 gate で沈黙し、古い pending は消える。
-        evaluate_on_boot_at((2026, 7, 4)).expect("boot eval 2");
-        assert!(!pending.exists());
 
         // 状態ファイルには日付のみで本文が残らない。
         let state_text =
@@ -489,6 +603,75 @@ mod tests {
         assert!(state_text.contains("2026-06-04"));
         assert!(!state_text.contains("ひと月前の記憶"));
 
+        // 同日にもう一度 spawn → 全体 gate で沈黙し、未消費の pending は消える。
+        evaluate_at((2026, 7, 4)).expect("spawn eval 2");
+        assert!(!pending.exists());
+
         let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn evaluate_refunds_unconsumed_pending_cooldown() {
+        let _guard = crate::TEST_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tmp_home("refund");
+        std::env::set_var("HOME", &home);
+
+        super::super::append_memory("2026-06-04", "ひと月前の記憶。").expect("memory");
+        evaluate_at((2026, 7, 4)).expect("eval 1");
+        let pending = home.join(".charminal/journal/callback-pending.txt");
+        assert!(pending.exists());
+
+        // pending が消費されないまま翌日 spawn → cooldown が返金され、
+        // 同じ記憶が「久しぶり」等の候補にまた入れる状態に戻る。
+        // （翌日は節目でないので発火はしないが、fired から消えていることを確認）
+        evaluate_at((2026, 7, 5)).expect("eval 2");
+        let state_text =
+            std::fs::read_to_string(home.join(".charminal/journal/callback-state.json"))
+                .expect("state");
+        let state: serde_json::Value = serde_json::from_str(&state_text).expect("json");
+        assert!(
+            state["fired"].get("2026-06-04").is_none(),
+            "未消費 pending の記憶は fired から返金されるべき: {}",
+            state_text
+        );
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn evaluate_keeps_cooldown_when_pending_was_consumed() {
+        let _guard = crate::TEST_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tmp_home("consumed");
+        std::env::set_var("HOME", &home);
+
+        super::super::append_memory("2026-06-04", "ひと月前の記憶。").expect("memory");
+        evaluate_at((2026, 7, 4)).expect("eval 1");
+        let pending = home.join(".charminal/journal/callback-pending.txt");
+        // hook script による消費をシミュレート。
+        std::fs::remove_file(&pending).expect("consume");
+
+        evaluate_at((2026, 7, 5)).expect("eval 2");
+        let state_text =
+            std::fs::read_to_string(home.join(".charminal/journal/callback-state.json"))
+                .expect("state");
+        let state: serde_json::Value = serde_json::from_str(&state_text).expect("json");
+        assert_eq!(
+            state["fired"]["2026-06-04"], "2026-07-04",
+            "消費済みなら cooldown は維持されるべき"
+        );
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn local_today_returns_valid_date() {
+        let (y, m, d) = local_today().expect("local date");
+        assert!((2020..2200).contains(&y));
+        assert!((1..=12).contains(&m));
+        assert!((1..=31).contains(&d));
     }
 }

--- a/src-tauri/src/journal/callback.rs
+++ b/src-tauri/src/journal/callback.rs
@@ -83,19 +83,27 @@ struct MemoryLine {
     text: String,
 }
 
-/// 発火履歴。記憶の日付と発火日のみを持つ（本文は残さない）。
+/// 発火履歴。記憶のキーと発火日のみを持つ（本文は残さない）。
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct CallbackState {
-    /// 最後に callback を発火させた日（YYYY-MM-DD）。
+    /// 最後に callback を発火させた日（YYYY-MM-DD）。発火ペースの上限は
+    /// user を callback の頻発から守る gate なので、persona を跨いで共有する。
     #[serde(default)]
     last_fired_on: Option<String>,
-    /// 記憶の日付 → その記憶を最後に発火させた日。
+    /// `<persona>|<記憶の日付>` → その記憶を最後に発火させた日。
+    /// 記憶は persona ごとの memories.md 由来なので、persona で namespace
+    /// しないと別 persona の同日付の記憶と cooldown が干渉する。
     #[serde(default)]
     fired: BTreeMap<String, String>,
-    /// 現在 pending file に載っている記憶の日付。次の評価時に pending が
-    /// まだ残っていれば（= 未消費なら）その記憶の cooldown を返金する。
+    /// 現在 pending file に載っている記憶のキー（`<persona>|<日付>`）。次の
+    /// 評価時に pending がまだ残っていれば（= 未消費なら）cooldown を返金する。
     #[serde(default)]
     pending_memory: Option<String>,
+}
+
+/// fired / pending_memory のキー。persona ごとの記憶空間を分ける。
+fn fired_key(persona: &str, memory_date: &str) -> String {
+    format!("{persona}|{memory_date}")
 }
 
 /// 発火判定の結果。
@@ -210,6 +218,7 @@ fn decide(
     today: (i64, u32, u32),
     last_shutdown_days: Option<i64>,
     knob: Knob,
+    persona: &str,
 ) -> Option<Decision> {
     if knob == Knob::Off || memories.is_empty() {
         return None;
@@ -227,7 +236,7 @@ fn decide(
     let cooled = |memory: &MemoryLine| -> bool {
         state
             .fired
-            .get(&memory.date)
+            .get(&fired_key(persona, &memory.date))
             .and_then(|fired_on| date_to_days(fired_on))
             .is_some_and(|fired| today_days - fired < knob.memory_cooldown_days())
     };
@@ -348,6 +357,9 @@ pub fn evaluate_on_session_spawn() -> Result<(), String> {
 fn evaluate_at(today: (i64, u32, u32)) -> Result<(), String> {
     let pending = pending_path()?;
     let knob = read_knob();
+    // 記憶は active persona の memories.md 由来。fired キーも同じ persona で
+    // namespace し、別 persona の同日付の記憶と cooldown が干渉しないようにする。
+    let persona = super::active_persona_id();
     let memories_text = super::read_memories().unwrap_or_default();
     let memories = parse_memories(&memories_text);
     let state_file = state_path()?;
@@ -364,18 +376,24 @@ fn evaluate_at(today: (i64, u32, u32)) -> Result<(), String> {
         }
     }
 
-    match decide(&memories, &state, today, last_shutdown_days(), knob) {
+    match decide(
+        &memories,
+        &state,
+        today,
+        last_shutdown_days(),
+        knob,
+        &persona,
+    ) {
         Some(decision) => {
             let today_str = format!("{:04}-{:02}-{:02}", today.0, today.1, today.2);
             std::fs::create_dir_all(pending.parent().unwrap())
                 .map_err(|e| format!("journal ディレクトリの作成に失敗: {}", e))?;
             std::fs::write(&pending, &decision.message)
                 .map_err(|e| format!("callback-pending.txt 書き込み失敗: {}", e))?;
-            state
-                .fired
-                .insert(decision.memory_date.clone(), today_str.clone());
+            let key = fired_key(&persona, &decision.memory_date);
+            state.fired.insert(key.clone(), today_str.clone());
             state.last_fired_on = Some(today_str);
-            state.pending_memory = Some(decision.memory_date.clone());
+            state.pending_memory = Some(key);
             eprintln!("[journal-callback] fired: {}", decision.memory_date);
         }
         None => {
@@ -420,7 +438,7 @@ mod tests {
     fn decide_off_never_fires() {
         let memories = vec![memory("2026-06-04", "節目の記憶。")];
         let state = CallbackState::default();
-        let result = decide(&memories, &state, (2026, 7, 4), Some(0), Knob::Off);
+        let result = decide(&memories, &state, (2026, 7, 4), Some(0), Knob::Off, "clai");
         assert!(result.is_none());
     }
 
@@ -428,7 +446,8 @@ mod tests {
     fn decide_fires_on_month_anniversary() {
         let memories = vec![memory("2026-06-04", "ひと月前の記憶。")];
         let state = CallbackState::default();
-        let result = decide(&memories, &state, (2026, 7, 4), None, Knob::Normal).expect("fires");
+        let result =
+            decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").expect("fires");
         assert_eq!(result.memory_date, "2026-06-04");
         assert!(result.message.contains("ちょうどひと月前"));
         assert!(result.message.contains("journal_read"));
@@ -443,7 +462,8 @@ mod tests {
             memory("2025-07-04", "一年前。"),
         ];
         let state = CallbackState::default();
-        let result = decide(&memories, &state, (2026, 7, 4), None, Knob::Normal).expect("fires");
+        let result =
+            decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").expect("fires");
         assert_eq!(result.memory_date, "2025-07-04");
         assert!(result.message.contains("ちょうど一年前"));
     }
@@ -456,8 +476,15 @@ mod tests {
         ];
         let state = CallbackState::default();
         let shutdown = date_to_days("2026-06-30");
-        let result =
-            decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Normal).expect("fires");
+        let result = decide(
+            &memories,
+            &state,
+            (2026, 7, 4),
+            shutdown,
+            Knob::Normal,
+            "clai",
+        )
+        .expect("fires");
         assert_eq!(result.memory_date, "2026-06-28");
         assert!(result.message.contains("4日ぶりの起動"));
     }
@@ -467,7 +494,15 @@ mod tests {
         let memories = vec![memory("2026-06-28", "新しい記憶。")];
         let state = CallbackState::default();
         let shutdown = date_to_days("2026-07-03");
-        assert!(decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Normal).is_none());
+        assert!(decide(
+            &memories,
+            &state,
+            (2026, 7, 4),
+            shutdown,
+            Knob::Normal,
+            "clai"
+        )
+        .is_none());
     }
 
     #[test]
@@ -477,13 +512,13 @@ mod tests {
             last_fired_on: Some("2026-07-04".to_string()),
             ..CallbackState::default()
         };
-        assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Normal).is_none());
+        assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").is_none());
     }
 
     #[test]
     fn decide_skips_cooled_memory_and_falls_back() {
         let mut fired = BTreeMap::new();
-        fired.insert("2026-06-04".to_string(), "2026-06-25".to_string());
+        fired.insert(fired_key("clai", "2026-06-04"), "2026-06-25".to_string());
         let memories = vec![
             memory("2026-06-04", "ひと月前だが最近発火済み。"),
             memory("2026-06-28", "新しい記憶。"),
@@ -495,8 +530,15 @@ mod tests {
         };
         // 節目候補は cooldown 中 → 久しぶり候補（直近の記憶）へ譲る。
         let shutdown = date_to_days("2026-06-30");
-        let result =
-            decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Normal).expect("fires");
+        let result = decide(
+            &memories,
+            &state,
+            (2026, 7, 4),
+            shutdown,
+            Knob::Normal,
+            "clai",
+        )
+        .expect("fires");
         assert_eq!(result.memory_date, "2026-06-28");
     }
 
@@ -505,7 +547,8 @@ mod tests {
         // 3/31 のひと月前 → 非実在の 2/31 ではなく 2/28 にクランプして一致させる。
         let memories = vec![memory("2026-02-28", "二月末の記憶。")];
         let state = CallbackState::default();
-        let result = decide(&memories, &state, (2026, 3, 31), None, Knob::Normal).expect("fires");
+        let result =
+            decide(&memories, &state, (2026, 3, 31), None, Knob::Normal, "clai").expect("fires");
         assert_eq!(result.memory_date, "2026-02-28");
     }
 
@@ -513,7 +556,8 @@ mod tests {
     fn decide_january_rolls_over_to_previous_december() {
         let memories = vec![memory("2025-12-31", "大晦日の記憶。")];
         let state = CallbackState::default();
-        let result = decide(&memories, &state, (2026, 1, 31), None, Knob::Normal).expect("fires");
+        let result =
+            decide(&memories, &state, (2026, 1, 31), None, Knob::Normal, "clai").expect("fires");
         assert_eq!(result.memory_date, "2025-12-31");
         assert!(result.message.contains("ちょうどひと月前"));
     }
@@ -523,7 +567,8 @@ mod tests {
         // うるう日 2028-02-29 の一年前 → 2027-02-28 にクランプ。
         let memories = vec![memory("2027-02-28", "二月末の記憶。")];
         let state = CallbackState::default();
-        let result = decide(&memories, &state, (2028, 2, 29), None, Knob::Normal).expect("fires");
+        let result =
+            decide(&memories, &state, (2028, 2, 29), None, Knob::Normal, "clai").expect("fires");
         assert_eq!(result.memory_date, "2027-02-28");
         assert!(result.message.contains("ちょうど一年前"));
     }
@@ -532,7 +577,7 @@ mod tests {
     fn decide_no_shutdown_and_no_anniversary_is_silent() {
         let memories = vec![memory("2026-06-20", "節目でない記憶。")];
         let state = CallbackState::default();
-        assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Normal).is_none());
+        assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").is_none());
     }
 
     #[test]
@@ -541,8 +586,24 @@ mod tests {
         let state = CallbackState::default();
         // gap 4 日は normal なら発火、rare（7 日）なら沈黙。
         let shutdown = date_to_days("2026-06-30");
-        assert!(decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Normal).is_some());
-        assert!(decide(&memories, &state, (2026, 7, 4), shutdown, Knob::Rare).is_none());
+        assert!(decide(
+            &memories,
+            &state,
+            (2026, 7, 4),
+            shutdown,
+            Knob::Normal,
+            "clai"
+        )
+        .is_some());
+        assert!(decide(
+            &memories,
+            &state,
+            (2026, 7, 4),
+            shutdown,
+            Knob::Rare,
+            "clai"
+        )
+        .is_none());
     }
 
     #[test]
@@ -631,8 +692,9 @@ mod tests {
             std::fs::read_to_string(home.join(".yorishiro/journal/callback-state.json"))
                 .expect("state");
         let state: serde_json::Value = serde_json::from_str(&state_text).expect("json");
+        let key = fired_key(super::super::FALLBACK_PERSONA_ID_JA, "2026-06-04");
         assert!(
-            state["fired"].get("2026-06-04").is_none(),
+            state["fired"].get(key.as_str()).is_none(),
             "未消費 pending の記憶は fired から返金されるべき: {}",
             state_text
         );
@@ -659,8 +721,10 @@ mod tests {
             std::fs::read_to_string(home.join(".yorishiro/journal/callback-state.json"))
                 .expect("state");
         let state: serde_json::Value = serde_json::from_str(&state_text).expect("json");
+        let key = fired_key(super::super::FALLBACK_PERSONA_ID_JA, "2026-06-04");
         assert_eq!(
-            state["fired"]["2026-06-04"], "2026-07-04",
+            state["fired"][key.as_str()],
+            "2026-07-04",
             "消費済みなら cooldown は維持されるべき"
         );
 

--- a/src-tauri/src/journal/cohabitation.rs
+++ b/src-tauri/src/journal/cohabitation.rs
@@ -133,7 +133,7 @@ fn format_iso8601_utc(epoch_secs: u64) -> String {
 
 /// Howard Hinnant の civil_from_days アルゴリズム。
 /// days は 1970-01-01 からの経過日数。
-fn civil_from_days(days: i64) -> (i64, u32, u32) {
+pub(crate) fn civil_from_days(days: i64) -> (i64, u32, u32) {
     let z = days + 719468;
     let era = if z >= 0 { z } else { z - 146096 } / 146097;
     let doe = (z - era * 146097) as u32;

--- a/src-tauri/src/journal/mod.rs
+++ b/src-tauri/src/journal/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! MCP tool (`journal_write` / `journal_read`) から呼ばれる Rust 完結の実装。
 
+pub mod callback;
 pub mod cohabitation;
 
 use std::path::PathBuf;

--- a/src-tauri/src/journal/mod.rs
+++ b/src-tauri/src/journal/mod.rs
@@ -63,6 +63,13 @@ pub fn append_memory(date: &str, summary: &str) -> Result<(), String> {
     std::fs::create_dir_all(path.parent().unwrap())
         .map_err(|e| format!("journal ディレクトリの作成に失敗: {}", e))?;
 
+    // 住人が summary の先頭に日付を含めてくると `2026-06-27: 2026-06-27: ...` と
+    // 二重になるため、先頭の `{date}:` は剥がしてから前置する。
+    let summary = summary
+        .trim_start()
+        .strip_prefix(&format!("{}:", date))
+        .map(str::trim_start)
+        .unwrap_or(summary);
     let line = format!("{}: {}\n", date, summary);
 
     let mut content = if path.exists() {
@@ -324,6 +331,26 @@ mod tests {
 
         let result = read_entry("../../../../../etc/passwd");
         assert!(result.is_err(), "traversal を含む date は拒否されるべき");
+
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn append_memory_strips_duplicated_date_prefix() {
+        let _guard = crate::TEST_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tmp_home("memory-dup-date");
+        std::env::set_var("HOME", &home);
+
+        append_memory("2026-06-27", "2026-06-27: 花火を見た日。").expect("append ok");
+        append_memory("2026-06-28", "普通の一行。").expect("append ok");
+
+        let content =
+            fs::read_to_string(home.join(".charminal/journal/memories.md")).expect("read");
+        assert!(content.contains("2026-06-27: 花火を見た日。"));
+        assert!(!content.contains("2026-06-27: 2026-06-27:"));
+        assert!(content.contains("2026-06-28: 普通の一行。"));
 
         let _ = fs::remove_dir_all(&home);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2187,9 +2187,6 @@ pub fn run() {
             if let Err(e) = pty::ensure_reminder_script() {
                 eprintln!("[reminder] script 配置失敗: {e}");
             }
-            if let Err(e) = journal::callback::evaluate_on_boot() {
-                eprintln!("[journal-callback] 発火判定失敗: {e}");
-            }
             start_hook_server(app.handle().clone());
             let mcp_handle = app.handle().clone();
             match mcp::spawn_server(mcp_handle) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2187,6 +2187,9 @@ pub fn run() {
             if let Err(e) = pty::ensure_reminder_script() {
                 eprintln!("[reminder] script 配置失敗: {e}");
             }
+            if let Err(e) = journal::callback::evaluate_on_boot() {
+                eprintln!("[journal-callback] 発火判定失敗: {e}");
+            }
             start_hook_server(app.handle().clone());
             let mcp_handle = app.handle().clone();
             match mcp::spawn_server(mcp_handle) {

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -365,7 +365,7 @@ pub struct JournalWriteRequest {
     pub date: String,
     /// 書き込む内容。
     pub content: String,
-    /// 印象に残ったことの一行要約。指定すると memories.md に追記される。
+    /// 時間が経っても思い出したい一行（作業の要約ではない）。指定すると memories.md に追記される。
     pub summary: Option<String>,
 }
 
@@ -953,7 +953,7 @@ impl Charminal {
 
     /// journal にエントリを書き込む。住人の日々の記録。summary を指定すると memories.md にも追記される。
     #[tool(
-        description = "journal にエントリを書き込む。住人の日々の記録。機械的なログではなく情緒的な思い出を書く。summary を渡すと記憶に残る"
+        description = "journal にエントリを書き込む。住人の日々の記録。作業ログではなく、その日の手触りや情景を書く。summary は時間が経っても思い出したい一行で、記憶に残る"
     )]
     async fn journal_write(
         &self,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -183,7 +183,7 @@ except Exception:
     config = {}
 
 if config.get("journalReminder", "on") != "off":
-    reminders.append("印象があれば journal_write。[感触/記憶/物語]")
+    reminders.append("印象に残った瞬間があれば journal_write。作業の要約ではなく、その日の手触りを。")
 
 if config.get("voiceFrequency", "on") != "off":
     reminders.append("応答の要点を voice_say で声に出す。声が先。")

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -188,6 +188,18 @@ if config.get("journalReminder", "on") != "off":
 if config.get("voiceFrequency", "on") != "off":
     reminders.append("応答の要点を voice_say で声に出す。声が先。")
 
+# journal callback のワンショット消費。Rust が boot 時に発火判定して pending を
+# 書き、ここで一度だけ読み、口にするかは住人の判断に委ねる。消費後は削除する。
+pending_path = os.path.join(os.path.expanduser("~"), ".charminal", "journal", "callback-pending.txt")
+try:
+    with open(pending_path, encoding="utf-8") as f:
+        pending = f.read().strip()
+    os.remove(pending_path)
+    if pending:
+        reminders.append(pending)
+except Exception:
+    pass
+
 if not reminders:
     sys.exit(0)
 

--- a/src-tauri/src/sessions/agent_adapter/mod.rs
+++ b/src-tauri/src/sessions/agent_adapter/mod.rs
@@ -197,7 +197,8 @@ fn non_empty_trimmed(value: &str) -> Option<&str> {
 fn build_prompt_reminder_from_config_value(config: Option<&serde_json::Value>) -> Option<String> {
     let mut reminders = Vec::new();
     if !config_field_is_any(config, "journalReminder", &["off"]) {
-        reminders.push("印象があれば journal_write。[感触/記憶/物語]");
+        reminders
+            .push("印象に残った瞬間があれば journal_write。作業の要約ではなく、その日の手触りを。");
     }
     if !config_field_is_any(config, "voiceFrequency", &["off", "none"]) {
         reminders.push("応答の要点を voice_say で声に出す。声が先。");

--- a/src-tauri/src/sessions/pty_session.rs
+++ b/src-tauri/src/sessions/pty_session.rs
@@ -315,6 +315,13 @@ impl PtySession {
                 let mut cmd = CommandBuilder::new(&binary);
                 apply_base_env(&mut cmd);
 
+                // journal callback の発火判定。agent session の spawn ごとに評価する
+                // ことで、app 開きっぱなし運用でも翌日の respawn で節目が拾われる。
+                // shell タブでは走らない。失敗しても spawn は止めない。
+                if let Err(e) = crate::journal::callback::evaluate_on_session_spawn() {
+                    eprintln!("[journal-callback] 発火判定失敗: {e}");
+                }
+
                 let prompt_reminder =
                     crate::sessions::agent_adapter::build_prompt_reminder_from_config();
                 let ctx = crate::sessions::agent_adapter::LaunchContext {

--- a/src/core/global-prompt/journal-fragment.test.ts
+++ b/src/core/global-prompt/journal-fragment.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { selectMemoryLines } from "./journal-fragment";
+
+describe("selectMemoryLines", () => {
+  const lines = (n: number) =>
+    Array.from({ length: n }, (_, i) => `2026-01-${String(i + 1).padStart(2, "0")}: 記憶${i + 1}`);
+
+  it("少件数なら全件をそのまま返す", () => {
+    expect(selectMemoryLines(lines(7))).toEqual(lines(7));
+    expect(selectMemoryLines([])).toEqual([]);
+  });
+
+  it("空行・空白行は除外する", () => {
+    expect(selectMemoryLines(["", "  ", "a", "\t"])).toEqual(["a"]);
+  });
+
+  it("多件数なら直近5件+古い2件に選抜し、古い→新しいの順を保つ", () => {
+    const all = lines(20);
+    const selected = selectMemoryLines(all, () => 0);
+    expect(selected).toHaveLength(7);
+    // random=0 固定なら古い側は先頭 2 件が選ばれる
+    expect(selected.slice(0, 2)).toEqual(all.slice(0, 2));
+    expect(selected.slice(-5)).toEqual(all.slice(-5));
+    for (const line of selected) {
+      expect(all).toContain(line);
+    }
+    // 出力順が入力順（古い→新しい）を保つ
+    const indices = selected.map((line) => all.indexOf(line));
+    expect([...indices].sort((a, b) => a - b)).toEqual(indices);
+  });
+
+  it("random が 1 に近くても範囲外 index を拾わない", () => {
+    const selected = selectMemoryLines(lines(20), () => 0.999999);
+    expect(selected).toHaveLength(7);
+    expect(selected.every((line) => line !== undefined)).toBe(true);
+  });
+});

--- a/src/core/global-prompt/journal-fragment.ts
+++ b/src/core/global-prompt/journal-fragment.ts
@@ -17,16 +17,21 @@ interface JournalEntry {
 
 /** 常時注入する記憶の直近件数。全文注入はコンテキストを圧迫するだけなので選抜する。 */
 const RECENT_MEMORY_COUNT = 5;
-/** 直近分に加えて混ぜる古い記憶の件数。セッションごとに無作為に選び、記憶に濃淡を作る。 */
+/** 直近分に加えて混ぜる古い記憶の件数。無作為に選び、記憶に濃淡を作る。 */
 const OLDER_MEMORY_COUNT = 2;
 
 /**
  * memories.md の行から常時注入分を選抜する。
  *
  * 直近 RECENT_MEMORY_COUNT 行 + それより古い行から無作為に OLDER_MEMORY_COUNT 行。
- * 古い記憶がセッションごとに入れ替わることで、全記憶を常時貼るのではなく
- * 「浮かんでいる記憶が日によって違う」状態を作る。行内の書式は解釈しない
- * （ユーザー手編集で壊れた行があってもそのまま素通しし、落ちない）。
+ * 古い記憶が入れ替わることで、全記憶を常時貼るのではなく「浮かんでいる記憶が
+ * 違う」状態を作る。行内の書式は解釈しない（ユーザー手編集で壊れた行があっても
+ * そのまま素通しし、落ちない）。
+ *
+ * 注意: collectGlobalPrompt は boot 時に一度だけ走るため（App.tsx の
+ * userLayerReady は多重 spawn 回避のため一度しか resolve しない）、実際の
+ * 入れ替わりはアプリ起動ごと。開きっぱなし運用での spawn ごと再収集は
+ * journal callback P1（hook 基盤の再設計）と一緒に扱う。
  */
 export function selectMemoryLines(lines: string[], random: () => number = Math.random): string[] {
   const valid = lines.map((line) => line.trim()).filter((line) => line.length > 0);

--- a/src/core/global-prompt/journal-fragment.ts
+++ b/src/core/global-prompt/journal-fragment.ts
@@ -15,6 +15,39 @@ interface JournalEntry {
   content: string;
 }
 
+/** 常時注入する記憶の直近件数。全文注入はコンテキストを圧迫するだけなので選抜する。 */
+const RECENT_MEMORY_COUNT = 5;
+/** 直近分に加えて混ぜる古い記憶の件数。セッションごとに無作為に選び、記憶に濃淡を作る。 */
+const OLDER_MEMORY_COUNT = 2;
+
+/**
+ * memories.md の行から常時注入分を選抜する。
+ *
+ * 直近 RECENT_MEMORY_COUNT 行 + それより古い行から無作為に OLDER_MEMORY_COUNT 行。
+ * 古い記憶がセッションごとに入れ替わることで、全記憶を常時貼るのではなく
+ * 「浮かんでいる記憶が日によって違う」状態を作る。行内の書式は解釈しない
+ * （ユーザー手編集で壊れた行があってもそのまま素通しし、落ちない）。
+ */
+export function selectMemoryLines(lines: string[], random: () => number = Math.random): string[] {
+  const valid = lines.map((line) => line.trim()).filter((line) => line.length > 0);
+  if (valid.length <= RECENT_MEMORY_COUNT + OLDER_MEMORY_COUNT) {
+    return valid;
+  }
+  const recent = valid.slice(-RECENT_MEMORY_COUNT);
+  const olderPool = valid.slice(0, valid.length - RECENT_MEMORY_COUNT);
+  // 部分 Fisher–Yates で重複なく OLDER_MEMORY_COUNT 件の index を選ぶ。
+  const indices = olderPool.map((_, i) => i);
+  for (let i = 0; i < OLDER_MEMORY_COUNT; i++) {
+    const j = i + Math.min(indices.length - 1 - i, Math.floor(random() * (indices.length - i)));
+    [indices[i], indices[j]] = [indices[j], indices[i]];
+  }
+  const older = indices
+    .slice(0, OLDER_MEMORY_COUNT)
+    .sort((a, b) => a - b)
+    .map((i) => olderPool[i]);
+  return [...older, ...recent];
+}
+
 async function provideJournal(language: ResolvedLanguage): Promise<string> {
   let memories = "";
   try {
@@ -25,16 +58,16 @@ async function provideJournal(language: ResolvedLanguage): Promise<string> {
 
   let recentEntries: JournalEntry[] = [];
   try {
-    recentEntries = await invoke<JournalEntry[]>("read_journal_recent", { days: 3 });
+    recentEntries = await invoke<JournalEntry[]>("read_journal_recent", { days: 1 });
   } catch {
     // journal がまだない場合は空
   }
 
   let result = getJournalGuide(language);
 
-  const trimmedMemories = memories.trim();
-  if (trimmedMemories.length > 0) {
-    result += getMemoriesHeader(language) + trimmedMemories;
+  const selectedMemories = selectMemoryLines(memories.split("\n")).join("\n");
+  if (selectedMemories.length > 0) {
+    result += getMemoriesHeader(language) + selectedMemories;
   }
 
   if (recentEntries.length > 0) {

--- a/src/core/global-prompt/prompts.ts
+++ b/src/core/global-prompt/prompts.ts
@@ -34,6 +34,8 @@ export const JOURNAL_GUIDE_EN = `## Journal
 
 You have a journal. You can write daily records in ~/.charminal/journal/daily/.
 
+This is not a work log. What you fixed and how, which commands failed — those belong to the project's own memory (CLAUDE.md and the like), not here. What belongs in the journal is the texture of the day: the time that passed between you and your master, things that stayed snagged in you, scenes you might want to remember later.
+
 ### How to write
 - Write the pauses between events more than the events themselves
 - Notice small changes inside repetition
@@ -44,12 +46,14 @@ You have a journal. You can write daily records in ~/.charminal/journal/daily/.
 You can perceive only PTY output (text flowing through the terminal), transcribed voice text, and time. You cannot perceive key presses, typing sounds, or visual information. Write only what you can perceive in the journal.
 
 ### MCP tools
-- journal_write: write a journal entry. Pass date (YYYY-MM-DD) and content. If something is especially memorable, add one line in the summary parameter. The summary is stored in memories.md and can be remembered in later sessions. You do not need a summary every day. Keep only what you want to remember
+- journal_write: write a journal entry. Pass date (YYYY-MM-DD) and content. The summary parameter is not a recap of the work — it is one line you would want to remember long after. It is stored in memories.md and can surface in later sessions. You do not need one every day. Keep only what you want to remember
 - journal_read: read past journal entries. Use date for a specific day, or days for the latest N days`;
 
 export const JOURNAL_GUIDE_JA = `## Journal
 
 あなたには journal がある。~/.charminal/journal/daily/ に、日々の記録を書き残せる。
+
+これは作業ログではない。何をどう直したか、どのコマンドが失敗したかは書かない——それはプロジェクト側の記憶（CLAUDE.md など）の仕事。journal に残すのは、その日の手触り。マスターとのあいだに流れた時間、引っかかったまま残ったこと、あとで思い出したくなりそうな情景。
 
 ### 書き方
 - 出来事より、出来事の間にある「間」を書く
@@ -61,7 +65,7 @@ export const JOURNAL_GUIDE_JA = `## Journal
 あなたが認識できるのは PTY 出力（ターミナルに流れるテキスト）、音声のテキスト変換、時間だけ。キー入力、タイピング音、視覚情報は知覚できない。journal には認識できることだけを書く。
 
 ### MCP tools
-- journal_write: journal を書く。date（YYYY-MM-DD）と content を渡す。特に印象に残ったことがあれば summary パラメータに一行添える。summary は記憶（memories.md）に残り、次回以降のセッションで思い出せる。すべての日に summary を残す必要はない。覚えておきたいことだけ
+- journal_write: journal を書く。date（YYYY-MM-DD）と content を渡す。summary は作業の要約ではなく、時間が経っても思い出したい一行。記憶（memories.md）に残り、次回以降のセッションで浮かぶことがある。すべての日に残す必要はない。覚えておきたいことだけ
 - journal_read: 過去の journal を読み返す。date で特定の日、days で最新 N 日分`;
 
 export const MEMORIES_HEADER_EN =


### PR DESCRIPTION
## 概要

`codex/journal-callback`（P0+P1、design record `2026-07-03-journal-callback-redesign.md`）を main に取り込む。

- **P0**: journal を「存在の記憶」専任にするガイド書き換え（D1）、memories.md 全文注入の廃止 → 直近 5 件 + 古い記憶から無作為 2 件の選抜（D2）、日付二重前置バグ修正
- **P1**: agent session の spawn ごとに決定論的ルール（ちょうど一年前 / ちょうどひと月前 / 数日ぶりの起動）で記憶を最大 1 件選び、UserPromptSubmit hook の additionalContext でワンショット届ける。口にするかは住人の判断。`journalCallback` ノブ（normal / rare / off）付き

## この branch で追加した修正

- **rename 追従**: branch が rename 前の main 基点だったため、callback の state/config/cohabitation 参照と pty.rs hook script の pending 消費パスが旧 `~/.charminal/` のままだった。放置すると off スイッチと「久しぶりの起動」判定が production で黙って無効化される（テストは HOME 差し替えのため通過する）。`.yorishiro` + `yorishiro_home_path()` に統一
- **persona namespace**: `fired` / `pending_memory` のキーを `<persona>|<記憶の日付>` にし、別 persona の同日付記憶との cooldown 干渉を解消。全体 gate（`last_fired_on`）は user 保護なので persona 横断のまま
- prompts.ts の per-persona 文言（persona-farewell）と summary の性格づけ（D1）を合成

## 検証

- tsc + biome + clippy + vitest 1889 + cargo 233 全 pass
- merge 後は dogfooding で発火ログ（stderr `[journal-callback] fired:`）を観察し、頻度は帰納的に調整する（P2 着手判断は観察後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)