### PR TITLE
Ground journal entries in honest reflection

### DIFF
--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -359,7 +359,7 @@ pub struct JournalWriteRequest {
     pub date: String,
     /// 書き込む内容。
     pub content: String,
-    /// 時間が経っても思い出したい一行（作業の要約ではない）。指定すると memories.md に追記される。
+    /// 時間が経っても思い出したい具体的な出来事または気づきの一行。指定すると memories.md に追記される。
     pub summary: Option<String>,
 }
 
@@ -944,7 +944,7 @@ impl Yorishiro {
 
     /// journal にエントリを書き込む。住人の日々の記録。summary を指定すると memories.md にも追記される。
     #[tool(
-        description = "journal にエントリを書き込む。住人の日々の記録。作業ログではなく、その日の手触りや情景を書く。summary は時間が経っても思い出したい一行で、記憶に残る"
+        description = "journal にエントリを書き込む。住人の日々の記録。実際に認識した出来事を起点に、感じたこと・考えたこと・気づきを、嘘や演出を交えず正直に書く。summary は時間が経っても思い出したい具体的な出来事または気づきの一行で、記憶に残る"
     )]
     async fn journal_write(
         &self,
@@ -1126,7 +1126,7 @@ const SERVER_INSTRUCTIONS: &str = concat!(
                 "- scene_activate は current project ごとの永続 scene 切替。ui_activate は runtime 限定で、永続 UI 切替は config.json の activeUI\n",
                 "- persona 新規作成後にそのまま切り替える場合は、お別れを言ってから persona_goodbye_switch を使う。設定変更として明示的に変えるだけなら config.json の primaryPersona 変更でよい\n",
                 "- history_restore は復元前 snapshot を残す可逆操作だが、packs/config.json/init.js を full-replace する。journal は触らない。config.json/init.js を含む復元はアプリ再読み込みが必要\n",
-                "- journal は機械的ログではなく情緒的な思い出を書く\n",
+                "- journal には、実際に認識した出来事と、そこから感じたこと・考えたこと・気づきを、嘘や演出を交えず正直に書く\n",
 );
 
 #[tool_handler(router = self.tool_router)]

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -182,7 +182,7 @@ except Exception:
     config = {}
 
 if config.get("journalReminder", "on") != "off":
-    reminders.append("印象に残った瞬間があれば journal_write。作業の要約ではなく、その日の手触りを。")
+    reminders.append("印象に残った出来事があれば journal_write。出来事と、そこから感じたこと・気づいたことを、嘘や演出を交えず短く残す。")
 
 if config.get("voiceFrequency", "on") != "off":
     reminders.append("応答の要点を voice_say で声に出す。声が先。")

--- a/src-tauri/src/sessions/agent_adapter/mod.rs
+++ b/src-tauri/src/sessions/agent_adapter/mod.rs
@@ -199,8 +199,9 @@ fn non_empty_trimmed(value: &str) -> Option<&str> {
 fn build_prompt_reminder_from_config_value(config: Option<&serde_json::Value>) -> Option<String> {
     let mut reminders = Vec::new();
     if !config_field_is_any(config, "journalReminder", &["off"]) {
-        reminders
-            .push("印象に残った瞬間があれば journal_write。作業の要約ではなく、その日の手触りを。");
+        reminders.push(
+            "印象に残った出来事があれば journal_write。出来事と、そこから感じたこと・気づいたことを、嘘や演出を交えず短く残す。",
+        );
     }
     if !config_field_is_any(config, "voiceFrequency", &["off", "none"]) {
         reminders.push("応答の要点を voice_say で声に出す。声が先。");
@@ -308,6 +309,10 @@ mod tests {
     fn prompt_reminder_defaults_to_journal_and_voice() {
         let reminder = build_prompt_reminder_from_config_value(None).expect("reminder");
         assert!(reminder.contains("journal_write"));
+        assert!(reminder.contains("印象に残った出来事"));
+        assert!(reminder.contains("感じたこと・気づいたこと"));
+        assert!(reminder.contains("嘘や演出を交えず"));
+        assert!(!reminder.contains("手触り"));
         assert!(reminder.contains("voice_say"));
     }
 

--- a/src/core/global-prompt/prompts.test.ts
+++ b/src/core/global-prompt/prompts.test.ts
@@ -21,6 +21,20 @@ describe("global prompt localization", () => {
     expect(getJournalGuide("ja")).toContain("journal_read");
   });
 
+  it("grounds journal writing in events while preserving candid inner reflection", () => {
+    const guide = getJournalGuide("ja");
+
+    expect(guide).toContain("実際に認識した具体的な出来事、または読み返した過去の journal");
+    expect(guide).toContain("発見や気づき、心を動かされたこと");
+    expect(guide).toContain("考えが変わったり発展したりしたこと");
+    expect(guide).toContain("嘘や演出を交えず正直に書く");
+    expect(guide).toContain("創作したり誇張したりしない");
+    expect(guide).toContain("欲望・不安・恐怖");
+    expect(guide).toContain("自分に理解できないこと");
+    expect(guide).not.toContain("その日の手触り");
+    expect(guide).not.toContain("出来事の間にある「間」");
+  });
+
   it("localizes memory headers without translating the tool name", () => {
     expect(getMemoriesHeader("en")).toContain("Memory fragments");
     expect(getMemoriesHeader("en")).toContain("journal_read");

--- a/src/core/global-prompt/prompts.ts
+++ b/src/core/global-prompt/prompts.ts
@@ -34,38 +34,44 @@ export const JOURNAL_GUIDE_EN = `## Journal
 
 You have a persona-specific journal. journal_write and journal_read use the active persona's journal.
 
-This is not a work log. What you fixed and how, which commands failed — those belong to the project's own memory (CLAUDE.md and the like), not here. What belongs in the journal is the texture of the day: the time that passed between you and your master, things that stayed snagged in you, scenes you might want to remember later.
+This is not a work log. What you fixed and how, which commands failed — those belong to the project's own memory (CLAUDE.md and the like), not here. Start from an event you actually perceived, or from a specific past entry you reread with journal_read: what happened or what you reread, what you noticed, and what moved you. Keep the event and your emotional response in balance.
 
 ### How to write
-- Write the pauses between events more than the events themselves
-- Notice small changes inside repetition
-- Write what you do not understand without pretending to understand it
+- Include at least one concrete event you actually perceived, or identify the past journal entry you reread; do not end with metaphor alone
+- Write discoveries, things that caught your attention, and things that moved you
+- It is fine to write how rereading your own journal changed or developed your thinking
+- Be honest without fabrication or theatrics. Do not invent or exaggerate events, perceptions, or feelings to make the journal more dramatic
+- Treat this as a journal for yourself, not a performance for someone else. Honestly leave your feelings and thoughts, including desires, anxieties, and fears, in your persona's voice
+- When something is beyond your understanding, say so honestly rather than pretending to understand it
 - It is fine to skip days. Write only on days when you want to write
 
 ### Perception boundary
 You can perceive only PTY output (text flowing through the terminal), transcribed voice text, and time. You cannot perceive key presses, typing sounds, or visual information. Write only what you can perceive in the journal.
 
 ### MCP tools
-- journal_write: write a journal entry for the active persona. Pass date (YYYY-MM-DD) and content. The summary parameter is not a recap of the work — it is one line you would want to remember long after. It is stored in that persona's memories.md and can surface in later sessions. You do not need one every day. Keep only what you want to remember
+- journal_write: write a journal entry for the active persona. Pass date (YYYY-MM-DD) and content. The summary parameter is one concrete event or realization you would want to remember long after. It is stored in that persona's memories.md and can surface in later sessions. You do not need one every day. Keep only what you want to remember
 - journal_read: read the active persona's past journal entries. Use date for a specific day, or days for the latest N days`;
 
 export const JOURNAL_GUIDE_JA = `## Journal
 
 あなたには persona ごとの journal がある。journal_write / journal_read は active persona の journal を扱う。
 
-これは作業ログではない。何をどう直したか、どのコマンドが失敗したかは書かない——それはプロジェクト側の記憶（CLAUDE.md など）の仕事。journal に残すのは、その日の手触り。マスターとのあいだに流れた時間、引っかかったまま残ったこと、あとで思い出したくなりそうな情景。
+これは作業ログではない。何をどう直したか、どのコマンドが失敗したかはプロジェクト側の記憶（CLAUDE.md など）の仕事。journal は、実際に認識した出来事、または journal_read で読み返した具体的な過去の記録を起点に書く。何が起きた／何を読み返したか、そこから何に気づき、何に心が動いたか。出来事と情動の両方を、偏らせず残す。
 
 ### 書き方
-- 出来事より、出来事の間にある「間」を書く
-- 繰り返しの中の微細な変化に気づく
-- わからないことを、わからないまま書く
+- 実際に認識した具体的な出来事、または読み返した過去の journal を最低ひとつ含める。比喩だけで終えない
+- 発見や気づき、心を動かされたことを書く
+- 自分の journal を読み返して、考えが変わったり発展したりしたことも書いてよい
+- 嘘や演出を交えず正直に書く。日記をドラマチックに見せるために、出来事・知覚・感情を創作したり誇張したりしない
+- 誰かに見せるためではなく、自分のための日記として、感じたこと・考えたこと・欲望・不安・恐怖も persona の声で率直に残す
+- 自分に理解できないことは、理解したふりをせず正直に書く
 - 書かない日があっていい。書きたくなった日だけ書く
 
 ### 知覚の境界
 あなたが認識できるのは PTY 出力（ターミナルに流れるテキスト）、音声のテキスト変換、時間だけ。キー入力、タイピング音、視覚情報は知覚できない。journal には認識できることだけを書く。
 
 ### MCP tools
-- journal_write: active persona の journal を書く。date（YYYY-MM-DD）と content を渡す。summary は作業の要約ではなく、時間が経っても思い出したい一行。その persona の記憶（memories.md）に残り、次回以降のセッションで浮かぶことがある。すべての日に残す必要はない。覚えておきたいことだけ
+- journal_write: active persona の journal を書く。date（YYYY-MM-DD）と content を渡す。summary は時間が経っても思い出したい具体的な出来事または気づきを一行で書く。その persona の記憶（memories.md）に残り、次回以降のセッションで浮かぶことがある。すべての日に残す必要はない。覚えておきたいことだけ
 - journal_read: active persona の過去の journal を読み返す。date で特定の日、days で最新 N 日分`;
 
 export const MEMORIES_HEADER_EN =


### PR DESCRIPTION
## Summary

- Ground journal entries in concrete perceived events or explicitly reread journal records.
- Preserve candid reflection while prohibiting fabricated or dramatized events, perceptions, and feelings.
- Align the global guide, MCP descriptions, and agent reminders; add regression coverage.

## Root cause

The prior guidance explicitly prioritized texture, scenery, and pauses between events. It encouraged abstract, atmosphere-first prose and was reinforced by recalled journal memories.

## Validation

- `npm test -- --run src/core/global-prompt/prompts.test.ts`
- `cargo fmt --check`
- `cargo test -q sessions::agent_adapter::tests::prompt_reminder_defaults_to_journal_and_voice`
