### PR TITLE
Clarify light alerts and resume agents after workspace switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Light alerts now use a brighter, quicker double pulse with a distinct beat between flashes.
 - Fixed Codex `$yori` command discovery by installing Yorishiro's generated skills in Codex's user skill directory (`~/.agents/skills`) instead of an undiscoverable plugin cache entry.
 - Renamed the product from Charminal to Yorishiro, including app metadata, command namespace, SDK package naming, bundled docs, and automatic `~/.charminal/` → `~/.yorishiro/` data directory migration.
 - Release asset fetching now fails packaging builds when `YORISHIRO_ASSETS_REQUIRED=1` is set and any required asset target is missing.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3727,6 +3727,8 @@ function App() {
         await updateYorishiroConfig((cur) => ({ ...cur, projectFolder: nextCwd }));
         if (nextCwd === cwd) return;
         localStorage.setItem(CWD_STORAGE_KEY, nextCwd);
+        // 既存 main PTY は作り直しつつ、新しい workspace の会話履歴があれば resume する。
+        markMainSessionRespawnPending();
         // Workspace 切替は runtime singleton 群を一度作り直す。
         // PTY / xterm / perception の寿命が絡むため、差分更新より WebView reload の方が安定する。
         beginCurtainReload();

--- a/src/runtime/three-runtime/attention-cue-envelope.test.ts
+++ b/src/runtime/three-runtime/attention-cue-envelope.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ATTENTION_CUE_DURATION_SECONDS,
   ATTENTION_CUE_PULSE_DURATION_SECONDS,
+  ATTENTION_CUE_PULSE_GAP_SECONDS,
   computeAttentionCueLightIntensity,
 } from "./attention-cue-envelope";
 
@@ -11,9 +12,13 @@ describe("computeAttentionCueLightIntensity", () => {
     const rising = computeAttentionCueLightIntensity(ATTENTION_CUE_PULSE_DURATION_SECONDS * 0.25);
     const firstPeak = computeAttentionCueLightIntensity(ATTENTION_CUE_PULSE_DURATION_SECONDS * 0.5);
     const falling = computeAttentionCueLightIntensity(ATTENTION_CUE_PULSE_DURATION_SECONDS * 0.75);
-    const betweenPulses = computeAttentionCueLightIntensity(ATTENTION_CUE_PULSE_DURATION_SECONDS);
+    const betweenPulses = computeAttentionCueLightIntensity(
+      ATTENTION_CUE_PULSE_DURATION_SECONDS + ATTENTION_CUE_PULSE_GAP_SECONDS * 0.5,
+    );
     const secondPeak = computeAttentionCueLightIntensity(
-      ATTENTION_CUE_PULSE_DURATION_SECONDS * 1.5,
+      ATTENTION_CUE_PULSE_DURATION_SECONDS +
+        ATTENTION_CUE_PULSE_GAP_SECONDS +
+        ATTENTION_CUE_PULSE_DURATION_SECONDS * 0.5,
     );
     const end = computeAttentionCueLightIntensity(ATTENTION_CUE_DURATION_SECONDS);
 
@@ -26,8 +31,9 @@ describe("computeAttentionCueLightIntensity", () => {
     expect(secondPeak.point).toBeCloseTo(firstPeak.point);
     expect(secondPeak.spot).toBeCloseTo(firstPeak.spot);
     expect(end).toEqual({ ambient: 0, point: 0, spot: 0 });
-    expect(firstPeak.ambient).toBeCloseTo(0.02);
-    expect(firstPeak.point).toBeCloseTo(0.18);
-    expect(firstPeak.spot).toBeCloseTo(0.21);
+    expect(ATTENTION_CUE_DURATION_SECONDS).toBeCloseTo(1.12);
+    expect(firstPeak.ambient).toBeCloseTo(0.03);
+    expect(firstPeak.point).toBeCloseTo(0.27);
+    expect(firstPeak.spot).toBeCloseTo(0.32);
   });
 });

--- a/src/runtime/three-runtime/attention-cue-envelope.ts
+++ b/src/runtime/three-runtime/attention-cue-envelope.ts
@@ -7,9 +7,11 @@
  */
 
 export const ATTENTION_CUE_PULSE_COUNT = 2;
-export const ATTENTION_CUE_PULSE_DURATION_SECONDS = 1.7;
+export const ATTENTION_CUE_PULSE_DURATION_SECONDS = 0.5;
+export const ATTENTION_CUE_PULSE_GAP_SECONDS = 0.12;
 export const ATTENTION_CUE_DURATION_SECONDS =
-  ATTENTION_CUE_PULSE_DURATION_SECONDS * ATTENTION_CUE_PULSE_COUNT;
+  ATTENTION_CUE_PULSE_DURATION_SECONDS * ATTENTION_CUE_PULSE_COUNT +
+  ATTENTION_CUE_PULSE_GAP_SECONDS * (ATTENTION_CUE_PULSE_COUNT - 1);
 
 export interface AttentionCueLightIntensity {
   readonly ambient: number;
@@ -18,9 +20,9 @@ export interface AttentionCueLightIntensity {
 }
 
 const ATTENTION_CUE_PEAK_INTENSITY: AttentionCueLightIntensity = {
-  ambient: 0.02,
-  point: 0.18,
-  spot: 0.21,
+  ambient: 0.03,
+  point: 0.27,
+  spot: 0.32,
 };
 
 export function computeAttentionCueLightIntensity(
@@ -39,7 +41,18 @@ export function computeAttentionCueLightIntensityInto(
     out.spot = 0;
     return out;
   }
-  const pulseElapsed = elapsedSeconds % ATTENTION_CUE_PULSE_DURATION_SECONDS;
+  const pulseInterval = ATTENTION_CUE_PULSE_DURATION_SECONDS + ATTENTION_CUE_PULSE_GAP_SECONDS;
+  const pulseIndex = Math.floor(elapsedSeconds / pulseInterval);
+  const pulseElapsed = elapsedSeconds - pulseIndex * pulseInterval;
+  if (
+    pulseIndex >= ATTENTION_CUE_PULSE_COUNT ||
+    pulseElapsed >= ATTENTION_CUE_PULSE_DURATION_SECONDS
+  ) {
+    out.ambient = 0;
+    out.point = 0;
+    out.spot = 0;
+    return out;
+  }
   const progress = pulseElapsed / ATTENTION_CUE_PULSE_DURATION_SECONDS;
   const fade = progress < 0.5 ? smootherstep(progress * 2) : smootherstep((1 - progress) * 2);
   out.ambient = ATTENTION_CUE_PEAK_INTENSITY.ambient * fade;


### PR DESCRIPTION
## Summary

- Make light alerts brighter and reduce the cue from a slow 3.4-second cycle to a distinct 1.12-second double pulse.
- Add a short dark gap between pulses so the two flashes read clearly.
- Recreate the main PTY after a workspace folder change while allowing the selected workspace Codex or Claude conversation to resume.

## Why

The existing light cue was too dim and slow to read as an immediate notification. Folder changes also reattached the existing main PTY, leaving the agent in the previous working directory.

The workspace-switch path now requests a respawn instead of a fresh conversation. The agent adapters resume only when a matching session exists for the new cwd, while the existing persona gate still prevents unsafe resume across persona changes.

## Validation

- Full Vitest suite: 155 files, 1,893 tests passed.
- Workspace and session regression tests: 49 tests passed.
- TypeScript typecheck passed.
- Biome check passed.
- Rust format check passed.
- git diff --check passed.