### PR TITLE
Skip sad pulse for run-slow-completed in presence bridge

### DIFF
--- a/src/runtime/workspace-attention/presence-bridge.test.ts
+++ b/src/runtime/workspace-attention/presence-bridge.test.ts
@@ -161,10 +161,10 @@ describe("workspace attention presence bridge", () => {
         rect: { x: 20, y: 30, width: 500, height: 80 },
         range: { startRow: 2, endRow: 6, startCol: 0, endCol: 79 },
       },
-      type: "run-slow-completed",
+      type: "run-running-long",
       severity: "medium",
       producer: { kind: "host", id: "test" },
-      producerKey: "test:slow",
+      producerKey: "test:running",
     });
 
     store.resolve(item.id);
@@ -194,14 +194,44 @@ describe("workspace attention presence bridge", () => {
         rect: { x: 20, y: 30, width: 0, height: 80 },
         range: { startRow: 2, endRow: 6, startCol: 0, endCol: 79 },
       },
+      type: "run-running-long",
+      severity: "medium",
+      producer: { kind: "host", id: "test" },
+      producerKey: "test:running",
+    });
+
+    expect(attention.setSourceTarget).not.toHaveBeenCalled();
+    expect(body.body.acquireExpressionSlot).toHaveBeenCalledWith("persona", "mood", "sad", 0.16);
+  });
+
+  it("run-slow-completed（成功）が primary でも表情 pulse は発火しない", () => {
+    const store = createWorkspaceAttentionStore();
+    const attention = createAttentionFake();
+    const body = createBodyFake();
+
+    startWorkspaceAttentionPresenceBridge({
+      store,
+      attention: attention.attention,
+      getBody: () => body.body,
+      setTimeout: () => 1,
+      clearTimeout: vi.fn<(id: unknown) => void>(),
+    });
+
+    store.upsert({
+      sessionId: "session-1",
+      locus: {
+        kind: "terminal-region",
+        sessionId: "session-1",
+        rect: { x: 20, y: 30, width: 500, height: 80 },
+        range: { startRow: 2, endRow: 6, startCol: 0, endCol: 79 },
+      },
       type: "run-slow-completed",
       severity: "medium",
       producer: { kind: "host", id: "test" },
       producerKey: "test:slow",
     });
 
-    expect(attention.setSourceTarget).not.toHaveBeenCalled();
-    expect(body.body.acquireExpressionSlot).toHaveBeenCalledWith("persona", "mood", "sad", 0.16);
+    expect(body.body.acquireExpressionSlot).not.toHaveBeenCalled();
   });
 
   it("awaiting-approval が primary でも表情 pulse は発火しない", () => {

--- a/src/runtime/workspace-attention/presence-bridge.ts
+++ b/src/runtime/workspace-attention/presence-bridge.ts
@@ -67,9 +67,9 @@ export function startWorkspaceAttentionPresenceBridge(
 
     if (item.id === currentPrimaryId) return;
     currentPrimaryId = item.id;
-    // awaiting-approval は「まだ何も起きていない待機」で、sad の語彙が合わないため
-    // 表情 pulse を発火しない（既存の失敗系 pulse 挙動は不変）。
-    if (item.type === "awaiting-approval") {
+    // awaiting-approval は「まだ何も起きていない待機」、run-slow-completed は「成功の報告」で、
+    // どちらも sad の語彙が合わないため表情 pulse を発火しない（失敗系 pulse 挙動は不変）。
+    if (item.type === "awaiting-approval" || item.type === "run-slow-completed") {
       releaseExpression();
       return;
     }


### PR DESCRIPTION
## 概要

presence-bridge が workspace-attention の primary item 遷移で無条件に sad 表情 pulse を出すため、**成功の報告である `run-slow-completed`（30s 超の成功コマンド完了）でも住人が悲しむ**語彙バグを修正。awaiting-approval と同様に skip する。

失敗系（`run-failed` / `run-running-long`）の pulse 挙動は不変。

## 変更

- `presence-bridge.ts`: skip 条件に `run-slow-completed` を追加
- `presence-bridge.test.ts`: 「run-slow-completed では pulse を発火しない」を追加（RED 確認済み）。成功 item を pulse の担体にしていた既存テスト 2 本は `run-running-long` に差し替え

## 検証

- presence-bridge テスト 6/6、vitest 全体 1890 pass、tsc / biome green

背景: design-record `2026-07-07-reaction-expansion-design.md` D8（反応拡張計画自体は中止、本修正のみ独立して取り込み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)