### PR TITLE
journal 想起に「最近の記憶」を追加、配達経路のない agent では発火しない

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,11 +39,11 @@ Yorishiro は起動時に `~/.yorishiro/config.json` を読み、壊れている
 | `motionIntensity` | `number` (`0.0`–`3.0`) | `1.0` | idle procedural motion（呼吸 / sway / head drift / posture）の振幅ノブ。`1.0` は従来どおり、`0` 付近はほぼ静止、上端は opt-in のオーバーアクション |
 | `mcpPort` | `number` | `18743` | Rust MCP server の listen port |
 | `disabledPacks` | `string[]` | `[]` | rescue 用。指定 id の user pack を load しない |
-| `journalCallback` | `"normal"`, `"rare"`, or `"off"` | `"normal"` | journal callback（セッション開始時の記憶想起）の頻度ノブ。`rare` は発火条件と cooldown を広げ、`off` で無効化。Rust 側が config.json を直接読む |
+| `journalCallback` | `"normal"`, `"rare"`, or `"off"` | `"normal"` | journal callback（セッション開始時の記憶想起）の頻度ノブ。`rare` は日常の想起をせず節目と久しぶりの起動だけに絞り、`off` で無効化。Rust 側が config.json を直接読む |
 
 ### Journal callback
 
-`journalCallback` は、agent session の開始時に住人の過去の journal（`~/.yorishiro/journal/`）から記憶を最大 1 件、会話の背景情報として届ける機能の頻度ノブ。発火は決定論的ルール（ちょうど一年前 / ちょうどひと月前の記憶、数日ぶりの起動）で、届いた記憶に触れるかどうかは住人が判断する。`normal` でも発火はセッションあたり最大 1 回・1 日 1 回・同じ記憶は約 3 週間空く。
+`journalCallback` は、agent session の開始時に住人の過去の journal（`~/.yorishiro/journal/`）から記憶を最大 1 件、会話の背景情報として届ける機能の頻度ノブ。発火は決定論的ルールで、優先順位は「ちょうど一年前 / ちょうどひと月前の記憶 > 数日ぶりの起動 > 最近の記憶（昨日〜数日前）」。届いた記憶に触れるかどうかは住人が判断する。`normal` でも発火はセッションあたり最大 1 回・1 日 1 回・同じ記憶は約 3 週間空く。journal を書かない日が続くと最近の記憶は自然に沈黙し、次に届くのは節目だけになる。`rare` は最近の記憶を想起せず、節目と久しぶりの起動だけに絞る。
 
 ### Scene selection
 

