### PR TITLE
fix: allow restoring bundled Yori VRM

### DIFF
--- a/bundled-packs/ui/yorishiro-settings/ui.tsx
+++ b/bundled-packs/ui/yorishiro-settings/ui.tsx
@@ -2175,6 +2175,9 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
     const stored = localStorage.getItem("yorishiro:vrm");
     return stored ? (stored.split("/").pop() ?? stored) : DEFAULT_VRM_NAME;
   });
+  const [usesCustomVrm, setUsesCustomVrm] = useState(
+    () => localStorage.getItem("yorishiro:vrm") !== null,
+  );
   const [persona, setPersona] = useState<string | null>(null);
   const [scene, setScene] = useState<string | null>(null);
   const [agent, setAgent] = useState<string>("claude");
@@ -2454,11 +2457,19 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
       const dest = await invoke<string>("import_vrm", { src: selected as string });
       ctx.app.setVrm(dest);
       setVrmName(dest.split("/").pop() ?? dest);
+      setUsesCustomVrm(true);
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       console.error("[yorishiro-settings] vrm load failed:", reason);
       ctx.emitEvent("yorishiro-settings:write-failed", { field: "vrm", reason });
     }
+  };
+
+  /** custom VRM の選択だけを解除し、app に同梱された Yori へ戻す。import 済み file は残す。 */
+  const onResetVrm = () => {
+    ctx.app.setVrm(null);
+    setVrmName(DEFAULT_VRM_NAME);
+    setUsesCustomVrm(false);
   };
 
   /** 設定パネルを閉じる共通 helper。 */
@@ -2674,45 +2685,78 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
 
           {/* VRM */}
           <div style={{ opacity: 0.7 }}>VRM</div>
-          <button
-            type="button"
-            onClick={onPickVrm}
+          <div
             style={{
-              position: "relative",
+              display: "flex",
+              alignItems: "center",
+              gap: SPACING.sm,
               width: "100%",
               minWidth: "220px",
               maxWidth: "360px",
-              background: COLORS.bgInput,
-              padding: `6px ${SPACING.xl} 6px 10px`,
-              borderRadius: RADIUS.sm,
-              border: `1px solid ${COLORS.borderSubtle}`,
-              opacity: 0.85,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              cursor: "pointer",
-              color: COLORS.fg,
-              font: "inherit",
-              fontFamily: FONT.family,
-              fontSize: FONT.sizeS,
-              textAlign: "left",
             }}
-            title={vrmName || undefined}
           >
-            {vrmName}
-            <FolderOpen
-              size={12}
-              aria-hidden="true"
+            <button
+              type="button"
+              onClick={onPickVrm}
               style={{
-                position: "absolute",
-                right: SPACING.sm,
-                top: "50%",
-                transform: "translateY(-50%)",
-                pointerEvents: "none",
-                color: COLORS.fgDimmer,
+                position: "relative",
+                flex: 1,
+                minWidth: 0,
+                background: COLORS.bgInput,
+                padding: `6px ${SPACING.xl} 6px 10px`,
+                borderRadius: RADIUS.sm,
+                border: `1px solid ${COLORS.borderSubtle}`,
+                opacity: 0.85,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                cursor: "pointer",
+                color: COLORS.fg,
+                font: "inherit",
+                fontFamily: FONT.family,
+                fontSize: FONT.sizeS,
+                textAlign: "left",
               }}
-            />
-          </button>
+              title={vrmName || undefined}
+            >
+              {vrmName}
+              <FolderOpen
+                size={12}
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  right: SPACING.sm,
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  pointerEvents: "none",
+                  color: COLORS.fgDimmer,
+                }}
+              />
+            </button>
+            {usesCustomVrm ? (
+              <button
+                type="button"
+                onClick={onResetVrm}
+                title={strings.resetVrmToYori}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: SPACING.xs,
+                  flexShrink: 0,
+                  border: "none",
+                  background: "transparent",
+                  padding: `${SPACING.xs} 0`,
+                  color: COLORS.fgDimmer,
+                  cursor: "pointer",
+                  font: "inherit",
+                  fontSize: FONT.sizeXs,
+                }}
+              >
+                <RotateCcw size={12} aria-hidden="true" />
+                {strings.resetVrmToYori}
+              </button>
+            ) : null}
+          </div>
 
           {/* Persona */}
           <div style={{ opacity: 0.7 }}>{strings.labelPersona}</div>

--- a/src/i18n/strings.test.ts
+++ b/src/i18n/strings.test.ts
@@ -127,6 +127,11 @@ describe("changeStrings", () => {
     expect(getStrings("en").defaultFolderName).toBe("~");
     expect(getStrings("ja").defaultFolderName).toBe("~");
   });
+
+  it("labels the bundled Yori VRM reset action in both languages", () => {
+    expect(getStrings("en").resetVrmToYori).toBe("Return to Yori");
+    expect(getStrings("ja").resetVrmToYori).toBe("Yori に戻す");
+  });
 });
 
 describe("restoreConfirmStrings", () => {

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -22,6 +22,7 @@ export interface UiStrings {
   readonly motionLevelLively: string;
   readonly motionLevelOver: string;
   readonly selectVrmFile: string;
+  readonly resetVrmToYori: string;
   readonly agentControlledByProfile: string;
   readonly helpPrompt: string;
   readonly tutorialPrompt: string;
@@ -139,6 +140,7 @@ const EN: UiStrings = {
   motionLevelLively: "Lively",
   motionLevelOver: "Over-the-top",
   selectVrmFile: "Select VRM file",
+  resetVrmToYori: "Return to Yori",
   agentControlledByProfile: "Launch agent is fixed by defaultProfile",
   helpPrompt: "/yori:help",
   tutorialPrompt: "/yori:tutorial",
@@ -252,6 +254,7 @@ const JA: UiStrings = {
   motionLevelLively: "活発",
   motionLevelOver: "オーバー",
   selectVrmFile: "VRM ファイルを選択",
+  resetVrmToYori: "Yori に戻す",
   agentControlledByProfile: "※ 起動 agent は defaultProfile で固定中",
   helpPrompt: "/yori:help",
   tutorialPrompt: "/yori:tutorial",

--- a/src/sdk/ui-pack.d.ts
+++ b/src/sdk/ui-pack.d.ts
@@ -203,7 +203,7 @@ export type FixedTerminalPromptKey = "help" | "tutorial" | "shortcut" | "create-
 export interface UiAppAPI {
   /**
    * VRM body を切り替える。localStorage 永続化と App-level vrmPath state への
-   * 反映を行う。`null` で VRM 未読み込み状態に戻す。
+   * 反映を行う。`null` で custom VRM の選択を解除し、同梱 Yori に戻す。
    */
   setVrm(path: string | null): void;
   /**


### PR DESCRIPTION
## Summary

- show a localized “Return to Yori” action while a custom VRM is selected
- clear the custom VRM selection through the existing `setVrm(null)` path without deleting imported files
- document that a null VRM selection resolves to the bundled Yori model

## Why

After switching from the bundled Yori model to a custom VRM, Settings exposed only another file selection. Users who did not have a standalone copy of Yori’s VRM could not select the bundled model again, even though the app already used it as the null/default fallback.

## User impact

Users can now return to the bundled Yori model directly from Settings. The action appears only when a custom VRM is active, and imported VRM files remain available on disk.

## Validation

- `npm run test:run` — 156 test files, 1912 tests passed
- `npm run build`
- pre-push checks: TypeScript, Biome, cargo fmt, cargo clippy, TypeDoc validation
