### PR TITLE
Loop Reel P1: salience markers and catch-up playback

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -810,6 +810,26 @@ body,
   color: #d8fff8;
 }
 
+.loop-reel-player-live-badge {
+  flex: 0 0 auto;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(226, 232, 240, 0.13);
+  border-radius: 6px;
+  padding: 0 8px;
+  color: rgba(244, 247, 250, 0.66);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+.loop-reel-player-live-badge[data-live="true"] {
+  border-color: rgba(127, 217, 168, 0.36);
+  background: rgba(127, 217, 168, 0.13);
+  color: #dfffea;
+}
+
 .loop-reel-player-scrubber {
   position: relative;
   flex: 1 1 220px;
@@ -856,19 +876,21 @@ body,
   content: "";
 }
 
-.loop-reel-player-marker[data-phase="failed"]::before {
+.loop-reel-player-marker[data-marker="failed"]::before,
+.loop-reel-player-marker[data-marker="command-failed"]::before {
   border-top-color: #f08f8f;
 }
 
-.loop-reel-player-marker[data-phase="completed"]::before {
+.loop-reel-player-marker[data-marker="completed"]::before {
   border-top-color: #7fd9a8;
 }
 
-.loop-reel-player-marker[data-phase="blocked-on-approval"]::before {
+.loop-reel-player-marker[data-marker="blocked-on-approval"]::before,
+.loop-reel-player-marker[data-marker="intervention"]::before {
   border-top-color: #f1c56f;
 }
 
-.loop-reel-player-marker[data-phase="progress-milestone"]::before {
+.loop-reel-player-marker[data-marker="progress-milestone"]::before {
   border-top-color: #8ab4f8;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1234,13 +1234,28 @@ function App() {
       devLog: createSubsystemLog(devLog, "Perception"),
       onPresenceRestore: () => presenceRestoreRef.current(),
       recordObserved: (event) => {
-        if (event.kind !== "loop-lifecycle") return;
-        const fallbackSessionId = loopReelStore.getActiveSession() ?? DEFAULT_SESSION_ID;
-        const loopReelSessionId = loopReelStore.recordLifecycle(fallbackSessionId, event);
-        // loop_announce 起点の録画は geometry を知らずに作られるため、started 観測時に
-        // terminal 側から初期 cols/rows を seed する（store の resize dedup で冪等）。
-        if (event.phase === "started" && loopReelSessionId !== null) {
-          getTerminalRuntime(loopReelSessionId).seedLoopReelGeometry();
+        if (event.kind === "loop-lifecycle") {
+          const fallbackSessionId = loopReelStore.getActiveSession() ?? DEFAULT_SESSION_ID;
+          const loopReelSessionId = loopReelStore.recordLifecycle(fallbackSessionId, event);
+          // loop_announce 起点の録画は geometry を知らずに作られるため、started 観測時に
+          // terminal 側から初期 cols/rows を seed する（store の resize dedup で冪等）。
+          if (event.phase === "started" && loopReelSessionId !== null) {
+            getTerminalRuntime(loopReelSessionId).seedLoopReelGeometry();
+          }
+          return;
+        }
+        if (event.kind === "command-block" && event.exitCode !== null && event.exitCode !== 0) {
+          loopReelStore.recordMarker(
+            event.sessionId,
+            "command-failed",
+            event.command ?? "Command failed",
+            {
+              command: event.command,
+              exitCode: event.exitCode,
+              durationMs: event.durationMs,
+            },
+            event.timestamp,
+          );
         }
       },
     });

--- a/src/components/LoopReelPlayer.test.tsx
+++ b/src/components/LoopReelPlayer.test.tsx
@@ -1,32 +1,61 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   LoopReelPersistedMeta,
   LoopReelPersistenceController,
   LoopReelStore,
+  RecordedEntry,
   SessionRecording,
 } from "../runtime/loop-reel";
 import { LoopReelPlayer } from "./LoopReelPlayer";
+
+const replayState = vi.hoisted(() => ({
+  instances: [] as Array<{
+    readonly attachTo: ReturnType<typeof vi.fn>;
+    readonly detachContainer: ReturnType<typeof vi.fn>;
+    readonly loadStream: ReturnType<typeof vi.fn>;
+    readonly appendEntries: ReturnType<typeof vi.fn>;
+    readonly play: ReturnType<typeof vi.fn>;
+    readonly playWindow: ReturnType<typeof vi.fn>;
+    readonly pause: ReturnType<typeof vi.fn>;
+    readonly seekLinear: ReturnType<typeof vi.fn>;
+    readonly onPosition: ReturnType<typeof vi.fn>;
+    readonly setHidden: ReturnType<typeof vi.fn>;
+    readonly dispose: ReturnType<typeof vi.fn>;
+  }>,
+}));
 
 vi.mock("../runtime/loop-reel", async () => {
   const actual =
     await vi.importActual<typeof import("../runtime/loop-reel")>("../runtime/loop-reel");
   return {
     ...actual,
-    createReplayTerminal: () => ({
-      attachTo: vi.fn(),
-      detachContainer: vi.fn(),
-      loadStream: vi.fn(),
-      play: vi.fn(),
-      playWindow: vi.fn(),
-      pause: vi.fn(),
-      seekLinear: vi.fn(),
-      onPosition: vi.fn(() => ({ dispose: vi.fn() })),
-      setHidden: vi.fn(),
-      dispose: vi.fn(),
-    }),
+    createReplayTerminal: () => {
+      const replay = {
+        attachTo: vi.fn(),
+        detachContainer: vi.fn(),
+        loadStream: vi.fn(),
+        appendEntries: vi.fn(),
+        play: vi.fn(),
+        playWindow: vi.fn(),
+        pause: vi.fn(),
+        seekLinear: vi.fn(),
+        onPosition: vi.fn(() => ({ dispose: vi.fn() })),
+        setHidden: vi.fn(),
+        dispose: vi.fn(),
+      };
+      replayState.instances.push(replay);
+      return replay;
+    },
+    loadLoopReelRedactionSources: vi.fn(async () => ({
+      username: "secret",
+      homeBasename: null,
+      hostname: null,
+      gitUserName: null,
+      gitUserEmail: null,
+    })),
     resolveReplayTerminalSurface: () => {
       const surface = document.createElement("div");
       surface.getBoundingClientRect = () =>
@@ -46,21 +75,26 @@ vi.mock("../runtime/loop-reel", async () => {
   };
 });
 
-const meta = (id: string, startedAt: number): LoopReelPersistedMeta => ({
+const meta = (
+  id: string,
+  startedAt: number,
+  status: LoopReelPersistedMeta["status"] = "ended",
+): LoopReelPersistedMeta => ({
   id,
   sessionId: "default-session",
   label: id,
   kind: "agent",
   origin: "lifecycle",
   startedAt,
-  endedAt: startedAt + 100,
-  status: "ended",
+  endedAt: status === "ended" ? startedAt + 100 : null,
+  status,
 });
 
 const recording = (item: LoopReelPersistedMeta): SessionRecording => ({
   ...item,
   entries: [
     { kind: "marker", marker: "session-start", label: item.label, timestamp: item.startedAt },
+    { kind: "pty", text: "initial\n", timestamp: item.startedAt + 50 },
   ],
 });
 
@@ -74,8 +108,23 @@ function deferred<T>() {
 
 function createStore() {
   const listeners = new Set<() => void>();
+  const recordingSubscribers = new Set<{
+    readonly onEntriesAppended?: (event: {
+      readonly recordingId: string;
+      readonly meta: LoopReelPersistedMeta;
+      readonly entries: readonly RecordedEntry[];
+    }) => void;
+  }>();
   const store = {
     listMetas: vi.fn(() => []),
+    subscribeRecordingEvents: vi.fn((callbacks) => {
+      recordingSubscribers.add(callbacks);
+      return {
+        dispose: () => {
+          recordingSubscribers.delete(callbacks);
+        },
+      };
+    }),
     subscribe: vi.fn((listener: () => void) => {
       listeners.add(listener);
       return {
@@ -90,11 +139,21 @@ function createStore() {
     emit: () => {
       for (const listener of Array.from(listeners)) listener();
     },
+    emitEntries: (
+      recordingId: string,
+      item: LoopReelPersistedMeta,
+      entries: readonly RecordedEntry[],
+    ) => {
+      for (const subscriber of Array.from(recordingSubscribers)) {
+        subscriber.onEntriesAppended?.({ recordingId, meta: item, entries });
+      }
+    },
   };
 }
 
 afterEach(() => {
   cleanup();
+  replayState.instances.length = 0;
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -108,6 +167,7 @@ describe("LoopReelPlayer refresh", () => {
     const persistence = {
       initialize: vi.fn(),
       flushAll: vi.fn(() => Promise.resolve()),
+      flushRecording: vi.fn(() => Promise.resolve()),
       listRecordings: vi
         .fn<LoopReelPersistenceController["listRecordings"]>()
         .mockResolvedValueOnce([meta("initial", 100)])
@@ -158,5 +218,180 @@ describe("LoopReelPlayer refresh", () => {
       await Promise.resolve();
     });
     expect(screen.queryByRole("option", { name: /stale/ })).toBeNull();
+  });
+
+  it("keeps running recordings selectable for catch-up", async () => {
+    const { store } = createStore();
+    const persistence = {
+      initialize: vi.fn(),
+      flushAll: vi.fn(() => Promise.resolve()),
+      flushRecording: vi.fn(() => Promise.resolve()),
+      listRecordings: vi.fn(async () => [meta("active", 300, "recording")]),
+      loadRecording: vi.fn(async (id: string) => recording(meta(id, 300, "recording"))),
+      dispose: vi.fn(),
+    } satisfies LoopReelPersistenceController;
+
+    render(
+      <LoopReelPlayer
+        open
+        store={store}
+        persistence={persistence}
+        recordingActive={false}
+        onToggleRecording={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const option = screen.getByRole("option", { name: /active.*録画中/ }) as HTMLOptionElement;
+    expect(option.disabled).toBe(false);
+    expect(persistence.flushRecording).toHaveBeenCalledWith("active");
+  });
+
+  it("keeps playing when speed changes during playback", async () => {
+    const { store } = createStore();
+    const persistence = {
+      initialize: vi.fn(),
+      flushAll: vi.fn(() => Promise.resolve()),
+      flushRecording: vi.fn(() => Promise.resolve()),
+      listRecordings: vi.fn(async () => [meta("ended", 100)]),
+      loadRecording: vi.fn(async (id: string) => recording(meta(id, 100))),
+      dispose: vi.fn(),
+    } satisfies LoopReelPersistenceController;
+
+    render(
+      <LoopReelPlayer
+        open
+        store={store}
+        persistence={persistence}
+        recordingActive={false}
+        onToggleRecording={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Play Loop Reel" }));
+    expect(screen.getByRole("button", { name: "Pause Loop Reel" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "2x" }));
+
+    expect(screen.getByRole("button", { name: "Pause Loop Reel" })).toBeTruthy();
+    expect(replayState.instances[0].playWindow).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      2,
+      expect.any(Function),
+    );
+  });
+
+  it("coalesces live tail state while appending RAW replay entries immediately", async () => {
+    vi.useFakeTimers();
+    const active = meta("active", 100, "recording");
+    const { store, emitEntries } = createStore();
+    const persistence = {
+      initialize: vi.fn(),
+      flushAll: vi.fn(() => Promise.resolve()),
+      flushRecording: vi.fn(() => Promise.resolve()),
+      listRecordings: vi.fn(async () => [active]),
+      loadRecording: vi.fn(async () => recording(active)),
+      dispose: vi.fn(),
+    } satisfies LoopReelPersistenceController;
+
+    render(
+      <LoopReelPlayer
+        open
+        store={store}
+        persistence={persistence}
+        recordingActive={false}
+        onToggleRecording={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const replay = replayState.instances[0];
+
+    act(() => {
+      emitEntries("active", active, [
+        { kind: "marker", marker: "command-failed", label: "first fail", timestamp: 180 },
+      ]);
+      emitEntries("active", active, [
+        { kind: "marker", marker: "command-failed", label: "second fail", timestamp: 190 },
+      ]);
+    });
+
+    expect(replay.appendEntries).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole("button", { name: "Jump to first fail" })).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    expect(screen.getByRole("button", { name: "Jump to first fail" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Jump to second fail" })).toBeTruthy();
+  });
+
+  it("reloads the full stream for MASKED live tail instead of appending chunks", async () => {
+    vi.useFakeTimers();
+    const active = meta("active", 100, "recording");
+    const { store, emitEntries } = createStore();
+    const persistence = {
+      initialize: vi.fn(),
+      flushAll: vi.fn(() => Promise.resolve()),
+      flushRecording: vi.fn(() => Promise.resolve()),
+      listRecordings: vi.fn(async () => [active]),
+      loadRecording: vi.fn(async () => recording(active)),
+      dispose: vi.fn(),
+    } satisfies LoopReelPersistenceController;
+
+    render(
+      <LoopReelPlayer
+        open
+        store={store}
+        persistence={persistence}
+        recordingActive={false}
+        onToggleRecording={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const replay = replayState.instances[0];
+    replay.loadStream.mockClear();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Toggle Loop Reel mask" }));
+      await Promise.resolve();
+    });
+    replay.loadStream.mockClear();
+
+    act(() => {
+      emitEntries("active", active, [{ kind: "pty", text: "sec", timestamp: 180 }]);
+      emitEntries("active", active, [{ kind: "pty", text: "ret\n", timestamp: 190 }]);
+    });
+
+    expect(replay.appendEntries).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(replay.loadStream).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(replay.loadStream).toHaveBeenCalledTimes(1);
+    expect(replay.seekLinear).toHaveBeenCalled();
   });
 });

--- a/src/components/LoopReelPlayer.tsx
+++ b/src/components/LoopReelPlayer.tsx
@@ -23,7 +23,9 @@ import {
   buildIterationClips,
   clampTimestamp,
   createReplayTerminal,
-  endedLoopReelMetas,
+  getLoopReelLastSeenMap,
+  isAtLiveEdge,
+  LOOP_REEL_TUNING,
   type LoopReelPersistedMeta,
   type LoopReelPersistenceController,
   type LoopReelRedactionSources,
@@ -32,13 +34,15 @@ import {
   mergeLoopReelMetas,
   nextClipTimestamp,
   nextFailedTimestamp,
-  phaseMarkersOfRecording,
   previousClipTimestamp,
+  type RecordedEntry,
   type ReplayTerminal,
   recordingTimeRange,
   redactLoopReelRecording,
+  resolveCatchUpStart,
   resolveReplayTerminalSurface,
   type SessionRecording,
+  scrubberMarkersOfRecording,
 } from "../runtime/loop-reel";
 
 interface LoopReelPlayerProps {
@@ -67,15 +71,14 @@ const EMPTY_REDACTION_SOURCES: LoopReelRedactionSources = {
   gitUserEmail: null,
 };
 
-// 実機調整前提: placement と操作感の値は dogfooding 後にまとめて詰める。
 const PLAYER_UI = {
-  surfaceRetryMs: 250,
-  refreshDebounceMs: 300,
-  controlBarHeight: 46,
-  markerSize: 9,
+  surfaceRetryMs: LOOP_REEL_TUNING.surfaceRetryMs,
+  refreshDebounceMs: LOOP_REEL_TUNING.refreshDebounceMs,
+  controlBarHeight: LOOP_REEL_TUNING.controlBarHeight,
+  markerSize: LOOP_REEL_TUNING.markerSize,
 } as const;
 
-const PLAYER_SPEEDS = [1, 2, 4] as const;
+const PLAYER_SPEEDS = LOOP_REEL_TUNING.playbackSpeeds;
 
 export function LoopReelPlayer({
   open,
@@ -87,13 +90,27 @@ export function LoopReelPlayer({
 }: LoopReelPlayerProps) {
   const replayRef = useRef<ReplayTerminal | null>(null);
   const positionRef = useRef(0);
+  const speedRef = useRef<(typeof PLAYER_SPEEDS)[number]>(1);
   const redactionRequestRef = useRef<Promise<LoopReelRedactionSources> | null>(null);
+  const redactionEnabledRef = useRef(false);
+  const redactionSourcesRef = useRef<LoopReelRedactionSources | null>(null);
+  const recordingRef = useRef<SessionRecording | null>(null);
+  const selectedIdRef = useRef<string | null>(null);
   const refreshRequestIdRef = useRef(0);
   const refreshTimerRef = useRef<number | null>(null);
+  const liveTailBufferRef = useRef<RecordedEntry[]>([]);
+  const liveTailBufferConsumedRef = useRef(false);
+  const pendingLiveStateEntriesRef = useRef(new Map<string, RecordedEntry[]>());
+  const liveStateFlushTimerRef = useRef<number | null>(null);
+  const maskedReloadTimerRef = useRef<number | null>(null);
+  const pendingCatchUpAutoplayRef = useRef(false);
+  const speedTouchedRef = useRef(false);
+  const rememberCatchUpPositionRef = useRef<() => void>(() => {});
   const [surfaceBox, setSurfaceBox] = useState<SurfaceBox | null>(null);
   const [metas, setMetas] = useState<readonly LoopReelPersistedMeta[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [recording, setRecording] = useState<SessionRecording | null>(null);
+  const [streamLoadVersion, setStreamLoadVersion] = useState(0);
   const [position, setPosition] = useState(0);
   const [speed, setSpeed] = useState<(typeof PLAYER_SPEEDS)[number]>(1);
   const [playing, setPlaying] = useState(false);
@@ -104,25 +121,93 @@ export function LoopReelPlayer({
   const [redactionSources, setRedactionSources] = useState<LoopReelRedactionSources | null>(null);
   const [redactionLoading, setRedactionLoading] = useState(false);
 
-  const endedMetas = useMemo(() => endedLoopReelMetas(metas), [metas]);
+  const lastSeenMap = useMemo(() => getLoopReelLastSeenMap(), []);
+  const selectedMeta = useMemo(
+    () => metas.find((meta) => meta.id === selectedId) ?? null,
+    [metas, selectedId],
+  );
+  const catchUpMode = selectedMeta?.status === "recording";
   const displayRecording = useMemo(() => {
     if (!recording || !redactionEnabled) return recording;
     return redactLoopReelRecording(recording, redactionSources ?? EMPTY_REDACTION_SOURCES);
   }, [recording, redactionEnabled, redactionSources]);
   const range = useMemo(() => (recording ? recordingTimeRange(recording) : null), [recording]);
   const clips = useMemo(() => (recording ? buildIterationClips(recording) : []), [recording]);
-  const markers = useMemo(() => (recording ? phaseMarkersOfRecording(recording) : []), [recording]);
+  const markers = useMemo(
+    () => (recording ? scrubberMarkersOfRecording(recording) : []),
+    [recording],
+  );
   const previousClip = useMemo(() => previousClipTimestamp(clips, position), [clips, position]);
   const nextClip = useMemo(() => nextClipTimestamp(clips, position), [clips, position]);
   const nextFailed = useMemo(
     () => (recording ? nextFailedTimestamp(recording, position) : null),
     [recording, position],
   );
+  const liveEdge = range?.toTs ?? 0;
+  const atLiveEdge =
+    catchUpMode && range
+      ? isAtLiveEdge(position, liveEdge, LOOP_REEL_TUNING.liveEdgeToleranceMs)
+      : false;
 
   const setCurrentPosition = useCallback((timestamp: number) => {
     positionRef.current = timestamp;
     setPosition(timestamp);
   }, []);
+
+  useEffect(() => {
+    speedRef.current = speed;
+  }, [speed]);
+
+  useEffect(() => {
+    redactionEnabledRef.current = redactionEnabled;
+    redactionSourcesRef.current = redactionSources;
+  }, [redactionEnabled, redactionSources]);
+
+  useEffect(() => {
+    selectedIdRef.current = selectedId;
+  }, [selectedId]);
+
+  useEffect(() => {
+    recordingRef.current = recording;
+  }, [recording]);
+
+  const markSeenAtEdge = useCallback(
+    (target: SessionRecording, edge: number) => {
+      lastSeenMap.set(target.sessionId, edge);
+    },
+    [lastSeenMap],
+  );
+
+  const isWithinLiveEdge = useCallback(
+    (timestamp: number, edge: number) =>
+      isAtLiveEdge(timestamp, edge, LOOP_REEL_TUNING.liveEdgeToleranceMs),
+    [],
+  );
+
+  const finishCatchUpAtEdge = useCallback(
+    (target: SessionRecording, edge: number) => {
+      setPlaying(false);
+      setCurrentPosition(edge);
+      markSeenAtEdge(target, edge);
+    },
+    [markSeenAtEdge, setCurrentPosition],
+  );
+
+  const rememberCatchUpPosition = useCallback(() => {
+    if (!recording || !range || !catchUpMode) return;
+    lastSeenMap.set(recording.sessionId, clampTimestamp(positionRef.current, range));
+  }, [catchUpMode, lastSeenMap, range, recording]);
+
+  useEffect(() => {
+    rememberCatchUpPositionRef.current = rememberCatchUpPosition;
+  }, [rememberCatchUpPosition]);
+
+  useEffect(() => {
+    if (!open) return;
+    return () => {
+      rememberCatchUpPositionRef.current();
+    };
+  }, [open]);
 
   const refreshList = useCallback(
     async (options: { flush: boolean; showLoading: boolean }) => {
@@ -135,11 +220,10 @@ export function LoopReelPlayer({
         const persisted = await persistence.listRecordings();
         const merged = mergeLoopReelMetas(persisted, store.listMetas());
         if (requestId !== refreshRequestIdRef.current) return;
-        const ended = endedLoopReelMetas(merged);
         setMetas(merged);
         setSelectedId((current) => {
-          if (current && ended.some((meta) => meta.id === current)) return current;
-          return ended[0]?.id ?? null;
+          if (current && merged.some((meta) => meta.id === current)) return current;
+          return merged[0]?.id ?? null;
         });
       } catch (err) {
         if (requestId === refreshRequestIdRef.current) {
@@ -154,10 +238,66 @@ export function LoopReelPlayer({
     [persistence, store],
   );
 
+  const flushPendingLiveState = useCallback(() => {
+    liveStateFlushTimerRef.current = null;
+    const targetId = selectedIdRef.current;
+    if (!targetId) return;
+    const entries = pendingLiveStateEntriesRef.current.get(targetId);
+    if (!entries || entries.length === 0) return;
+    pendingLiveStateEntriesRef.current.delete(targetId);
+    setRecording((current) =>
+      current?.id === targetId ? appendRecordingEntries(current, entries) : current,
+    );
+  }, []);
+
+  const queueLiveStateAppend = useCallback(
+    (recordingId: string, entries: readonly RecordedEntry[]) => {
+      if (entries.length === 0) return;
+      const pending = pendingLiveStateEntriesRef.current.get(recordingId) ?? [];
+      pending.push(...entries);
+      pendingLiveStateEntriesRef.current.set(recordingId, pending);
+      if (liveStateFlushTimerRef.current !== null) return;
+      liveStateFlushTimerRef.current = window.setTimeout(
+        flushPendingLiveState,
+        LOOP_REEL_TUNING.liveTailStateCoalesceMs,
+      );
+    },
+    [flushPendingLiveState],
+  );
+
+  const scheduleMaskedStreamReload = useCallback(() => {
+    if (maskedReloadTimerRef.current !== null) {
+      window.clearTimeout(maskedReloadTimerRef.current);
+    }
+    maskedReloadTimerRef.current = window.setTimeout(() => {
+      maskedReloadTimerRef.current = null;
+      setStreamLoadVersion((version) => version + 1);
+    }, LOOP_REEL_TUNING.maskedLiveTailReloadDebounceMs);
+  }, []);
+
+  const clearLiveTailTimers = useCallback(() => {
+    if (liveStateFlushTimerRef.current !== null) {
+      window.clearTimeout(liveStateFlushTimerRef.current);
+      liveStateFlushTimerRef.current = null;
+    }
+    if (maskedReloadTimerRef.current !== null) {
+      window.clearTimeout(maskedReloadTimerRef.current);
+      maskedReloadTimerRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     if (!open) return;
     setRedactionEnabled(false);
     setPlaying(false);
+    setRecording(null);
+    recordingRef.current = null;
+    setStreamLoadVersion(0);
+    pendingLiveStateEntriesRef.current.clear();
+    liveTailBufferRef.current = [];
+    liveTailBufferConsumedRef.current = false;
+    clearLiveTailTimers();
+    speedTouchedRef.current = false;
     void refreshList({ flush: true, showLoading: true });
     const subscription = store.subscribe(() => {
       // 実機調整前提: PTY append ごとの点滅を避け、一覧更新だけを trailing でまとめる。
@@ -173,9 +313,11 @@ export function LoopReelPlayer({
         window.clearTimeout(refreshTimerRef.current);
         refreshTimerRef.current = null;
       }
+      pendingLiveStateEntriesRef.current.clear();
+      clearLiveTailTimers();
       subscription.dispose();
     };
-  }, [open, refreshList, store]);
+  }, [clearLiveTailTimers, open, refreshList, store]);
 
   useEffect(() => {
     if (!open) return;
@@ -230,24 +372,80 @@ export function LoopReelPlayer({
   }, [open, setCurrentPosition]);
 
   useEffect(() => {
+    liveTailBufferRef.current = [];
+    liveTailBufferConsumedRef.current = false;
+    pendingLiveStateEntriesRef.current.clear();
+    clearLiveTailTimers();
+    if (!open || !selectedId || selectedMeta?.status !== "recording") return;
+    const subscription = store.subscribeRecordingEvents({
+      onEntriesAppended: (event) => {
+        if (event.recordingId !== selectedId) return;
+        const entries = [...event.entries];
+        if (!liveTailBufferConsumedRef.current) {
+          liveTailBufferRef.current.push(...entries);
+          return;
+        }
+
+        const currentRecording = recordingRef.current;
+        if (!currentRecording || currentRecording.id !== selectedId) return;
+        if (redactionEnabledRef.current) {
+          queueLiveStateAppend(selectedId, entries);
+          scheduleMaskedStreamReload();
+          return;
+        }
+        replayRef.current?.appendEntries(entries);
+        queueLiveStateAppend(selectedId, entries);
+      },
+    });
+    return () => subscription.dispose();
+  }, [
+    clearLiveTailTimers,
+    open,
+    queueLiveStateAppend,
+    scheduleMaskedStreamReload,
+    selectedId,
+    selectedMeta?.status,
+    store,
+  ]);
+
+  useEffect(() => {
     if (!open || !selectedId) {
       setRecording(null);
       return;
     }
     let cancelled = false;
+    const isCatchUpSelection = selectedMeta?.status === "recording";
     setLoadingRecording(true);
     setError(null);
-    void persistence
-      .loadRecording(selectedId)
+    void (async () => {
+      if (isCatchUpSelection) await persistence.flushRecording(selectedId);
+      return persistence.loadRecording(selectedId);
+    })()
       .then((loaded) => {
         if (cancelled) return;
-        setRecording(loaded);
         if (!loaded) {
           setError("Loop Reel recording not found.");
           return;
         }
-        const nextRange = recordingTimeRange(loaded);
-        setCurrentPosition(nextRange.fromTs);
+        const bufferedTail = liveTailBufferRef.current;
+        liveTailBufferRef.current = [];
+        const loadedWithTail =
+          isCatchUpSelection && bufferedTail.length > 0
+            ? appendRecordingEntries(loaded, bufferedTail)
+            : loaded;
+        recordingRef.current = loadedWithTail;
+        liveTailBufferConsumedRef.current = true;
+        setRecording(loadedWithTail);
+        const nextRange = recordingTimeRange(loadedWithTail);
+        const start = isCatchUpSelection
+          ? clampTimestamp(resolveCatchUpStart(lastSeenMap, loadedWithTail), nextRange)
+          : nextRange.fromTs;
+        if (!speedTouchedRef.current) {
+          setSpeed(isCatchUpSelection ? LOOP_REEL_TUNING.catchUpDefaultSpeed : 1);
+        }
+        pendingCatchUpAutoplayRef.current = isCatchUpSelection;
+        setCurrentPosition(start);
+        setStreamLoadVersion((version) => version + 1);
       })
       .catch((err) => {
         if (!cancelled) setError(`Loop Reel load failed: ${stringifyError(err)}`);
@@ -258,25 +456,57 @@ export function LoopReelPlayer({
     return () => {
       cancelled = true;
     };
-  }, [open, persistence, selectedId, setCurrentPosition]);
+  }, [lastSeenMap, open, persistence, selectedId, selectedMeta?.status, setCurrentPosition]);
 
   useEffect(() => {
+    if (streamLoadVersion === 0) return;
     const replay = replayRef.current;
-    if (!open || !displayRecording || !replay) return;
-    const nextRange = recordingTimeRange(displayRecording);
+    const currentRecording = recordingRef.current;
+    if (!open || !currentRecording || !replay) return;
+    const streamRecording =
+      redactionEnabled && redactionSources
+        ? redactLoopReelRecording(currentRecording, redactionSources)
+        : currentRecording;
+    const nextRange = recordingTimeRange(streamRecording);
     const timestamp = clampTimestamp(positionRef.current, nextRange);
-    replay.loadStream(displayRecording);
+    replay.loadStream(streamRecording, {
+      maxGapMs: catchUpMode ? LOOP_REEL_TUNING.catchUpMaxGapMs : undefined,
+    });
     replay.seekLinear(timestamp);
     replay.setHidden(false);
     setCurrentPosition(timestamp);
     setPlaying(false);
-  }, [displayRecording, open, setCurrentPosition]);
+    if (!catchUpMode || !pendingCatchUpAutoplayRef.current) return;
+    pendingCatchUpAutoplayRef.current = false;
+    if (isWithinLiveEdge(timestamp, nextRange.toTs)) {
+      markSeenAtEdge(currentRecording, nextRange.toTs);
+      return;
+    }
+    const nextSpeed = speedTouchedRef.current
+      ? speedRef.current
+      : LOOP_REEL_TUNING.catchUpDefaultSpeed;
+    replay.playWindow(timestamp, nextRange.toTs, nextSpeed, () => {
+      finishCatchUpAtEdge(currentRecording, nextRange.toTs);
+    });
+    setPlaying(true);
+  }, [
+    catchUpMode,
+    finishCatchUpAtEdge,
+    isWithinLiveEdge,
+    markSeenAtEdge,
+    open,
+    redactionEnabled,
+    redactionSources,
+    setCurrentPosition,
+    streamLoadVersion,
+  ]);
 
   useEffect(() => {
     if (!open) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       event.preventDefault();
+      rememberCatchUpPositionRef.current();
       onClose();
     };
     window.addEventListener("keydown", onKeyDown, { capture: true });
@@ -299,22 +529,57 @@ export function LoopReelPlayer({
   const playFromCurrent = useCallback(
     (nextSpeed = speed) => {
       if (!range || !displayRecording) return;
-      const start = positionRef.current >= range.toTs ? range.fromTs : positionRef.current;
-      replayRef.current?.loadStream(displayRecording);
+      const start =
+        positionRef.current >= range.toTs
+          ? catchUpMode
+            ? range.toTs
+            : range.fromTs
+          : positionRef.current;
+      if (catchUpMode && isWithinLiveEdge(start, range.toTs)) {
+        replayRef.current?.seekLinear(range.toTs);
+        if (recording) {
+          finishCatchUpAtEdge(recording, range.toTs);
+        } else {
+          setPlaying(false);
+          setCurrentPosition(range.toTs);
+        }
+        return;
+      }
+      replayRef.current?.loadStream(displayRecording, {
+        maxGapMs: catchUpMode ? LOOP_REEL_TUNING.catchUpMaxGapMs : undefined,
+      });
       replayRef.current?.playWindow(start, range.toTs, nextSpeed, () => {
-        setPlaying(false);
-        setCurrentPosition(range.toTs);
+        if (catchUpMode && recording) {
+          finishCatchUpAtEdge(recording, range.toTs);
+        } else {
+          setPlaying(false);
+          setCurrentPosition(range.toTs);
+        }
       });
       setCurrentPosition(start);
       setPlaying(true);
     },
-    [displayRecording, range, setCurrentPosition, speed],
+    [
+      catchUpMode,
+      displayRecording,
+      finishCatchUpAtEdge,
+      isWithinLiveEdge,
+      range,
+      recording,
+      setCurrentPosition,
+      speed,
+    ],
   );
 
   const pause = useCallback(() => {
     replayRef.current?.pause();
     setPlaying(false);
   }, []);
+
+  const closePlayer = useCallback(() => {
+    rememberCatchUpPosition();
+    onClose();
+  }, [onClose, rememberCatchUpPosition]);
 
   const toggleRedaction = useCallback(async () => {
     if (redactionEnabled) {
@@ -338,11 +603,12 @@ export function LoopReelPlayer({
 
   if (!open) return null;
 
-  const hasPlayableRecording = endedMetas.length > 0;
-  const inactiveReason =
-    metas.length === 0
-      ? "No loop recordings yet."
-      : "Recording is still in progress. Finished recordings can be replayed here.";
+  const emptyMessage =
+    loadingList && metas.length === 0
+      ? "Loading..."
+      : metas.length === 0
+        ? "No loop recordings yet. Running recordings can be followed with catch-up."
+        : null;
 
   return (
     <div
@@ -353,9 +619,7 @@ export function LoopReelPlayer({
       <div className="loop-reel-player-status" data-visible={error ? "true" : "false"}>
         {error}
       </div>
-      {!hasPlayableRecording ? (
-        <div className="loop-reel-player-empty">{loadingList ? "Loading..." : inactiveReason}</div>
-      ) : null}
+      {emptyMessage ? <div className="loop-reel-player-empty">{emptyMessage}</div> : null}
       <div className="loop-reel-player-controls" style={{ minHeight: PLAYER_UI.controlBarHeight }}>
         <button
           type="button"
@@ -377,7 +641,9 @@ export function LoopReelPlayer({
           className="loop-reel-player-select"
           value={selectedId ?? ""}
           onChange={(event) => {
+            rememberCatchUpPosition();
             pause();
+            pendingCatchUpAutoplayRef.current = false;
             setSelectedId(event.currentTarget.value || null);
           }}
           disabled={loadingList}
@@ -385,15 +651,16 @@ export function LoopReelPlayer({
         >
           {metas.length === 0 ? <option value="">No recordings</option> : null}
           {metas.map((meta) => (
-            <option
-              key={meta.id}
-              value={meta.status === "ended" ? meta.id : ""}
-              disabled={meta.status !== "ended"}
-            >
+            <option key={meta.id} value={meta.id}>
               {formatRecordingOption(meta)}
             </option>
           ))}
         </select>
+        {catchUpMode ? (
+          <span className="loop-reel-player-live-badge" data-live={atLiveEdge ? "true" : "false"}>
+            {atLiveEdge ? "LIVE" : "CATCH-UP"}
+          </span>
+        ) : null}
         <IconButton
           label={playing ? "Pause Loop Reel" : "Play Loop Reel"}
           disabled={!recording || loadingRecording}
@@ -408,6 +675,7 @@ export function LoopReelPlayer({
               type="button"
               className={value === speed ? "is-active" : ""}
               onClick={() => {
+                speedTouchedRef.current = true;
                 setSpeed(value);
                 if (playing) playFromCurrent(value);
               }}
@@ -424,17 +692,17 @@ export function LoopReelPlayer({
             {range
               ? markers.map((marker) => (
                   <button
-                    key={`${marker.phase}-${marker.timestamp}`}
+                    key={`${marker.kind}-${marker.marker}-${marker.timestamp}`}
                     type="button"
                     className="loop-reel-player-marker"
-                    data-phase={marker.phase}
+                    data-marker={marker.marker}
                     style={{
                       left: `${markerLeft(marker.timestamp, range.fromTs, range.toTs)}%`,
                       width: PLAYER_UI.markerSize,
                       height: PLAYER_UI.markerSize,
                     }}
-                    aria-label={`Jump to ${marker.phase}`}
-                    title={marker.phase}
+                    aria-label={`Jump to ${marker.label ?? marker.marker}`}
+                    title={marker.label ?? marker.marker}
                     onClick={() => seekTo(marker.timestamp)}
                   />
                 ))
@@ -500,7 +768,7 @@ export function LoopReelPlayer({
           )}
           <span>{redactionEnabled ? "MASKED" : "RAW"}</span>
         </button>
-        <IconButton label="Close Loop Reel" onClick={onClose}>
+        <IconButton label="Close Loop Reel" onClick={closePlayer}>
           <X size={15} aria-hidden="true" />
         </IconButton>
       </div>
@@ -528,6 +796,14 @@ function IconButton({ label, disabled = false, onClick, children }: IconButtonPr
       {children}
     </button>
   );
+}
+
+function appendRecordingEntries(
+  recording: SessionRecording,
+  entries: readonly RecordedEntry[],
+): SessionRecording {
+  if (entries.length === 0) return recording;
+  return { ...recording, entries: [...recording.entries, ...entries] };
 }
 
 const sameSurfaceBox = (a: SurfaceBox | null, b: SurfaceBox): boolean =>

--- a/src/core/perception/perception.test.ts
+++ b/src/core/perception/perception.test.ts
@@ -134,6 +134,23 @@ describe("Perception", () => {
       }
     });
 
+    it("calls recordObserved after dispatch for command blocks", () => {
+      const recordObserved = vi.fn();
+      const { perception, dispatched } = createStack({ recordObserved });
+      clockMs = 2500;
+
+      perception.onCommandBlock({
+        command: "npm test",
+        exitCode: 1,
+        durationMs: 1200,
+        sessionId: "shell-1",
+      });
+
+      expect(dispatched).toHaveLength(1);
+      expect(recordObserved).toHaveBeenCalledOnce();
+      expect(recordObserved).toHaveBeenCalledWith(dispatched[0]);
+    });
+
     it("does not dispatch after dispose", () => {
       const { perception, dispatched } = createStack();
       perception.dispose();
@@ -475,7 +492,7 @@ describe("Perception", () => {
       expect(dispatched).toHaveLength(0);
     });
 
-    it("calls recordObserved after dispatch for loop lifecycle only", () => {
+    it("calls recordObserved after dispatch for loop lifecycle", () => {
       const recordObserved = vi.fn();
       const { perception, dispatched } = createStack({ recordObserved });
       clockMs = 5000;

--- a/src/core/perception/perception.ts
+++ b/src/core/perception/perception.ts
@@ -45,7 +45,7 @@ export interface PerceptionDeps {
   readonly devLog?: SubsystemLog;
   /** user-prompt-submit 検知時に呼ばれる。Presence を full に復帰する。 */
   readonly onPresenceRestore?: () => void;
-  /** Loop Reel など、dispatch 済み観察 event の追加記録 hook。P0 は loop-lifecycle のみ呼ぶ。 */
+  /** Loop Reel など、dispatch 済み観察 event の追加記録 hook。 */
   readonly recordObserved?: (event: DispatchEvent) => void;
 }
 
@@ -197,6 +197,7 @@ export class Perception {
       timestamp: this.time.now(),
     };
     this.bus.dispatch(event);
+    this.recordObserved?.(event);
   }
 
   /**

--- a/src/runtime/loop-reel/README.md
+++ b/src/runtime/loop-reel/README.md
@@ -1,10 +1,13 @@
-# Loop Reel P0
+# Loop Reel P1
 
-Loop Reel は、自律 loop の lifecycle と live PTY output を host 側で観察し、あとから手動で再生するための記録層です。
+Loop Reel は、自律 loop の lifecycle と live PTY output を host 側で観察し、あとから手動 replay / catch-up するための記録層です。
 
-- 記録対象: PTY text、terminal resize、session marker、loop phase。highlight / digest / voice / cinema 自動再生は P0 対象外。
+- 記録対象: PTY text、terminal resize、session marker、loop phase。marker は session 系に加えて user intervention / failed command を持ちます。highlight / digest / voice / cinema 自動再生は対象外。
 - 永続化先: `~/.yorishiro/loop-reels/<recording-id>/meta.json` と `entries.jsonl`。player を開くまでは entries を読みません。
+- 録画中 recording は catch-up で選択できます。開始時に対象 recording だけ flush して disk 全量を読み、以後の live tail は store の append event を replay terminal へ合流します。
+- catch-up は dead-time gap を短く圧縮して既定 2x で自動再生し、live edge に到達したら pause します。新 entry への自動追従再生はしません。
 - store / disk は常に raw を保持します。redaction は player が replay terminal へ渡す直前の view 変換で、raw 記録を書き換えません。
 - redaction source は Rust command から username / home basename / hostname / global git user name / email を取得し、同じ文字数の `*` で置換します。
 - replay は PTY に接続しない xterm overlay です。live PTY は止めず、入力も送りません。
 - iteration clips は phase entry から導出します。phase entry が無い手動録画では clip を捏造せず、scrub / play だけを提供します。
+- 既知制限: lifecycle 録画の session 帰属が fallback session になった場合、別 sessionId の command-block marker は active recording に紐づかず drop されます。

--- a/src/runtime/loop-reel/constants.ts
+++ b/src/runtime/loop-reel/constants.ts
@@ -1,0 +1,15 @@
+// 実機調整前提: Loop Reel の操作感に関わる値はここへ集約する。
+export const LOOP_REEL_TUNING = {
+  replayMaxGapMs: 1800,
+  catchUpMaxGapMs: 400,
+  interventionMarkerThrottleMs: 5000,
+  catchUpDefaultSpeed: 2,
+  liveEdgeToleranceMs: 250,
+  maskedLiveTailReloadDebounceMs: 500,
+  liveTailStateCoalesceMs: 250,
+  surfaceRetryMs: 250,
+  refreshDebounceMs: 300,
+  controlBarHeight: 46,
+  markerSize: 9,
+  playbackSpeeds: [1, 2, 4],
+} as const;

--- a/src/runtime/loop-reel/index.ts
+++ b/src/runtime/loop-reel/index.ts
@@ -1,4 +1,6 @@
+export { LOOP_REEL_TUNING } from "./constants";
 export { buildIterationClips } from "./iteration-clips";
+export { getLoopReelLastSeenMap } from "./last-seen";
 export { getLoopReelStore, type LoopReelStore } from "./loop-reel-store";
 export {
   createLoopReelPersistence,
@@ -7,19 +9,21 @@ export {
 } from "./persistence";
 export {
   clampTimestamp,
-  endedLoopReelMetas,
+  isAtLiveEdge,
   mergeLoopReelMetas,
   nextClipTimestamp,
   nextFailedTimestamp,
-  phaseMarkersOfRecording,
   previousClipTimestamp,
   recordingTimeRange,
+  resolveCatchUpStart,
+  scrubberMarkersOfRecording,
 } from "./player-state";
 export {
   type LoopReelRedactionSources,
   loadLoopReelRedactionSources,
+  redactLoopReelEntries,
   redactLoopReelRecording,
 } from "./redaction";
 export { resolveReplayTerminalSurface } from "./replay-surface";
 export { createReplayTerminal, type ReplayTerminal } from "./replay-terminal";
-export type { SessionRecording } from "./types";
+export type { RecordedEntry, SessionRecording } from "./types";

--- a/src/runtime/loop-reel/last-seen.ts
+++ b/src/runtime/loop-reel/last-seen.ts
@@ -1,0 +1,7 @@
+import { getOrInit } from "../hot-data";
+import { KEYS } from "../module-registry/keys";
+
+/** hot-data Map。catch-up 視聴位置はアプリ再起動では消えてよい。 */
+export function getLoopReelLastSeenMap(): Map<string, number> {
+  return getOrInit(KEYS.LOOP_REEL_LAST_SEEN, () => new Map<string, number>());
+}

--- a/src/runtime/loop-reel/loop-reel-store.test.ts
+++ b/src/runtime/loop-reel/loop-reel-store.test.ts
@@ -457,6 +457,72 @@ describe("LoopReelStore as session recorder", () => {
     ]);
   });
 
+  it("throttles noisy intervention markers per active recording", () => {
+    const store = createLoopReelStore();
+
+    store.startSession("default-session", { label: "claude", kind: "agent", timestamp: 100 });
+    store.recordMarker("default-session", "intervention", undefined, { length: 1 }, 1000);
+    store.recordMarker("default-session", "intervention", undefined, { length: 2 }, 5999);
+    store.recordMarker("default-session", "intervention", undefined, { length: 3 }, 6000);
+    store.recordMarker("default-session", "command-failed", "npm test", { exitCode: 1 }, 6001);
+
+    const markers = store
+      .list()[0]
+      .entries.filter((entry) => entry.kind === "marker")
+      .map((entry) => ({
+        marker: entry.marker,
+        label: entry.label,
+        detail: entry.detail,
+        timestamp: entry.timestamp,
+      }));
+    expect(markers).toEqual([
+      {
+        marker: "session-start",
+        label: "claude",
+        detail: undefined,
+        timestamp: 100,
+      },
+      {
+        marker: "intervention",
+        label: "User intervention",
+        detail: { length: 1 },
+        timestamp: 1000,
+      },
+      {
+        marker: "intervention",
+        label: "User intervention",
+        detail: { length: 3 },
+        timestamp: 6000,
+      },
+      {
+        marker: "command-failed",
+        label: "npm test",
+        detail: { exitCode: 1 },
+        timestamp: 6001,
+      },
+    ]);
+  });
+
+  it("resets intervention throttle state for a new recording on the same session", () => {
+    const store = createLoopReelStore();
+
+    store.startSession("default-session", { label: "first", kind: "agent", timestamp: 100 });
+    store.recordMarker("default-session", "intervention", undefined, { length: 1 }, 1000);
+    store.endSession("default-session", 1200);
+    store.startSession("default-session", { label: "second", kind: "agent", timestamp: 1500 });
+    store.recordMarker("default-session", "intervention", undefined, { length: 2 }, 1501);
+
+    const [second] = store.list();
+    expect(second.label).toBe("second");
+    expect(second.entries).toContainEqual({
+      kind: "marker",
+      marker: "intervention",
+      label: "User intervention",
+      detail: { length: 2 },
+      timestamp: 1501,
+    });
+  });
+
   it("drops old pty entries at the cap, warns once, and keeps structured markers", () => {
     const warn = vi.fn();
     const store = createLoopReelStore({ maxEntriesPerRecording: 4, warn });
@@ -507,6 +573,25 @@ describe("LoopReelStore as session recorder", () => {
       [{ kind: "pty", text: "middle\n", timestamp: 120 }],
       [{ kind: "pty", text: "new\n", timestamp: 130 }],
     ]);
+  });
+
+  it("reuses one cloned entry array for append callbacks and subscribers", () => {
+    const callbackAppended = vi.fn();
+    const subscriberAppended = vi.fn();
+    const store = createLoopReelStore({
+      callbacks: { onEntriesAppended: callbackAppended },
+    });
+    store.subscribeRecordingEvents({ onEntriesAppended: subscriberAppended });
+
+    store.startSession("default-session", { label: "codex", kind: "agent", timestamp: 100 });
+    store.recordPty("default-session", "hello\n", 110);
+
+    expect(callbackAppended).toHaveBeenCalledTimes(2);
+    expect(subscriberAppended).toHaveBeenCalledTimes(2);
+    expect(callbackAppended.mock.calls[1][0].entries).toBe(
+      subscriberAppended.mock.calls[1][0].entries,
+    );
+    expect(callbackAppended.mock.calls[1][0].entries).not.toBe(store.list()[0].entries);
   });
 
   it("evicts the oldest ended recordings at the recording cap", () => {

--- a/src/runtime/loop-reel/loop-reel-store.ts
+++ b/src/runtime/loop-reel/loop-reel-store.ts
@@ -3,6 +3,7 @@ import { Time } from "../../core/time";
 import { getOrInit } from "../hot-data";
 import { KEYS } from "../module-registry/keys";
 import type { SessionId, SessionKind } from "../sessions/types";
+import { LOOP_REEL_TUNING } from "./constants";
 import type {
   LoopMarker,
   RecordedEntry,
@@ -71,7 +72,7 @@ export interface LoopReelStore {
   recordMarker(
     sessionId: SessionId,
     marker: SessionTimelineMarker,
-    label: string,
+    label?: string,
     detail?: unknown,
     timestamp?: number,
   ): void;
@@ -127,6 +128,7 @@ class LoopReelStoreImpl implements LoopReelStore {
   private readonly time: LoopReelClock;
   private readonly callbacks: LoopReelStoreCallbacks;
   private readonly recordingEventSubscribers = new Set<LoopReelStoreCallbacks>();
+  private readonly lastInterventionBySessionId = new Map<SessionId, number>();
   private activeSessionId: SessionId | null = null;
   private warnedRecordingEviction = false;
   private ptyEmitScheduled = false;
@@ -176,6 +178,7 @@ class LoopReelStoreImpl implements LoopReelStore {
     };
     this.appendEntries(recording, [endedMarker], { emitPtySoon: false });
     this.activeBySessionId.delete(sessionId);
+    this.lastInterventionBySessionId.delete(sessionId);
     this.evictRecordingsIfNeeded();
     this.notifyRecordingChanged(recording);
     this.emit();
@@ -209,15 +212,19 @@ class LoopReelStoreImpl implements LoopReelStore {
   recordMarker(
     sessionId: SessionId,
     marker: SessionTimelineMarker,
-    label: string,
+    label = defaultMarkerLabel(marker),
     detail?: unknown,
     timestamp: number = this.time.now(),
   ): void {
     const recording = this.activeBySessionId.get(sessionId);
     if (!recording) return;
+    if (this.shouldThrottleInterventionMarker(sessionId, marker, timestamp)) return;
     this.appendEntries(recording, [{ kind: "marker", marker, label, detail, timestamp }], {
       emitPtySoon: false,
     });
+    if (marker === "intervention") {
+      this.lastInterventionBySessionId.set(sessionId, timestamp);
+    }
     this.emit();
   }
 
@@ -355,8 +362,22 @@ class LoopReelStoreImpl implements LoopReelStore {
     }
     this.recordings.unshift(recording);
     this.activeBySessionId.set(sessionId, recording);
+    this.lastInterventionBySessionId.delete(sessionId);
     this.appendEntries(recording, initialEntries, { emitPtySoon: false });
     return recording;
+  }
+
+  private shouldThrottleInterventionMarker(
+    sessionId: SessionId,
+    marker: SessionTimelineMarker,
+    timestamp: number,
+  ): boolean {
+    if (marker !== "intervention") return false;
+    const previousTimestamp = this.lastInterventionBySessionId.get(sessionId);
+    return (
+      previousTimestamp !== undefined &&
+      timestamp - previousTimestamp < LOOP_REEL_TUNING.interventionMarkerThrottleMs
+    );
   }
 
   private updateRecordingMetadata(
@@ -416,16 +437,18 @@ class LoopReelStoreImpl implements LoopReelStore {
     recording: MutableSessionRecording,
     entries: readonly RecordedEntry[],
   ): void {
+    const clonedEntries = entries.map(cloneEntry);
+    const meta = this.metaOf(recording);
     this.callbacks.onEntriesAppended?.({
       recordingId: recording.id,
-      meta: this.metaOf(recording),
-      entries: entries.map(cloneEntry),
+      meta,
+      entries: clonedEntries,
     });
     for (const callbacks of this.recordingEventSubscribers) {
       callbacks.onEntriesAppended?.({
         recordingId: recording.id,
-        meta: this.metaOf(recording),
-        entries: entries.map(cloneEntry),
+        meta,
+        entries: clonedEntries,
       });
     }
   }
@@ -557,6 +580,23 @@ const lastResizeEntry = (
     if (entry.kind === "resize") return entry;
   }
   return null;
+};
+
+const defaultMarkerLabel = (marker: SessionTimelineMarker): string => {
+  switch (marker) {
+    case "session-start":
+      return "Session started";
+    case "session-resume":
+      return "Session resumed";
+    case "session-rewind":
+      return "Session rewind";
+    case "session-ended":
+      return "Session ended";
+    case "intervention":
+      return "User intervention";
+    case "command-failed":
+      return "Command failed";
+  }
 };
 
 const cloneEntry = (entry: RecordedEntry): RecordedEntry => ({ ...entry });

--- a/src/runtime/loop-reel/persistence.test.ts
+++ b/src/runtime/loop-reel/persistence.test.ts
@@ -123,6 +123,34 @@ describe("LoopReelPersistence", () => {
     }
   });
 
+  it("flushes only the requested recording id", async () => {
+    const backend = new MemoryLoopReelBackend();
+    const store = createLoopReelStore();
+    const persistence = createLoopReelPersistence(store, {
+      backend,
+      flushEntryCount: 64,
+      flushIntervalMs: 1000,
+    });
+
+    store.startSession("session-a", { label: "a", kind: "agent", timestamp: 100 });
+    store.startSession("session-b", { label: "b", kind: "agent", timestamp: 200 });
+    store.recordPty("session-a", "a\n", 210);
+    store.recordPty("session-b", "b\n", 220);
+
+    await persistence.flushRecording("session-session-a-100-1");
+
+    expect(backend.appendCalls.map((call) => call.id)).toEqual(["session-session-a-100-1"]);
+    expect(backend.entries.get("session-session-a-100-1")).toContain("a\\n");
+    expect(backend.entries.has("session-session-b-200-2")).toBe(false);
+
+    await persistence.flushAll();
+
+    expect(backend.appendCalls.map((call) => call.id)).toEqual([
+      "session-session-a-100-1",
+      "session-session-b-200-2",
+    ]);
+  });
+
   it("flushes immediately when a recording ends", async () => {
     const backend = new MemoryLoopReelBackend();
     const store = createLoopReelStore();

--- a/src/runtime/loop-reel/persistence.ts
+++ b/src/runtime/loop-reel/persistence.ts
@@ -35,6 +35,7 @@ export interface LoopReelPersistenceOptions {
 export interface LoopReelPersistenceController {
   initialize(): Promise<void>;
   flushAll(): Promise<void>;
+  flushRecording(id: string): Promise<void>;
   listRecordings(): Promise<readonly LoopReelPersistedMeta[]>;
   loadRecording(id: string): Promise<SessionRecording | null>;
   dispose(): void;
@@ -139,6 +140,16 @@ export class LoopReelPersistence implements LoopReelPersistenceController {
     }
   }
 
+  async flushRecording(id: string): Promise<void> {
+    const entries = this.pendingEntries.get(id);
+    if (!entries || entries.length === 0) {
+      await (this.appendChains.get(id) ?? Promise.resolve());
+      return;
+    }
+    this.pendingEntries.delete(id);
+    await this.enqueueAppend(id, entries);
+  }
+
   async listRecordings(): Promise<readonly LoopReelPersistedMeta[]> {
     const metas = await this.backend.list();
     for (const meta of metas) {
@@ -205,16 +216,6 @@ export class LoopReelPersistence implements LoopReelPersistenceController {
     await this.backend.create(meta);
     this.knownMetaIds.add(meta.id);
     this.metas.set(meta.id, meta);
-  }
-
-  private async flushRecording(id: string): Promise<void> {
-    const entries = this.pendingEntries.get(id);
-    if (!entries || entries.length === 0) {
-      await (this.appendChains.get(id) ?? Promise.resolve());
-      return;
-    }
-    this.pendingEntries.delete(id);
-    await this.enqueueAppend(id, entries);
   }
 
   private enqueueAppend(id: string, entries: readonly RecordedEntry[]): Promise<void> {

--- a/src/runtime/loop-reel/player-state.test.ts
+++ b/src/runtime/loop-reel/player-state.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from "vitest";
 import type { LoopReelPersistedMeta } from "./persistence";
 import {
   clampTimestamp,
-  endedLoopReelMetas,
+  isAtLiveEdge,
   mergeLoopReelMetas,
   nextClipTimestamp,
   nextFailedTimestamp,
-  phaseMarkersOfRecording,
   previousClipTimestamp,
   recordingTimeRange,
+  resolveCatchUpStart,
+  scrubberMarkersOfRecording,
 } from "./player-state";
 import type { SessionRecording } from "./types";
 
@@ -48,12 +49,6 @@ describe("loop reel player state helpers", () => {
     ]);
   });
 
-  it("filters player selection to ended recordings", () => {
-    expect(endedLoopReelMetas([meta("recording", 200, "recording"), meta("ended", 100)])).toEqual([
-      meta("ended", 100),
-    ]);
-  });
-
   it("derives a stable scrub range from recording timestamps", () => {
     const recording: SessionRecording = {
       ...meta("r1", 100),
@@ -67,6 +62,25 @@ describe("loop reel player state helpers", () => {
     expect(recordingTimeRange(recording)).toEqual({ fromTs: 100, toTs: 180 });
     expect(clampTimestamp(90, recordingTimeRange(recording))).toBe(100);
     expect(clampTimestamp(999, recordingTimeRange(recording))).toBe(180);
+  });
+
+  it("resolves catch-up start from hot lastSeen without moving before recording start", () => {
+    const recording = meta("r1", 100);
+    const lastSeen = new Map([
+      ["default-session", 240],
+      ["other", 999],
+    ]);
+
+    expect(resolveCatchUpStart(lastSeen, recording)).toBe(240);
+    expect(resolveCatchUpStart(new Map([["default-session", 50]]), recording)).toBe(100);
+    expect(resolveCatchUpStart(new Map(), recording)).toBe(100);
+  });
+
+  it("detects live edge with tolerance", () => {
+    expect(isAtLiveEdge(975, 1000, 25)).toBe(true);
+    expect(isAtLiveEdge(974, 1000, 25)).toBe(false);
+    expect(isAtLiveEdge(1010, 1000, 25)).toBe(true);
+    expect(isAtLiveEdge(Number.NaN, 1000, 25)).toBe(false);
   });
 
   it("finds clip and failed jump targets", () => {
@@ -91,19 +105,38 @@ describe("loop reel player state helpers", () => {
     expect(nextFailedTimestamp(recording, 250)).toBeNull();
   });
 
-  it("sorts phase markers by timestamp", () => {
+  it("extends scrubber markers with salience marker entries", () => {
     const recording: SessionRecording = {
       ...meta("r1", 100),
       entries: [
-        { kind: "phase", phase: "completed", agent: null, timestamp: 300 },
-        { kind: "pty", text: "x", timestamp: 200 },
+        { kind: "marker", marker: "command-failed", label: "npm test", timestamp: 220 },
         { kind: "phase", phase: "started", agent: null, timestamp: 100 },
+        {
+          kind: "marker",
+          marker: "intervention",
+          label: "User intervention",
+          detail: { length: 3 },
+          timestamp: 180,
+        },
       ],
     };
 
-    expect(phaseMarkersOfRecording(recording)).toEqual([
-      { phase: "started", timestamp: 100 },
-      { phase: "completed", timestamp: 300 },
+    expect(scrubberMarkersOfRecording(recording)).toEqual([
+      { kind: "phase", marker: "started", timestamp: 100, detail: undefined },
+      {
+        kind: "marker",
+        marker: "intervention",
+        label: "User intervention",
+        detail: { length: 3 },
+        timestamp: 180,
+      },
+      {
+        kind: "marker",
+        marker: "command-failed",
+        label: "npm test",
+        detail: undefined,
+        timestamp: 220,
+      },
     ]);
   });
 });

--- a/src/runtime/loop-reel/player-state.ts
+++ b/src/runtime/loop-reel/player-state.ts
@@ -1,16 +1,24 @@
 import type { LoopPhase } from "@yorishiro/sdk";
 import type { IterationClip } from "./iteration-clips";
 import { type LoopReelPersistedMeta, metaFromRecording } from "./persistence";
-import type { RecordedEntry, SessionRecording, SessionRecordingMeta } from "./types";
+import type {
+  RecordedEntry,
+  SessionRecording,
+  SessionRecordingMeta,
+  SessionTimelineMarker,
+} from "./types";
 
 export interface LoopReelTimeRange {
   readonly fromTs: number;
   readonly toTs: number;
 }
 
-export interface LoopReelPhaseMarker {
-  readonly phase: LoopPhase;
+export interface LoopReelScrubberMarker {
+  readonly kind: "phase" | "marker";
+  readonly marker: LoopPhase | SessionTimelineMarker;
   readonly timestamp: number;
+  readonly label?: string;
+  readonly detail?: unknown;
 }
 
 export function mergeLoopReelMetas(
@@ -25,13 +33,6 @@ export function mergeLoopReelMetas(
   );
 }
 
-export const endedLoopReelMetas = (
-  metas: readonly LoopReelPersistedMeta[],
-): readonly LoopReelPersistedMeta[] =>
-  metas
-    .filter((meta) => meta.status === "ended")
-    .sort((a, b) => b.startedAt - a.startedAt || b.id.localeCompare(a.id));
-
 export function recordingTimeRange(recording: SessionRecording): LoopReelTimeRange {
   const lastTimestamp = recording.entries.reduce(
     (max, entry) => Math.max(max, entry.timestamp),
@@ -41,12 +42,49 @@ export function recordingTimeRange(recording: SessionRecording): LoopReelTimeRan
   return { fromTs: recording.startedAt, toTs };
 }
 
-export const phaseMarkersOfRecording = (
+export function resolveCatchUpStart(
+  lastSeen: ReadonlyMap<string, number>,
+  recording: SessionRecordingMeta,
+): number {
+  const seen = lastSeen.get(recording.sessionId);
+  if (seen === undefined || !Number.isFinite(seen)) return recording.startedAt;
+  return Math.max(recording.startedAt, seen);
+}
+
+export function isAtLiveEdge(position: number, liveEdge: number, toleranceMs: number): boolean {
+  if (!Number.isFinite(position) || !Number.isFinite(liveEdge)) return false;
+  const safeTolerance = Number.isFinite(toleranceMs) && toleranceMs > 0 ? toleranceMs : 0;
+  return position >= liveEdge - safeTolerance;
+}
+
+export const scrubberMarkersOfRecording = (
   recording: SessionRecording,
-): readonly LoopReelPhaseMarker[] =>
+): readonly LoopReelScrubberMarker[] =>
   recording.entries
-    .filter((entry): entry is Extract<RecordedEntry, { kind: "phase" }> => entry.kind === "phase")
-    .map((entry) => ({ phase: entry.phase, timestamp: entry.timestamp }))
+    .filter(
+      (
+        entry,
+      ): entry is
+        | Extract<RecordedEntry, { kind: "phase" }>
+        | Extract<RecordedEntry, { kind: "marker" }> =>
+        entry.kind === "phase" || entry.kind === "marker",
+    )
+    .map((entry) =>
+      entry.kind === "phase"
+        ? {
+            kind: "phase" as const,
+            marker: entry.phase,
+            timestamp: entry.timestamp,
+            detail: entry.detail,
+          }
+        : {
+            kind: "marker" as const,
+            marker: entry.marker,
+            timestamp: entry.timestamp,
+            label: entry.label,
+            detail: entry.detail,
+          },
+    )
     .sort((a, b) => a.timestamp - b.timestamp);
 
 export function previousClipTimestamp(

--- a/src/runtime/loop-reel/reel-player.test.ts
+++ b/src/runtime/loop-reel/reel-player.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildReplayTimeline, replayDurationMs } from "./reel-player";
+import { appendReplayTimeline, buildReplayTimeline, replayDurationMs } from "./reel-player";
 import type { SessionRecording } from "./types";
 
 const recording: SessionRecording = {
@@ -47,5 +47,32 @@ describe("reel-player", () => {
 
     expect(frames.map((frame) => frame.dueMs)).toEqual([0, 100, 1100, 1100, 1160]);
     expect(replayDurationMs(frames)).toBe(1160);
+  });
+
+  it("appends live tail frames without rebuilding the existing timeline", () => {
+    const frames = buildReplayTimeline(recording, { maxGapMs: 1000 });
+    const extended = appendReplayTimeline(
+      frames,
+      [
+        { kind: "marker", marker: "intervention", label: "User intervention", timestamp: 6000 },
+        { kind: "pty", text: "tail\n", timestamp: 9000 },
+        { kind: "resize", cols: 100, rows: 28, timestamp: 9010 },
+      ],
+      { startedAt: recording.startedAt, maxGapMs: 400 },
+    );
+
+    expect(extended.slice(0, frames.length)).toEqual(frames);
+    expect(extended.slice(frames.length)).toEqual([
+      {
+        entry: { kind: "pty", text: "tail\n", timestamp: 9000 },
+        timestamp: 9000,
+        dueMs: 1560,
+      },
+      {
+        entry: { kind: "resize", cols: 100, rows: 28, timestamp: 9010 },
+        timestamp: 9010,
+        dueMs: 1570,
+      },
+    ]);
   });
 });

--- a/src/runtime/loop-reel/reel-player.ts
+++ b/src/runtime/loop-reel/reel-player.ts
@@ -1,3 +1,4 @@
+import { LOOP_REEL_TUNING } from "./constants";
 import type { RecordedEntry, SessionRecording } from "./types";
 
 export type ReplayStreamEntry = Extract<RecordedEntry, { kind: "pty" | "resize" }>;
@@ -12,8 +13,6 @@ export interface ReplayTimelineOptions {
   /** 記録上の空白時間を replay 上で何 ms まで保持するか。 */
   readonly maxGapMs?: number;
 }
-
-const DEFAULT_MAX_GAP_MS = 1800;
 
 const isReplayStreamEntry = (entry: RecordedEntry): entry is ReplayStreamEntry =>
   entry.kind === "pty" || entry.kind === "resize";
@@ -48,11 +47,38 @@ export function buildReplayTimeline(
   });
 }
 
+/**
+ * 既存 timeline の末尾に追記 entry から作った frame を足す。
+ *
+ * catch-up live tail 用。entries は store からの追記順（timestamp 昇順）を前提にし、
+ * 既存 frame や nextFrameIndex は組み替えない。
+ */
+export function appendReplayTimeline(
+  frames: readonly ReplayFrame[],
+  entries: readonly RecordedEntry[],
+  options: ReplayTimelineOptions & { readonly startedAt: number },
+): readonly ReplayFrame[] {
+  const maxGapMs = normalizeMaxGap(options.maxGapMs);
+  let previousTimestamp = frames[frames.length - 1]?.timestamp ?? options.startedAt;
+  let dueMs = replayDurationMs(frames);
+  const appended: ReplayFrame[] = [];
+  for (const entry of entries) {
+    if (!isReplayStreamEntry(entry)) continue;
+    const gap = Math.max(0, entry.timestamp - previousTimestamp);
+    dueMs += Math.min(gap, maxGapMs);
+    previousTimestamp = entry.timestamp;
+    appended.push({ entry, timestamp: entry.timestamp, dueMs });
+  }
+  return appended.length === 0 ? frames : [...frames, ...appended];
+}
+
 export function replayDurationMs(frames: readonly ReplayFrame[]): number {
   return frames[frames.length - 1]?.dueMs ?? 0;
 }
 
 const normalizeMaxGap = (value: number | undefined): number => {
-  if (value === undefined || !Number.isFinite(value) || value <= 0) return DEFAULT_MAX_GAP_MS;
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return LOOP_REEL_TUNING.replayMaxGapMs;
+  }
   return Math.floor(value);
 };

--- a/src/runtime/loop-reel/replay-terminal.test.ts
+++ b/src/runtime/loop-reel/replay-terminal.test.ts
@@ -157,6 +157,28 @@ describe("ReplayTerminal", () => {
     replay.dispose();
   });
 
+  it("appends live tail entries to the loaded stream", () => {
+    const replay = createReplayTerminal();
+    const terminal = mockState.terminals[0];
+
+    replay.loadStream(recording, { maxGapMs: 400 });
+    replay.appendEntries([
+      { kind: "marker", marker: "intervention", label: "User intervention", timestamp: 320 },
+      { kind: "pty", text: "tail\n", timestamp: 900 },
+      { kind: "resize", cols: 100, rows: 28, timestamp: 910 },
+    ]);
+    replay.seekLinear(910);
+
+    expect(terminal.writes).toEqual(["\x1b[32mhello\x1b[0m\n", "done\n", "tail\n"]);
+    expect(terminal.resizes).toEqual([
+      { cols: 80, rows: 24 },
+      { cols: 120, rows: 30 },
+      { cols: 100, rows: 28 },
+    ]);
+
+    replay.dispose();
+  });
+
   it("attaches as a fixed replay container and mirrors terminal rect visibility", () => {
     const replay = createReplayTerminal();
     const host = document.createElement("div");

--- a/src/runtime/loop-reel/replay-terminal.ts
+++ b/src/runtime/loop-reel/replay-terminal.ts
@@ -2,19 +2,23 @@ import { Terminal as XTerm } from "@xterm/xterm";
 import { applyFixedRect, readPaddedFixedRect } from "../terminal-runtime/fixed-terminal-rect";
 import { getCurrentTerminalTheme } from "../terminal-theme";
 import {
+  appendReplayTimeline,
   buildReplayTimeline,
   type ReplayFrame,
   type ReplayStreamEntry,
+  type ReplayTimelineOptions,
   replayDurationMs,
 } from "./reel-player";
-import type { SessionRecording } from "./types";
+import type { RecordedEntry, SessionRecording } from "./types";
 
 export interface ReplayTerminal {
   /** live terminal と同じ terminal placeholder に replay xterm を重ねる。 */
   attachTo(container: HTMLElement): void;
   detachContainer(): void;
   /** 録画 stream を読み込み、開始時刻まで linear seek する。 */
-  loadStream(recording: SessionRecording): void;
+  loadStream(recording: SessionRecording, options?: ReplayTimelineOptions): void;
+  /** catch-up の live tail を末尾に足す。再生中の nextFrameIndex は動かさない。 */
+  appendEntries(entries: readonly RecordedEntry[]): void;
   play(speed?: number): void;
   /** from→to の window だけ連続再生し、到達したら pause する。 */
   playWindow(fromTimestamp: number, toTimestamp: number, speed?: number, onEnd?: () => void): void;
@@ -51,6 +55,7 @@ class ReplayTerminalImpl implements ReplayTerminal {
   private lastTickAt = 0;
   private windowEndReplayMs: number | null = null;
   private windowEndCallback: (() => void) | null = null;
+  private timelineOptions: ReplayTimelineOptions = {};
   private hidden = true;
   private disposed = false;
   private readonly positionListeners = new Set<(timestamp: number) => void>();
@@ -104,14 +109,23 @@ class ReplayTerminalImpl implements ReplayTerminal {
     this.container.style.visibility = "hidden";
   }
 
-  loadStream(recording: SessionRecording): void {
+  loadStream(recording: SessionRecording, options: ReplayTimelineOptions = {}): void {
     if (this.disposed) return;
     this.pause();
     this.recording = recording;
-    this.frames = buildReplayTimeline(recording);
+    this.timelineOptions = options;
+    this.frames = buildReplayTimeline(recording, options);
     this.replayMs = 0;
     this.nextFrameIndex = 0;
     this.term.reset();
+  }
+
+  appendEntries(entries: readonly RecordedEntry[]): void {
+    if (this.disposed || !this.recording || entries.length === 0) return;
+    this.frames = appendReplayTimeline(this.frames, entries, {
+      ...this.timelineOptions,
+      startedAt: this.recording.startedAt,
+    });
   }
 
   play(speed = 1): void {

--- a/src/runtime/loop-reel/types.ts
+++ b/src/runtime/loop-reel/types.ts
@@ -5,7 +5,9 @@ export type SessionTimelineMarker =
   | "session-start"
   | "session-resume"
   | "session-rewind"
-  | "session-ended";
+  | "session-ended"
+  | "intervention"
+  | "command-failed";
 
 /** 記録された観察 entry。timestamp は host 側で stamp された時刻を使う。 */
 export type RecordedEntry =

--- a/src/runtime/module-registry/keys.ts
+++ b/src/runtime/module-registry/keys.ts
@@ -21,6 +21,8 @@ export const KEYS = {
   ATTENTION_LIGHT_CUE: "attention-light:cue",
   /** LoopReelStore singleton: 自律 loop の記録を HMR 越しに保持する。 */
   LOOP_REEL_STORE: "loop-reel:store",
+  /** LoopReel catch-up lastSeen map: 再起動では消えてよい hot-data の視聴位置。 */
+  LOOP_REEL_LAST_SEEN: "loop-reel:last-seen",
   /** AttentionCueClaimRegistry singleton: AttentionCueLight の yielding default 用 claim カウンタ。 */
   ATTENTION_CUE_CLAIMS: "attention-cue:claims",
   /** AmbientUiPackRegistry singleton: ambient-ui pack の登録と active 集合（multi-active）を管理する。 */

--- a/src/runtime/terminal-runtime/terminal-runtime.test.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.test.ts
@@ -280,12 +280,14 @@ function createRecorderSink(): LoopReelRecorderSink & {
   readonly endSession: ReturnType<typeof vi.fn<LoopReelRecorderSink["endSession"]>>;
   readonly recordPty: ReturnType<typeof vi.fn<LoopReelRecorderSink["recordPty"]>>;
   readonly recordResize: ReturnType<typeof vi.fn<LoopReelRecorderSink["recordResize"]>>;
+  readonly recordMarker: ReturnType<typeof vi.fn<LoopReelRecorderSink["recordMarker"]>>;
 } {
   return {
     startSession: vi.fn<LoopReelRecorderSink["startSession"]>(),
     endSession: vi.fn<LoopReelRecorderSink["endSession"]>(),
     recordPty: vi.fn<LoopReelRecorderSink["recordPty"]>(),
     recordResize: vi.fn<LoopReelRecorderSink["recordResize"]>(),
+    recordMarker: vi.fn<LoopReelRecorderSink["recordMarker"]>(),
   };
 }
 
@@ -508,6 +510,25 @@ describe("TerminalRuntime", () => {
     expect(recorder.recordPty).toHaveBeenCalledOnce();
     expect(recorder.recordPty).toHaveBeenCalledWith("shell-1", "あ");
     expect(perception.onPtyOutput).toHaveBeenLastCalledWith("あ");
+  });
+
+  it("user input の到達点で Loop Reel intervention marker を記録する", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const recorder = createRecorderSink();
+    const terminal = mockState.terminals[0];
+
+    runtime.setLoopReelRecorder(recorder);
+    terminal.dataHandler?.("npm test\r");
+    await flushMicrotasks();
+
+    expect(recorder.recordMarker).toHaveBeenCalledWith(
+      "shell-1",
+      "intervention",
+      "User intervention",
+      {
+        length: 9,
+      },
+    );
   });
 
   it("手動録画は現在 geometry を seed して開始・終了する", async () => {

--- a/src/runtime/terminal-runtime/terminal-runtime.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.ts
@@ -1070,6 +1070,9 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   private acceptUserInputData(data: string): void {
     if (this.shouldSuppressProtectedInterruptData(data)) return;
     this.lastUserInputAt = performance.now();
+    this.loopReelRecorder?.recordMarker(this.sessionId, "intervention", "User intervention", {
+      length: data.length,
+    });
     this.perceptionRef.current?.onUserInput(data);
     this.notifyUserInputListeners(data);
     this.detectClearCommand(data);

--- a/src/runtime/terminal-runtime/types.ts
+++ b/src/runtime/terminal-runtime/types.ts
@@ -2,6 +2,7 @@ import type { ITheme as XTermTheme } from "@xterm/xterm";
 import type { Disposable, TerminalCellData } from "@yorishiro/sdk";
 import type { SpawnSpec } from "../../bindings/tauri-commands";
 import type { Perception } from "../../core/perception";
+import type { SessionTimelineMarker } from "../loop-reel/types";
 import type { TerminalCommandRun } from "./command-run-store";
 import type { RegionPoint } from "./region-selection";
 import type { TerminalProblem } from "./terminal-problems";
@@ -82,6 +83,12 @@ export interface LoopReelRecorderSink {
   endSession(sessionId: string): void;
   recordPty(sessionId: string, text: string): void;
   recordResize(sessionId: string, cols: number, rows: number): void;
+  recordMarker(
+    sessionId: string,
+    marker: SessionTimelineMarker,
+    label?: string,
+    detail?: unknown,
+  ): void;
 }
 
 export interface TerminalRegionContext {


### PR DESCRIPTION
## 概要

Loop Reel P1（design doc §6・§9）。P0（#46）の上に積む stacked PR——**base は `feat/loop-reel-p0`**（P1 の差分のみ表示）。#46 merge 後に base を main へ付け替える。

> ⚠️ #46 と同じく OSS 公開後の merge 予定のため draft。

## 内容

- **salience marker 記録**
  - intervention: user 入力を per-session 5s throttle（O(1) 判定）で記録。detail は raw input を残さず長さのみ
  - command-failed: command-block event（exitCode 非 0 のみ）を event 自身の sessionId の active recording に記録
- **catch-up 再生**（留守中の走行に追いつく、デイリードライバー用途）
  - 録画中 recording を player で選択可能に。全量は disk（対象 recording のみ per-id flush → load）、以後は store の append event を live tail として合流
  - 開始位置 = lastSeen（hot-data）、catch-up 専用 gap 上限（400ms）+ 既定 2x で自動再生、**live edge 到達で pause + LIVE バッジ**（自動追従はしない——旧実装の自走 choreography は不採用）
  - MASKED 中の live tail は増分 append をやめ debounce 全量再ロード（chunk 跨ぎの秘匿文字列を増分 redaction が取りこぼすため）
  - スクラバは phase + intervention / command-failed の統合 marker 表現
- 感触値は `constants.ts` の `LOOP_REEL_TUNING` に集約（実機調整前提）

## 品質

- Codex xhigh 実装 + Claude review（3 angle finder → 確定指摘 12 件修正）: 速度変更で再生停止する回帰（テストで固定）/ MASKED tail の redaction 漏れ / StrictMode 二重描画 / flushAll 競合 / O(n) throttle scan ほか
- gate: check / **vitest 1970** / cargo 248 / build 全 pass、全 commit 単独 typecheck 通過
- 既知の制限: 多セッション時の session 帰属ずれで command-failed marker が drop し得る（P0 の帰属設計に従属、README 明記）

## 計画

`Charminal-design-record/2026-07-10-loop-reel-p1-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)