--- a/src-tauri/src/journal/callback.rs
+++ b/src-tauri/src/journal/callback.rs
@@ -384,7 +384,16 @@ fn local_today() -> Result<(i64, u32, u32), String> {
 
 /// agent session の spawn 時に呼ぶ。発火すれば pending file を書き、
 /// しなければ古い pending を消す。
-pub fn evaluate_on_session_spawn() -> Result<(), String> {
+///
+/// `can_deliver_callback` は「この agent に pending を届ける経路があるか」。
+/// 現状の消費経路は Claude の UserPromptSubmit hook だけなので、呼び出し側は
+/// adapter の lifecycle_hooks を渡す。経路のない agent（Codex 等）では評価
+/// 自体を skip する——届かない発火で last_fired_on を焼くと、同日にあとから
+/// 起動した hook 持ち agent の分まで global gate で潰してしまうため。
+pub fn evaluate_on_session_spawn(can_deliver_callback: bool) -> Result<(), String> {
+    if !can_deliver_callback {
+        return Ok(());
+    }
     evaluate_at(local_today()?)
 }
 
@@ -866,6 +875,34 @@ mod tests {
             "2026-07-04",
             "消費済みなら cooldown は維持されるべき"
         );
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn evaluate_skips_agents_without_delivery_path() {
+        let _guard = crate::TEST_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tmp_home("nodelivery");
+        std::env::set_var("HOME", &home);
+
+        // 届ける経路（UserPromptSubmit hook）を持たない agent の spawn では
+        // 評価自体を skip する——pending も state も一切書かない。届かない発火で
+        // last_fired_on を焼くと、同日にあとから起動した hook 持ち agent の分まで
+        // global gate で潰してしまうため。
+        super::super::append_memory("2026-06-04", "ひと月前の記憶。").expect("memory");
+        evaluate_on_session_spawn(false).expect("eval without delivery");
+        assert!(!home
+            .join(".yorishiro/journal/callback-pending.txt")
+            .exists());
+        assert!(!home.join(".yorishiro/journal/callback-state.json").exists());
+
+        // 同日に hook 持ち agent が spawn すれば通常どおり発火する。
+        evaluate_at((2026, 7, 4)).expect("eval with delivery");
+        assert!(home
+            .join(".yorishiro/journal/callback-pending.txt")
+            .exists());
 
         let _ = std::fs::remove_dir_all(&home);
     }

--- a/src-tauri/src/journal/callback.rs
+++ b/src-tauri/src/journal/callback.rs
@@ -28,6 +28,8 @@ const LONG_ABSENCE_DAYS_RARE: i64 = 7;
 const GLOBAL_MIN_GAP_DAYS_NORMAL: i64 = 1;
 /// 同・rare。
 const GLOBAL_MIN_GAP_DAYS_RARE: i64 = 7;
+/// 「最近の記憶」として想起する window（日）。normal のみ。帰納的調整の対象。
+const RECENT_WINDOW_DAYS_NORMAL: i64 = 7;
 /// 同じ記憶を再発火させない cooldown（日）。
 const MEMORY_COOLDOWN_DAYS_NORMAL: i64 = 21;
 /// 同・rare。
@@ -71,6 +73,15 @@ impl Knob {
         match self {
             Knob::Rare => MEMORY_COOLDOWN_DAYS_RARE,
             _ => MEMORY_COOLDOWN_DAYS_NORMAL,
+        }
+    }
+
+    /// 「最近の記憶」想起の window（日）。0 は無効。rare は節目と久しぶりの
+    /// 起動だけに絞り、日常の想起をしない。
+    fn recent_window_days(self) -> i64 {
+        match self {
+            Knob::Normal => RECENT_WINDOW_DAYS_NORMAL,
+            _ => 0,
         }
     }
 }
@@ -210,8 +221,9 @@ fn parse_memories(content: &str) -> Vec<MemoryLine> {
 
 /// 発火判定の純関数本体。
 ///
-/// 優先順位: 一年前の節目 > ひと月前の節目 > 久しぶりの起動（直近の記憶）。
-/// cooldown 中の記憶は次の候補に譲る。すべて gate に落ちたら None。
+/// 優先順位: 一年前の節目 > ひと月前の節目 > 久しぶりの起動（直近の記憶） >
+/// 最近の記憶（normal のみ）。cooldown 中の記憶は次の候補に譲る。すべて
+/// gate に落ちたら None。
 fn decide(
     memories: &[MemoryLine],
     state: &CallbackState,
@@ -266,6 +278,28 @@ fn decide(
             if let Some(latest) = memories.iter().max_by_key(|m| m.days) {
                 candidates.push((latest, format!("{}日ぶりの起動", gap)));
             }
+        }
+    }
+
+    // 最近の記憶: 節目でも久しぶりでもない日の default 想起（normal のみ）。
+    // 記念日は「たまに」だから効く——日常は昨日や数日前が受け持つ。
+    // 今日書かれた行は「さっきのこと」なので対象外。最新 1 件だけを候補にし、
+    // cooldown 中でも古い記憶へは遡らない（journal が途絶えたら window と
+    // cooldown が自然に沈黙させ、次に口を開くのは節目だけになる）。
+    let recent_window = knob.recent_window_days();
+    if recent_window > 0 {
+        if let Some(latest) = memories
+            .iter()
+            .filter(|m| (1..=recent_window).contains(&(today_days - m.days)))
+            .max_by_key(|m| m.days)
+        {
+            let diff = today_days - latest.days;
+            let reason = if diff == 1 {
+                "昨日".to_string()
+            } else {
+                format!("{}日前", diff)
+            };
+            candidates.push((latest, reason));
         }
     }
 
@@ -491,7 +525,8 @@ mod tests {
 
     #[test]
     fn decide_short_gap_does_not_fire_absence() {
-        let memories = vec![memory("2026-06-28", "新しい記憶。")];
+        // recent window の外の記憶にして、久しぶり判定だけを見る。
+        let memories = vec![memory("2026-06-20", "少し前の記憶。")];
         let state = CallbackState::default();
         let shutdown = date_to_days("2026-07-03");
         assert!(decide(
@@ -503,6 +538,110 @@ mod tests {
             "clai"
         )
         .is_none());
+    }
+
+    #[test]
+    fn decide_fires_yesterdays_memory_as_recent() {
+        let memories = vec![memory("2026-07-03", "夕方の散歩。")];
+        let state = CallbackState::default();
+        let result =
+            decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").expect("fires");
+        assert_eq!(result.memory_date, "2026-07-03");
+        assert!(result.message.contains("昨日"));
+    }
+
+    #[test]
+    fn decide_recent_reason_counts_days_ago() {
+        let memories = vec![memory("2026-07-01", "雨上がりの虹。")];
+        let state = CallbackState::default();
+        let result =
+            decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").expect("fires");
+        assert_eq!(result.memory_date, "2026-07-01");
+        assert!(result.message.contains("3日前"));
+    }
+
+    #[test]
+    fn decide_recent_ignores_todays_entry() {
+        let memories = vec![memory("2026-07-04", "書いたばかりの記憶。")];
+        let state = CallbackState::default();
+        assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").is_none());
+    }
+
+    #[test]
+    fn decide_recent_window_boundary() {
+        // window ちょうどは発火し、1 日超えたら沈黙する。
+        // 帰納的調整（定数変更）に追従するよう、日付は定数から組み立てる。
+        let today = (2026, 7, 4);
+        let today_days = days_from_civil(today.0, today.1, today.2);
+        let date_at = |diff: i64| {
+            let (y, m, d) = super::super::cohabitation::civil_from_days(today_days - diff);
+            format!("{:04}-{:02}-{:02}", y, m, d)
+        };
+        let inside = vec![memory(&date_at(RECENT_WINDOW_DAYS_NORMAL), "window 内。")];
+        let state = CallbackState::default();
+        assert!(decide(&inside, &state, today, None, Knob::Normal, "clai").is_some());
+        let outside = vec![memory(
+            &date_at(RECENT_WINDOW_DAYS_NORMAL + 1),
+            "window 外。",
+        )];
+        assert!(decide(&outside, &state, today, None, Knob::Normal, "clai").is_none());
+    }
+
+    #[test]
+    fn decide_rare_has_no_recent_recall() {
+        let memories = vec![memory("2026-07-03", "夕方の散歩。")];
+        let state = CallbackState::default();
+        assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Rare, "clai").is_none());
+    }
+
+    #[test]
+    fn decide_recent_does_not_fall_back_to_older_memories() {
+        // 最新が cooldown 中なら黙る。古い記憶まで遡って埋め草を喋らない。
+        let mut fired = BTreeMap::new();
+        fired.insert(fired_key("clai", "2026-07-03"), "2026-07-03".to_string());
+        let memories = vec![
+            memory("2026-07-02", "一昨日の買い物。"),
+            memory("2026-07-03", "夕方の散歩。"),
+        ];
+        let state = CallbackState {
+            last_fired_on: Some("2026-07-03".to_string()),
+            fired,
+            ..CallbackState::default()
+        };
+        assert!(decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").is_none());
+    }
+
+    #[test]
+    fn decide_prefers_anniversary_over_recent() {
+        let memories = vec![
+            memory("2026-07-03", "夕方の散歩。"),
+            memory("2026-06-04", "ひと月前の記憶。"),
+        ];
+        let state = CallbackState::default();
+        let result =
+            decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").expect("fires");
+        assert_eq!(result.memory_date, "2026-06-04");
+        assert!(result.message.contains("ちょうどひと月前"));
+    }
+
+    #[test]
+    fn decide_recent_fires_daily_with_fresh_memories() {
+        // 毎日 journal が書かれていれば、翌日にはその「昨日」を想起できる。
+        let mut fired = BTreeMap::new();
+        fired.insert(fired_key("clai", "2026-07-02"), "2026-07-03".to_string());
+        let memories = vec![
+            memory("2026-07-02", "一昨日の買い物。"),
+            memory("2026-07-03", "夕方の散歩。"),
+        ];
+        let state = CallbackState {
+            last_fired_on: Some("2026-07-03".to_string()),
+            fired,
+            ..CallbackState::default()
+        };
+        let result =
+            decide(&memories, &state, (2026, 7, 4), None, Knob::Normal, "clai").expect("fires");
+        assert_eq!(result.memory_date, "2026-07-03");
+        assert!(result.message.contains("昨日"));
     }
 
     #[test]

--- a/src-tauri/src/sessions/pty_session.rs
+++ b/src-tauri/src/sessions/pty_session.rs
@@ -321,8 +321,12 @@ impl PtySession {
 
                 // journal callback の発火判定。agent session の spawn ごとに評価する
                 // ことで、app 開きっぱなし運用でも翌日の respawn で節目が拾われる。
-                // shell タブでは走らない。失敗しても spawn は止めない。
-                if let Err(e) = crate::journal::callback::evaluate_on_session_spawn() {
+                // shell タブでは走らない。pending の消費経路は Claude の
+                // UserPromptSubmit hook だけなので、hook を持たない agent
+                // （Codex 等）では評価しない。失敗しても spawn は止めない。
+                if let Err(e) = crate::journal::callback::evaluate_on_session_spawn(
+                    adapter.capabilities().lifecycle_hooks,
+                ) {
                     eprintln!("[journal-callback] 発火判定失敗: {e}");
                 }
 


### PR DESCRIPTION
## 概要

journal callback（セッション開始時の記憶想起）を再設計する。現行は「記念日か久しぶりの起動」しか候補がなく、普通の日には何も想起されない。昨日・最近の記憶の想起を default にし、記念日は「たまに割り込む遠い記憶」として対比で際立たせる。

## 変更

- **最近の記憶の想起（normal のみ）**: 優先順位を「一年前の節目 > ひと月前の節目 > 久しぶりの起動 > 最近の記憶」に。昨日〜数日前（window 7 日、tentative）の最新の記録を想起し、理由文言は「昨日」「3日前」など。今日書いた行は対象外
- **fallback しない**: 最新の記憶が cooldown 中なら沈黙し、古い記憶へ遡らない。journal を書かない日が続くと想起は自然に沈黙し、次に届くのは節目だけになる
- **rare = 旧挙動**: 節目と久しぶりの起動のみ。日常の想起をしない
- **配達経路のゲート（レビュー指摘の修正）**: pending の消費経路は Claude の UserPromptSubmit hook のみなのに、評価は全 agent spawn で走っていた。Codex 先行起動の日は `last_fired_on` が焼かれ、同日の Claude 分が global gate で潰れる（memory cooldown は返金されるが `last_fired_on` は返金されない）。`evaluate_on_session_spawn(can_deliver_callback)` に変更し、`lifecycle_hooks` を持たない agent では評価自体を skip

## 検証

- TDD（RED→GREEN 確認済み）。`cargo test --lib` 242 pass、rustfmt / clippy クリーン
- window 7 日は帰納的調整の対象（const に明記）。merge 後 dogfooding で調整

## 備考

- hook を持たない agent への配達（prompt reminder 経由）は意味論の変更を伴うため follow-up
- README の追従は #（docs/readme-refresh）側。**本 PR を先に merge すること**

🤖 Generated with [Claude Code](https://claude.com/claude-code)