### PR TITLE
Fix production black screen: move boot styles out of inline <style>

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,24 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#020304" />
-    <style>
-:root {
-  color-scheme: dark;
-  background: #020304;
-}
-
-html,
-body,
-#root {
-  width: 100%;
-  height: 100%;
-  min-height: 100%;
-  margin: 0;
-  overflow: hidden;
-  background: #020304;
-  color: #e8ebe7;
-}
-    </style>
+    <!--
+      アンチフラッシュ CSS は inline <style> にしないこと。inline だと Tauri が
+      build 時に nonce を CSP style-src へ追記し 'unsafe-inline' が無効化され、
+      実行時に <style> を注入するライブラリ（leva/@stitches 等）が production で
+      壊れる（黒画面）。boot.css 冒頭のコメントと pitfalls/log.md 2026-07-10 を参照。
+    -->
+    <link rel="stylesheet" href="/boot.css" />
     <title>Tauri + React + Typescript</title>
   </head>
 

--- a/index.html
+++ b/index.html
@@ -6,22 +6,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#020304" />
     <style>
-      :root {
-                    color-scheme: dark;
-                    background: #020304;
-                  }
+:root {
+  color-scheme: dark;
+  background: #020304;
+}
 
-                  html,
-                  body,
-                  #root {
-                    width: 100%;
-                    height: 100%;
-                    min-height: 100%;
-                    margin: 0;
-                    overflow: hidden;
-                    background: #020304;
-                    color: #e8ebe7;
-                  }
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: #020304;
+  color: #e8ebe7;
+}
     </style>
     <title>Tauri + React + Typescript</title>
   </head>

--- a/public/boot.css
+++ b/public/boot.css
@@ -1,0 +1,26 @@
+/*
+ * Boot 時のアンチフラッシュ用スタイル（JS 読込前に適用される最小セット）。
+ *
+ * NOTE: これは意図的に index.html の inline <style> ではなく外部 CSS にしている。
+ * inline <style> があると Tauri が build 時に nonce を付与して CSP style-src に
+ * 追記し、CSP 仕様により 'unsafe-inline' が無効化される。その結果 leva
+ * (@stitches/react) など実行時に <style> を注入するライブラリが production で
+ * 全滅し、entry モジュール評価が module scope で死んで黒画面になる。
+ * 詳細: Charminal-design-record/pitfalls/log.md の 2026-07-10 エントリ。
+ */
+:root {
+  color-scheme: dark;
+  background: #020304;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: #020304;
+  color: #e8ebe7;
+}


### PR DESCRIPTION
## 問題

PR #27 以降、production build（`tauri build`）で起動直後から画面が真っ黒のままになる。dev（`tauri dev`）では再現しない。

## 原因

1. PR #27 が index.html に inline `<style>`（アンチフラッシュ CSS）を追加
2. Tauri は build 時に inline style へ nonce を付与し、CSP `style-src` に追記する
3. CSP 仕様により、nonce/hash が並ぶと `'unsafe-inline'` は**無効化**される
4. leva（@stitches/react）が実行時に注入する `<style>` がブロックされ、`appendChild(style).sheet` が null → module scope の `TypeError: null is not an object (evaluating 's.cssRules')` → **entry モジュールグラフ全体の評価が失敗**し React が mount しない（黒画面）

dev は CSP 緩和で無症状。v0.5.1 / v0.5.2 の index.html には inline style が無く、**リリース済み tag は影響なし**（影響は 2026-07-05 以降の main からの production build のみ）。

## 修正

アンチフラッシュ CSS を `public/boot.css` + `<link rel="stylesheet">` に移動し、nonce の発生源を除去（`'unsafe-inline'` が復活し、実行時 style 注入全般が動く）。index.html / boot.css 双方に再発防止コメントを記載。

## 検証

- 一時 probe（error / rejection / boot marker の画面描画）で、修正前は stitches の module-scope crash・修正後は crash 消滅 + React mount 完了を実機 debug bundle で確認
- `npm run build` pass
- 詳細な診断過程は `Charminal-design-record/pitfalls/log.md` の 2026-07-10 エントリ

🤖 Generated with [Claude Code](https://claude.com/claude-code)