### PR TITLE
Stabilize flaky focus assertion in RestoreConfirmDialog test

### DIFF
--- a/src/components/RestoreConfirmDialog.test.tsx
+++ b/src/components/RestoreConfirmDialog.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RestoreConfirmDialog, type RestoreConfirmStrings } from "./RestoreConfirmDialog";
@@ -104,6 +104,10 @@ describe("RestoreConfirmDialog", () => {
 
     expect((await screen.findByRole("alert")).textContent).toBe("Restore failed: disk is locked");
     expect(screen.getByRole("button", { name: STRINGS.retry })).toBeTruthy();
-    expect(screen.getByRole("button", { name: STRINGS.close })).toBe(document.activeElement);
+    // フォーカス移動は phase 遷移後の passive effect で走るため、findByRole（commit 時点で解決）
+    // 直後に同期 assert すると effect flush 前の一瞬を踏んで flaky になる。確定を待つ。
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: STRINGS.close })).toBe(document.activeElement),
+    );
   });
 });


### PR DESCRIPTION
## 問題

`RestoreConfirmDialog.test.tsx` の "shows error state and retry action when restore fails" が CI で間欠的に落ちる（同一コードで成功↔失敗、docs-only の PR #50 でも発生）。

## 原因

エラー状態への遷移は `onConfirm` の promise rejection 経由（非同期）で起きる。フォーカスを Close ボタンへ移すのは phase 変化後の **passive effect**（`useEffect`）。テストは `findByRole("alert")`（commit 時点の DOM で解決）の直後に同期で `document.activeElement` を assert していたため、focus の passive effect が flush される前の一瞬に当たると失敗する。初期フォーカスの assertion（別テスト）は `render()` の act() 内で effect が flush 済みなので安全。

## 修正

focus の assertion を `waitFor` で包み、effect 確定まで待つ（test-only、1 箇所）。

## 検証

- `npm run check` / `vitest RestoreConfirmDialog`（5 pass）
- 3 つの draft PR（#46/#50/#51）の CI を green にするための repo 健全化。main 起点で独立に merge 可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)