### PR TITLE
発話反射層 + voice_say mood — 発話中の顔を生かす

### DIFF
--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -365,6 +365,13 @@ pub struct VoiceSayRequest {
     /// 音声名（省略時は OS デフォルト）。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub voice: Option<String>,
+    /// 発話中だけ重ねる mood。happy / sad / angry / relaxed / surprised を受理する。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mood: Option<String>,
+    /// mood の強さ（0.0-1.0）。省略時は 1.0。
+    #[serde(rename = "moodIntensity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mood_intensity: Option<f64>,
 }
 
 /// `voice_play` の引数。
@@ -915,7 +922,7 @@ impl Yorishiro {
     /// voice_say: TTS でテキストを発話する。住人 AI がキャラクターとして
     /// 声に出したいセリフにのみ使う（全テキスト出力に使うものではない）。
     #[tool(
-        description = "Speak text aloud using text-to-speech. Use this to say something out loud as the character — only call this for dialogue you intend to be heard, not for all text output."
+        description = "Speak text aloud using text-to-speech. Use this to say something out loud as the character — only call this for dialogue you intend to be heard, not for all text output. You may optionally attach a mood (happy/sad/angry/relaxed/surprised) that fades in while speaking and releases when the speech ends."
     )]
     async fn voice_say(
         &self,
@@ -924,7 +931,12 @@ impl Yorishiro {
         emit_to(
             &self.app_handle,
             "voice.say",
-            json!({ "text": req.text, "voice": req.voice }),
+            json!({
+                "text": req.text,
+                "voice": req.voice,
+                "mood": req.mood,
+                "moodIntensity": req.mood_intensity,
+            }),
         )
         .await
     }
@@ -1326,6 +1338,18 @@ mod tests {
             SERVER_INSTRUCTIONS.contains("app_screenshot"),
             "server instructions must mention app_screenshot"
         );
+    }
+
+    #[test]
+    fn voice_say_request_accepts_optional_mood_fields() {
+        let req: VoiceSayRequest = serde_json::from_value(json!({
+            "text": "hello",
+            "mood": "happy",
+            "moodIntensity": 0.4,
+        }))
+        .expect("voice_say request");
+        assert_eq!(req.mood.as_deref(), Some("happy"));
+        assert_eq!(req.mood_intensity, Some(0.4));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1931,6 +1931,8 @@ function App() {
             .map((e) => ({ id: e.id, kind: "amenity" })),
         ];
 
+        let speechMoodGeneration = 0;
+        let speechMoodBody: Body | null = null;
         const handlers: ToolHandlerMap = {
           "list-packs": createListPacksHandler({
             readRegistry: () => packRegistry.listEntries(),
@@ -2170,8 +2172,30 @@ function App() {
           }),
           // ── Voice ─────────────────────────────────────────
           "voice.say": createVoiceSayHandler({
-            speak: (text) => {
-              voiceApi.say(text);
+            speak: (text, _voice, mood) => {
+              const handle = voiceApi.say(text);
+              const body = bodyRef.current;
+              const generation = ++speechMoodGeneration;
+
+              // mood なしの後続発話も発話粒度の上書きとして扱い、前 mood を解く。
+              if (speechMoodBody && (speechMoodBody !== body || mood === undefined)) {
+                speechMoodBody.releaseSpeechMood();
+                speechMoodBody = null;
+              }
+              if (!mood || !body) return;
+
+              body.setSpeechMood(mood.preset, mood.intensity);
+              speechMoodBody = body;
+              // 先行発話の completion が後続発話の mood を解かないよう世代で guard する。
+              void handle.completion
+                .finally(() => {
+                  if (generation !== speechMoodGeneration || speechMoodBody !== body) return;
+                  body.releaseSpeechMood();
+                  speechMoodBody = null;
+                })
+                .catch(() => {
+                  // VoicePlayer の失敗は completion の終了として扱い、handler へ再送出しない。
+                });
             },
             getFrequency: () => voiceFrequency,
           }),

--- a/src/core/body/body.test.ts
+++ b/src/core/body/body.test.ts
@@ -230,6 +230,65 @@ describe("Body speech microexpression wiring", () => {
   });
 });
 
+describe("Body speech mood wiring", () => {
+  function systemMood(body: Body) {
+    return body
+      .getExpressionSlots()
+      .find((slot) => slot.source === "system" && slot.kind === "mood");
+  }
+
+  it("(system, mood) slot を attack 時間で ramp し、(mcp, mood) と共存する", () => {
+    const { vrm } = mockBodyVrm();
+    const body = new Body(vrm, undefined, mockClaimState());
+    body.acquireExpressionSlot("mcp", "mood", "sad", 0.2);
+
+    body.setSpeechMood("happy", 0.8);
+    expect(systemMood(body)).toMatchObject({
+      source: "system",
+      kind: "mood",
+      expressionName: "happy",
+      requestedWeight: 0,
+    });
+
+    body.update(0.15, 0);
+    expect(systemMood(body)?.requestedWeight).toBeCloseTo(0.4);
+    expect(body.getExpressionSlots()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "mcp", kind: "mood", expressionName: "sad" }),
+      ]),
+    );
+  });
+
+  it("release 時間で weight を 0 にしてから slot を解放する", () => {
+    const { vrm } = mockBodyVrm();
+    const body = new Body(vrm, undefined, mockClaimState());
+    body.setSpeechMood("relaxed", 0.8);
+    body.update(0.3, 0);
+
+    body.releaseSpeechMood();
+    body.update(0.25, 0.25);
+    expect(systemMood(body)?.requestedWeight).toBeCloseTo(0.4);
+
+    body.update(0.25, 0.5);
+    expect(systemMood(body)).toBeUndefined();
+  });
+
+  it("新しい speech mood で前の slot を上書きする", () => {
+    const { vrm } = mockBodyVrm();
+    const body = new Body(vrm, undefined, mockClaimState());
+    body.setSpeechMood("happy", 0.8);
+    body.update(0.1, 0);
+
+    body.setSpeechMood("surprised", 0.6);
+
+    const slots = body
+      .getExpressionSlots()
+      .filter((slot) => slot.source === "system" && slot.kind === "mood");
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({ expressionName: "surprised", requestedWeight: 0 });
+  });
+});
+
 // ─── ExpressionManager ───────────────────────────────────
 
 describe("ExpressionManager", () => {

--- a/src/core/body/body.test.ts
+++ b/src/core/body/body.test.ts
@@ -123,6 +123,113 @@ describe("Body lip sync sampling", () => {
   });
 });
 
+// ─── Body speech microexpression wiring ─────────────────
+
+describe("Body speech microexpression wiring", () => {
+  function speechSource(volume: number) {
+    return {
+      isMouthActive: () => true,
+      sampleMouth: vi.fn(() => ({ aa: volume, ih: 0, ou: 0, ee: 0, oh: 0 })),
+    };
+  }
+
+  function exposeExpressions(vrm: VRM, names: ReadonlySet<string>) {
+    const manager = vrm.expressionManager;
+    if (!manager) throw new Error("expression manager is required");
+    vi.spyOn(manager, "getExpression").mockImplementation((name) =>
+      names.has(name) ? ({} as never) : null,
+    );
+    return vi.spyOn(manager, "setValue");
+  }
+
+  it("取得済み mouth 信号から既存 batch へ眉・目の反射 weight を加算する", () => {
+    const { vrm } = mockBodyVrm();
+    const setValue = exposeExpressions(vrm, new Set(["Fcl_BRW_Surprised", "Fcl_EYE_Spread"]));
+    const body = new Body(vrm, undefined, mockClaimState());
+    body.setState("thinking");
+    body.acquireExpressionSlot("persona", "part-brow", "Fcl_BRW_Surprised", 0.03);
+    body.setSpeechExpressionParams({ flickEnabled: false, attackMs: 100 });
+    const source = speechSource(0.8);
+    body.setLipSyncSource(source);
+
+    body.update(0.05, 0);
+
+    expect(source.sampleMouth).toHaveBeenCalledOnce();
+    expect(setValue).toHaveBeenCalledWith("Fcl_BRW_Surprised", expect.any(Number));
+    expect(setValue).toHaveBeenCalledWith("Fcl_EYE_Spread", expect.any(Number));
+    const browWrite = setValue.mock.calls.find(([name]) => name === "Fcl_BRW_Surprised");
+    expect(browWrite?.[1]).toBeGreaterThan(0.03);
+  });
+
+  it("expression claim 中は発話反射を更新・適用しない", () => {
+    const { vrm } = mockBodyVrm();
+    const setValue = exposeExpressions(vrm, new Set(["Fcl_BRW_Surprised", "Fcl_EYE_Spread"]));
+    const claimState = mockClaimState();
+    const body = new Body(vrm, undefined, claimState);
+    body.setLipSyncSource(speechSource(0.8));
+    const claim = claimState.claim("expression");
+
+    body.update(0.1, 0);
+
+    expect(setValue).not.toHaveBeenCalled();
+    claim.dispose();
+  });
+
+  it("対象 morph が無い VRM では発話反射だけを no-op にする", () => {
+    const { vrm } = mockBodyVrm();
+    const setValue = exposeExpressions(vrm, new Set());
+    const body = new Body(vrm, undefined, mockClaimState());
+    body.setLipSyncSource(speechSource(0.8));
+
+    body.update(0.1, 0);
+
+    expect(setValue).not.toHaveBeenCalledWith("Fcl_BRW_Surprised", expect.any(Number));
+    expect(setValue).not.toHaveBeenCalledWith("Fcl_EYE_Spread", expect.any(Number));
+    expect(setValue).toHaveBeenCalledWith("aa", 0.8);
+  });
+
+  it("発話 engagement 中は brow / eye の idle micro を suspend する", () => {
+    const { vrm } = mockBodyVrm();
+    exposeExpressions(vrm, new Set([...MICRO_BROW_POOL, ...MICRO_EYE_POOL, ...MICRO_MOUTH_POOL]));
+    const body = new Body(vrm, undefined, mockClaimState());
+    const channels = (
+      body as unknown as {
+        microChannels: ReadonlyArray<{
+          region: "brow" | "eye" | "mouth";
+          system: IdleMicroexpressionSystem;
+        }>;
+      }
+    ).microChannels;
+    const brow = channels.find((channel) => channel.region === "brow");
+    const eye = channels.find((channel) => channel.region === "eye");
+    brow?.system.injectEpisode("Fcl_BRW_Joy", 0.2, 0.4);
+    eye?.system.injectEpisode("Fcl_EYE_Sorrow", 0.2, 0.4);
+    body.setSpeechExpressionParams({ flickEnabled: false });
+    body.setLipSyncSource(speechSource(0.8));
+
+    body.update(0.05, 0);
+
+    expect(brow?.system.value).toBeNull();
+    expect(eye?.system.value).toBeNull();
+  });
+
+  it("フレーズ境界の要求を BlinkSystem へ渡す", () => {
+    const { vrm } = mockBodyVrm();
+    const body = new Body(vrm, undefined, mockClaimState());
+    const blinkSystem = (body as unknown as { blinkSystem: BlinkSystem }).blinkSystem;
+    const requestBlink = vi.spyOn(blinkSystem, "requestBlink");
+    const source = speechSource(0.8);
+    body.setLipSyncSource(source);
+    body.setSpeechExpressionParams({ gapThresholdMs: 100, blinkProbability: 1 });
+    body.update(0.1, 0);
+    source.sampleMouth.mockReturnValue({ aa: 0, ih: 0, ou: 0, ee: 0, oh: 0 });
+
+    body.update(0.11, 0.11);
+
+    expect(requestBlink).toHaveBeenCalledOnce();
+  });
+});
+
 // ─── ExpressionManager ───────────────────────────────────
 
 describe("ExpressionManager", () => {

--- a/src/core/body/index.ts
+++ b/src/core/body/index.ts
@@ -72,6 +72,7 @@ import {
   type SpeechMicroexpressionParams,
   SpeechMicroexpressionSystem,
 } from "./speech-microexpression-system";
+import { SpeechMoodChannel } from "./speech-mood-channel";
 
 // ─── Constants ───────────────────────────────────────────
 
@@ -155,6 +156,8 @@ export class Body {
   private readonly hasSpeechBrowExpression: boolean;
   private readonly hasSpeechEyeExpression: boolean;
   private speechExpressionEnabled = true;
+  /** voice_say に付随する発話粒度 mood の envelope。 */
+  private readonly speechMood: SpeechMoodChannel;
   private readonly cursorAttention: CursorAttentionSystem;
   private readonly animationPlayer: AnimationPlayer;
   private readonly proceduralBones: ProceduralBones;
@@ -235,6 +238,9 @@ export class Body {
     this.devLog = devLog;
     this.claimState = claimState ?? getClaimState();
     this.expressions = new ExpressionManager();
+    this.speechMood = new SpeechMoodChannel((preset, intensity) =>
+      this.acquireExpressionSlot("system", "mood", preset, intensity),
+    );
     this.blinkSystem = new BlinkSystem();
     this.eyeSystem = new EyeSystem();
     this.eyelids = new EyelidExpressionController(this.expressions, this.blinkSystem);
@@ -356,6 +362,16 @@ export class Body {
     this.speechMicroexpression.setParams(params);
   }
 
+  /** 発話に同期する system mood を attack 付きで開始する。 */
+  setSpeechMood(preset: string, intensity: number): void {
+    this.speechMood.setSpeechMood(preset, intensity);
+  }
+
+  /** 発話に同期する system mood の release を開始する。 */
+  releaseSpeechMood(): void {
+    this.speechMood.releaseSpeechMood();
+  }
+
   /** idle motion 倍率（0-3, 1 で現状）を breathing / procedural bones に伝播する。 */
   setMotionIntensity(intensity: number): void {
     this.breathing.setIntensity(intensity);
@@ -474,6 +490,7 @@ export class Body {
     const animationClaimed = this.claimState.isClaimed("animation");
     const expressionClaimed = this.claimState.isClaimed("expression");
     this.timeSinceStartle += delta;
+    this.speechMood.update(delta);
     this.cursorAttention.update(delta);
     const cursorAttention = this.cursorAttention.writeOutput(this.cursorAttentionOutput);
     this.proceduralBones.setHeadLookAtOffset(

--- a/src/core/body/index.ts
+++ b/src/core/body/index.ts
@@ -67,6 +67,11 @@ import {
   MotionScheduler,
 } from "./motion-scheduler";
 import { ProceduralBones } from "./procedural-bones";
+import {
+  type SpeechMicroexpressionOutput,
+  type SpeechMicroexpressionParams,
+  SpeechMicroexpressionSystem,
+} from "./speech-microexpression-system";
 
 // ─── Constants ───────────────────────────────────────────
 
@@ -77,6 +82,8 @@ export interface LipSyncSource {
 }
 
 const BLINK_EXPRESSION_NAME = "blink";
+const SPEECH_BROW_EXPRESSION_NAME = "Fcl_BRW_Surprised";
+const SPEECH_EYE_EXPRESSION_NAME = "Fcl_EYE_Spread";
 
 // Eye-head coordination：この magnitude 以上の saccade で頭が視線に追従する。
 // gain は「目の移動角の何割を頭が肩代わりするか」（人間はおよそ 2〜3 割）。
@@ -143,6 +150,11 @@ export class Body {
    * Hana 名が無い region は空 pool になり no-op 化する）。
    */
   private readonly microChannels: ReadonlyArray<MicroChannel>;
+  /** 発話音響から顔全体の生理的な賦活を作る反射層。 */
+  private readonly speechMicroexpression = new SpeechMicroexpressionSystem();
+  private readonly hasSpeechBrowExpression: boolean;
+  private readonly hasSpeechEyeExpression: boolean;
+  private speechExpressionEnabled = true;
   private readonly cursorAttention: CursorAttentionSystem;
   private readonly animationPlayer: AnimationPlayer;
   private readonly proceduralBones: ProceduralBones;
@@ -231,6 +243,10 @@ export class Body {
     // pool が空になっても system は no-op 化するだけで動作は壊れない）。
     const filterPool = (pool: ReadonlyArray<string>): ReadonlyArray<string> =>
       pool.filter((name) => vrm.expressionManager?.getExpression(name) !== null);
+    this.hasSpeechBrowExpression =
+      vrm.expressionManager?.getExpression(SPEECH_BROW_EXPRESSION_NAME) !== null;
+    this.hasSpeechEyeExpression =
+      vrm.expressionManager?.getExpression(SPEECH_EYE_EXPRESSION_NAME) !== null;
     this.microChannels = [
       new MicroChannel(
         "brow",
@@ -328,6 +344,16 @@ export class Body {
    */
   setLipSyncSource(source: LipSyncSource | null): void {
     this.lipSyncSource = source;
+  }
+
+  /** 発話反射層の master enable を切り替える。 */
+  setSpeechExpressionEnabled(enabled: boolean): void {
+    this.speechExpressionEnabled = enabled;
+  }
+
+  /** 発話反射層の感触パラメータを部分更新する。 */
+  setSpeechExpressionParams(params: Partial<SpeechMicroexpressionParams>): void {
+    this.speechMicroexpression.setParams(params);
   }
 
   /** idle motion 倍率（0-3, 1 で現状）を breathing / procedural bones に伝播する。 */
@@ -526,6 +552,12 @@ export class Body {
         ? lipSyncSource.sampleMouth(this.lipSyncMouthScratch)
         : null;
     const lipSyncHasSignal = lipSyncMouth ? hasMouthSignal(lipSyncMouth) : false;
+    const speechReflex = this.speechMicroexpression.update(
+      delta,
+      lipSyncMouth,
+      !expressionClaimed && this.speechExpressionEnabled,
+    );
+    if (speechReflex.blinkRequested) this.blinkSystem.requestBlink();
 
     // 5. Gradual relaxed expression (idle 30s+ → relaxed face)
     if (!expressionClaimed) {
@@ -539,10 +571,13 @@ export class Body {
       });
 
       // 5b. Region 別 idle micro layer — brow / eye / mouth が独立 instance で並走。
-      //     mouth だけは lip sync 中は suspend（visemes と競合させない）。
+      //     発話中は mouth の viseme に加え、brow / eye も発話反射層へ所有権を渡す。
       const microBaseEnabled = !nonIdleMoodActive;
+      const speechEngaged = this.speechMicroexpression.engagement > 0;
       for (const ch of this.microChannels) {
-        const enabled = microBaseEnabled && (ch.region !== "mouth" || !lipSyncHasSignal);
+        const speechSuspended =
+          (ch.region === "mouth" && lipSyncHasSignal) || (ch.region !== "mouth" && speechEngaged);
+        const enabled = microBaseEnabled && !speechSuspended;
         ch.update(delta, enabled);
       }
     } else {
@@ -555,7 +590,7 @@ export class Body {
 
     // 6. Apply expressions to VRM
     if (!expressionClaimed) {
-      this.applyExpressions(lipSyncMouth);
+      this.applyExpressions(lipSyncMouth, speechReflex);
     }
 
     // 7. Apply eye gaze to VRM
@@ -803,7 +838,10 @@ export class Body {
 
   // ─── Internal apply methods ───────────────────────────
 
-  private applyExpressions(lipSyncMouth: MouthValues | null): void {
+  private applyExpressions(
+    lipSyncMouth: MouthValues | null,
+    speechReflex: SpeechMicroexpressionOutput,
+  ): void {
     const exprMgr = this.vrm.expressionManager;
     if (!exprMgr) return;
 
@@ -820,6 +858,21 @@ export class Body {
           batch.set(k, lipSyncMouth[k]);
         }
       }
+    }
+
+    // 発話反射は slot を持たず、lip sync と同じ batch 直書きで既存表情へ加算する。
+    // ExpressionManager の kind 単位 suppress から独立させ、persona / idle を壊さない。
+    if (this.hasSpeechBrowExpression && speechReflex.browWeight > 0) {
+      batch.set(
+        SPEECH_BROW_EXPRESSION_NAME,
+        Math.min(1, (batch.get(SPEECH_BROW_EXPRESSION_NAME) ?? 0) + speechReflex.browWeight),
+      );
+    }
+    if (this.hasSpeechEyeExpression && speechReflex.eyeWeight > 0) {
+      batch.set(
+        SPEECH_EYE_EXPRESSION_NAME,
+        Math.min(1, (batch.get(SPEECH_EYE_EXPRESSION_NAME) ?? 0) + speechReflex.eyeWeight),
+      );
     }
 
     this.expressionSink.apply(batch, (name, weight) => {

--- a/src/core/body/speech-microexpression-system.test.ts
+++ b/src/core/body/speech-microexpression-system.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MouthValues } from "../voice/mouth-values";
+import { SpeechMicroexpressionSystem } from "./speech-microexpression-system";
+
+const SILENCE: MouthValues = { aa: 0, ih: 0, ou: 0, ee: 0, oh: 0 };
+
+function mouth(volume: number): MouthValues {
+  return { aa: volume, ih: 0, ou: 0, ee: 0, oh: 0 };
+}
+
+function createSystem(random: () => number = () => 0): SpeechMicroexpressionSystem {
+  const system = new SpeechMicroexpressionSystem(random);
+  system.setParams({
+    attackMs: 100,
+    releaseMs: 400,
+    gapThresholdMs: 250,
+    blinkProbability: 0.6,
+    onsetThreshold: 0.3,
+    onsetMinVolume: 0.4,
+    refractoryMs: 1_500,
+    flickDurationMs: 250,
+  });
+  return system;
+}
+
+describe("SpeechMicroexpressionSystem", () => {
+  it("無音から発話へ入ると engagement が attack 時間で立ち上がる", () => {
+    const system = createSystem();
+
+    const halfway = system.update(0.05, mouth(0.8), true);
+    expect(system.engagement).toBeCloseTo(0.5);
+    expect(halfway.browWeight).toBeGreaterThan(0);
+    expect(halfway.eyeWeight).toBeGreaterThan(0);
+
+    system.update(0.05, mouth(0.8), true);
+    expect(system.engagement).toBe(1);
+  });
+
+  it("発話から無音へ入ると engagement が release 時間で下がる", () => {
+    const system = createSystem();
+    system.update(0.1, mouth(0.8), true);
+
+    const halfway = system.update(0.2, SILENCE, true);
+    expect(system.engagement).toBeCloseTo(0.5);
+    expect(halfway.eyeWeight).toBeGreaterThan(0);
+
+    system.update(0.2, SILENCE, true);
+    expect(system.engagement).toBe(0);
+  });
+
+  it("発話後の無音ギャップが確定すると確率抽選で blink を要求する", () => {
+    const random = vi.fn(() => 0.2);
+    const system = createSystem(random);
+    system.update(0.1, mouth(0.8), true);
+
+    expect(system.update(0.2, SILENCE, true).blinkRequested).toBe(false);
+    expect(system.update(0.06, SILENCE, true).blinkRequested).toBe(true);
+    expect(random).toHaveBeenCalledOnce();
+  });
+
+  it("同じ無音ギャップでは blink を一度しか抽選しない", () => {
+    const random = vi.fn(() => 0.2);
+    const system = createSystem(random);
+    system.update(0.1, mouth(0.8), true);
+
+    expect(system.update(0.3, SILENCE, true).blinkRequested).toBe(true);
+    expect(system.update(0.3, SILENCE, true).blinkRequested).toBe(false);
+    expect(random).toHaveBeenCalledOnce();
+
+    system.update(0.1, mouth(0.8), true);
+    expect(system.update(0.3, SILENCE, true).blinkRequested).toBe(true);
+    expect(random).toHaveBeenCalledTimes(2);
+  });
+
+  it("急峻な onset で眉 flick を出し、refractory 中の再発火を抑える", () => {
+    const system = createSystem();
+    system.setParams({ engagementEnabled: false });
+
+    expect(system.update(0.05, mouth(0.8), true).browWeight).toBeGreaterThan(0);
+    system.update(0.25, SILENCE, true);
+    expect(system.update(0.05, mouth(0.8), true).browWeight).toBe(0);
+
+    system.update(1.2, SILENCE, true);
+    expect(system.update(0.05, mouth(0.8), true).browWeight).toBeGreaterThan(0);
+  });
+
+  it("mouth=null は出力と内部状態を即座にリセットする", () => {
+    const random = vi.fn(() => 0.2);
+    const system = createSystem(random);
+    system.update(0.1, mouth(0.8), true);
+
+    expect(system.update(0.05, null, true)).toEqual({
+      browWeight: 0,
+      eyeWeight: 0,
+      blinkRequested: false,
+    });
+    expect(system.engagement).toBe(0);
+    expect(system.update(0.3, SILENCE, true).blinkRequested).toBe(false);
+    expect(random).not.toHaveBeenCalled();
+  });
+
+  it("enabled=false は出力と内部状態を即座にリセットする", () => {
+    const system = createSystem();
+    system.update(0.1, mouth(0.8), true);
+
+    expect(system.update(0.05, mouth(0.8), false)).toEqual({
+      browWeight: 0,
+      eyeWeight: 0,
+      blinkRequested: false,
+    });
+    expect(system.engagement).toBe(0);
+  });
+
+  it("engagement と flick の合算を morph ごとの上限でクランプする", () => {
+    const system = createSystem();
+    system.setParams({
+      engagementBrowWeight: 1,
+      engagementEyeWeight: 1,
+      flickWeight: 1,
+      browWeightMax: 0.12,
+      eyeWeightMax: 0.08,
+    });
+
+    const out = system.update(0.1, mouth(1), true);
+    expect(out.browWeight).toBe(0.12);
+    expect(out.eyeWeight).toBe(0.08);
+  });
+
+  it("update は allocation-free の同一出力 object を再利用する", () => {
+    const system = createSystem();
+    const first = system.update(0.05, mouth(0.8), true);
+    const second = system.update(0.05, mouth(0.8), true);
+    expect(second).toBe(first);
+  });
+});

--- a/src/core/body/speech-microexpression-system.ts
+++ b/src/core/body/speech-microexpression-system.ts
@@ -1,0 +1,255 @@
+import type { MouthValues } from "../voice/mouth-values";
+
+export interface SpeechMicroexpressionParams {
+  engagementEnabled: boolean;
+  blinkEnabled: boolean;
+  flickEnabled: boolean;
+  speechThreshold: number;
+  attackMs: number;
+  releaseMs: number;
+  engagementBrowWeight: number;
+  engagementEyeWeight: number;
+  browWeightMax: number;
+  eyeWeightMax: number;
+  gapThresholdMs: number;
+  blinkProbability: number;
+  onsetThreshold: number;
+  onsetMinVolume: number;
+  refractoryMs: number;
+  flickDurationMs: number;
+  flickWeight: number;
+}
+
+// tentative: 実機調整前提
+export const DEFAULT_SPEECH_MICROEXPRESSION_PARAMS: Readonly<SpeechMicroexpressionParams> = {
+  engagementEnabled: true,
+  blinkEnabled: true,
+  flickEnabled: true,
+  speechThreshold: 0.05,
+  attackMs: 150,
+  releaseMs: 800,
+  engagementBrowWeight: 0.06,
+  engagementEyeWeight: 0.04,
+  browWeightMax: 0.14,
+  eyeWeightMax: 0.08,
+  gapThresholdMs: 250,
+  blinkProbability: 0.6,
+  onsetThreshold: 0.22,
+  onsetMinVolume: 0.3,
+  refractoryMs: 1_500,
+  flickDurationMs: 250,
+  flickWeight: 0.08,
+};
+
+export interface SpeechMicroexpressionOutput {
+  browWeight: number;
+  eyeWeight: number;
+  blinkRequested: boolean;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function approach(current: number, target: number, step: number): number {
+  if (current < target) return Math.min(target, current + step);
+  return Math.max(target, current - step);
+}
+
+/**
+ * 発話音響から、眉・目元の賦活とフレーズ境界 blink を作る純ロジック層。
+ * 感情は推定せず、Body が一度だけ取得した lip-sync 値だけを入力に使う。
+ */
+export class SpeechMicroexpressionSystem {
+  private readonly random: () => number;
+  private readonly currentParams: SpeechMicroexpressionParams = {
+    ...DEFAULT_SPEECH_MICROEXPRESSION_PARAMS,
+  };
+  private readonly out: SpeechMicroexpressionOutput = {
+    browWeight: 0,
+    eyeWeight: 0,
+    blinkRequested: false,
+  };
+
+  private engagementValue = 0;
+  private speechObserved = false;
+  private gapElapsedS = 0;
+  private gapHandled = false;
+  private previousVolume = 0;
+  private refractoryRemainingS = 0;
+  private flickElapsedS = 0;
+  private flickActive = false;
+
+  constructor(random?: () => number) {
+    this.random = random ?? Math.random;
+  }
+
+  /** 現在の調整値へ部分更新を適用する。 */
+  setParams(params: Partial<SpeechMicroexpressionParams>): void {
+    const next = this.currentParams;
+    if (params.engagementEnabled !== undefined) {
+      next.engagementEnabled = params.engagementEnabled;
+    }
+    if (params.blinkEnabled !== undefined) next.blinkEnabled = params.blinkEnabled;
+    if (params.flickEnabled !== undefined) next.flickEnabled = params.flickEnabled;
+    if (params.speechThreshold !== undefined) {
+      next.speechThreshold = clamp(params.speechThreshold, 0, 1);
+    }
+    if (params.attackMs !== undefined) next.attackMs = Math.max(1, params.attackMs);
+    if (params.releaseMs !== undefined) next.releaseMs = Math.max(1, params.releaseMs);
+    if (params.engagementBrowWeight !== undefined) {
+      next.engagementBrowWeight = Math.max(0, params.engagementBrowWeight);
+    }
+    if (params.engagementEyeWeight !== undefined) {
+      next.engagementEyeWeight = Math.max(0, params.engagementEyeWeight);
+    }
+    if (params.browWeightMax !== undefined) {
+      next.browWeightMax = clamp(params.browWeightMax, 0, 1);
+    }
+    if (params.eyeWeightMax !== undefined) {
+      next.eyeWeightMax = clamp(params.eyeWeightMax, 0, 1);
+    }
+    if (params.gapThresholdMs !== undefined) {
+      next.gapThresholdMs = Math.max(0, params.gapThresholdMs);
+    }
+    if (params.blinkProbability !== undefined) {
+      next.blinkProbability = clamp(params.blinkProbability, 0, 1);
+    }
+    if (params.onsetThreshold !== undefined) {
+      next.onsetThreshold = clamp(params.onsetThreshold, 0, 1);
+    }
+    if (params.onsetMinVolume !== undefined) {
+      next.onsetMinVolume = clamp(params.onsetMinVolume, 0, 1);
+    }
+    if (params.refractoryMs !== undefined) {
+      next.refractoryMs = Math.max(0, params.refractoryMs);
+    }
+    if (params.flickDurationMs !== undefined) {
+      next.flickDurationMs = Math.max(1, params.flickDurationMs);
+    }
+    if (params.flickWeight !== undefined) {
+      next.flickWeight = Math.max(0, params.flickWeight);
+    }
+  }
+
+  /** 発話エンゲージメント envelope の現在値。 */
+  get engagement(): number {
+    return this.engagementValue;
+  }
+
+  /**
+   * 1 frame 分の信号を進め、再利用される出力 object を返す。
+   * mouth=null と enabled=false は停止を表し、状態を即座に初期化する。
+   */
+  update(
+    delta: number,
+    mouth: Readonly<MouthValues> | null,
+    enabled: boolean,
+  ): SpeechMicroexpressionOutput {
+    this.clearOutput();
+    if (!enabled || mouth === null) {
+      this.reset();
+      return this.out;
+    }
+
+    const safeDelta = Math.max(0, delta);
+    const volume = Math.max(mouth.aa, mouth.ih, mouth.ou, mouth.ee, mouth.oh);
+    const speaking = volume > this.currentParams.speechThreshold;
+
+    this.updateEngagement(safeDelta, speaking);
+    this.updateBlink(safeDelta, speaking);
+    const flickStrength = this.updateFlick(safeDelta, volume, speaking);
+
+    const engagementBrow = this.engagementValue * this.currentParams.engagementBrowWeight;
+    const engagementEye = this.engagementValue * this.currentParams.engagementEyeWeight;
+    this.out.browWeight = clamp(
+      engagementBrow + flickStrength * this.currentParams.flickWeight,
+      0,
+      this.currentParams.browWeightMax,
+    );
+    this.out.eyeWeight = clamp(engagementEye, 0, this.currentParams.eyeWeightMax);
+    this.previousVolume = volume;
+    return this.out;
+  }
+
+  private updateEngagement(delta: number, speaking: boolean): void {
+    if (!this.currentParams.engagementEnabled) {
+      this.engagementValue = 0;
+      return;
+    }
+    const durationS =
+      (speaking ? this.currentParams.attackMs : this.currentParams.releaseMs) / 1_000;
+    this.engagementValue = approach(this.engagementValue, speaking ? 1 : 0, delta / durationS);
+  }
+
+  private updateBlink(delta: number, speaking: boolean): void {
+    if (!this.currentParams.blinkEnabled) {
+      this.resetBlink();
+      return;
+    }
+    if (speaking) {
+      this.speechObserved = true;
+      this.gapElapsedS = 0;
+      this.gapHandled = false;
+      return;
+    }
+    if (!this.speechObserved || this.gapHandled) return;
+
+    this.gapElapsedS += delta;
+    if (this.gapElapsedS < this.currentParams.gapThresholdMs / 1_000) return;
+    this.gapHandled = true;
+    this.out.blinkRequested = this.random() < this.currentParams.blinkProbability;
+  }
+
+  private updateFlick(delta: number, volume: number, speaking: boolean): number {
+    if (!this.currentParams.flickEnabled) {
+      this.refractoryRemainingS = 0;
+      this.flickElapsedS = 0;
+      this.flickActive = false;
+      return 0;
+    }
+
+    this.refractoryRemainingS = Math.max(0, this.refractoryRemainingS - delta);
+    const isOnset =
+      speaking &&
+      volume >= this.currentParams.onsetMinVolume &&
+      volume - this.previousVolume >= this.currentParams.onsetThreshold;
+    if (isOnset && this.refractoryRemainingS <= 0) {
+      this.flickActive = true;
+      this.flickElapsedS = 0;
+      this.refractoryRemainingS = this.currentParams.refractoryMs / 1_000;
+    }
+
+    if (!this.flickActive) return 0;
+    const durationS = this.currentParams.flickDurationMs / 1_000;
+    this.flickElapsedS += delta;
+    if (this.flickElapsedS >= durationS) {
+      this.flickActive = false;
+      this.flickElapsedS = 0;
+      return 0;
+    }
+    const progress = this.flickElapsedS / durationS;
+    return progress <= 0.5 ? progress * 2 : (1 - progress) * 2;
+  }
+
+  private clearOutput(): void {
+    this.out.browWeight = 0;
+    this.out.eyeWeight = 0;
+    this.out.blinkRequested = false;
+  }
+
+  private resetBlink(): void {
+    this.speechObserved = false;
+    this.gapElapsedS = 0;
+    this.gapHandled = false;
+  }
+
+  private reset(): void {
+    this.engagementValue = 0;
+    this.resetBlink();
+    this.previousVolume = 0;
+    this.refractoryRemainingS = 0;
+    this.flickElapsedS = 0;
+    this.flickActive = false;
+  }
+}

--- a/src/core/body/speech-mood-channel.test.ts
+++ b/src/core/body/speech-mood-channel.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { SpeechMoodChannel, type SpeechMoodHandle } from "./speech-mood-channel";
+
+function createHarness() {
+  const handles: Array<SpeechMoodHandle> = [];
+  const acquire = vi.fn((_preset: string, _intensity: number): SpeechMoodHandle => {
+    const handle = {
+      setIntensity: vi.fn(),
+      release: vi.fn(),
+    };
+    handles.push(handle);
+    return handle;
+  });
+  return { channel: new SpeechMoodChannel(acquire), acquire, handles };
+}
+
+describe("SpeechMoodChannel", () => {
+  it("attack 時間で 0 から指定 intensity まで ramp する", () => {
+    const { channel, acquire, handles } = createHarness();
+    channel.setSpeechMood("happy", 0.8);
+
+    expect(acquire).toHaveBeenCalledWith("happy", 0);
+    channel.update(0.15);
+    expect(handles[0]?.setIntensity).toHaveBeenLastCalledWith(0.4);
+
+    channel.update(0.15);
+    expect(handles[0]?.setIntensity).toHaveBeenLastCalledWith(0.8);
+  });
+
+  it("release 時間で 0 まで ramp してから handle を解放する", () => {
+    const { channel, handles } = createHarness();
+    channel.setSpeechMood("sad", 0.8);
+    channel.update(0.3);
+
+    channel.releaseSpeechMood();
+    channel.update(0.25);
+    expect(handles[0]?.setIntensity).toHaveBeenLastCalledWith(0.4);
+    expect(handles[0]?.release).not.toHaveBeenCalled();
+
+    channel.update(0.25);
+    expect(handles[0]?.setIntensity).toHaveBeenLastCalledWith(0);
+    expect(handles[0]?.release).toHaveBeenCalledOnce();
+  });
+
+  it("新しい mood は前の handle を即時解放して上書きする", () => {
+    const { channel, acquire, handles } = createHarness();
+    channel.setSpeechMood("happy", 0.8);
+    channel.update(0.1);
+
+    channel.setSpeechMood("surprised", 0.6);
+
+    expect(handles[0]?.release).toHaveBeenCalledOnce();
+    expect(acquire).toHaveBeenLastCalledWith("surprised", 0);
+    channel.update(0.15);
+    expect(handles[1]?.setIntensity).toHaveBeenLastCalledWith(0.3);
+  });
+
+  it("intensity を 0-1 にクランプする", () => {
+    const { channel, handles } = createHarness();
+    channel.setSpeechMood("angry", 3);
+    channel.update(0.3);
+    expect(handles[0]?.setIntensity).toHaveBeenLastCalledWith(1);
+  });
+});

--- a/src/core/body/speech-mood-channel.ts
+++ b/src/core/body/speech-mood-channel.ts
@@ -1,0 +1,65 @@
+export interface SpeechMoodHandle {
+  setIntensity(intensity: number): void;
+  release(): void;
+}
+
+export type AcquireSpeechMood = (preset: string, intensity: number) => SpeechMoodHandle;
+
+// tentative: 実機調整前提
+const SPEECH_MOOD_ATTACK_S = 0.3;
+const SPEECH_MOOD_RELEASE_S = 0.5;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** 発話単位の mood slot に attack / release envelope を与える。 */
+export class SpeechMoodChannel {
+  private readonly acquire: AcquireSpeechMood;
+  private handle: SpeechMoodHandle | null = null;
+  private intensity = 0;
+  private envelope = 0;
+  private releasing = false;
+
+  constructor(acquire: AcquireSpeechMood) {
+    this.acquire = acquire;
+  }
+
+  /** 前の mood を上書きし、0 weight から attack を開始する。 */
+  setSpeechMood(preset: string, intensity: number): void {
+    this.handle?.release();
+    this.intensity = clamp(Number.isFinite(intensity) ? intensity : 1, 0, 1);
+    this.envelope = 0;
+    this.releasing = false;
+    this.handle = this.acquire(preset, 0);
+  }
+
+  /** 現在値から release を開始する。 */
+  releaseSpeechMood(): void {
+    if (!this.handle) return;
+    this.releasing = true;
+    if (this.envelope <= 0) this.finishRelease();
+  }
+
+  /** Body の frame delta で envelope を進める。 */
+  update(delta: number): void {
+    const handle = this.handle;
+    if (!handle || delta <= 0) return;
+
+    if (this.releasing) {
+      this.envelope = Math.max(0, this.envelope - delta / SPEECH_MOOD_RELEASE_S);
+    } else {
+      this.envelope = Math.min(1, this.envelope + delta / SPEECH_MOOD_ATTACK_S);
+    }
+    handle.setIntensity(this.envelope * this.intensity);
+    if (this.releasing && this.envelope <= 0) this.finishRelease();
+  }
+
+  private finishRelease(): void {
+    this.handle?.release();
+    this.handle = null;
+    this.intensity = 0;
+    this.envelope = 0;
+    this.releasing = false;
+  }
+}

--- a/src/core/debug-controls/index.ts
+++ b/src/core/debug-controls/index.ts
@@ -1,2 +1,3 @@
 export { CameraControls } from "./camera-controls";
 export { SceneLayerControls } from "./scene-layer-controls";
+export { SpeechExpressionControls } from "./speech-expression-controls";

--- a/src/core/debug-controls/speech-expression-controls.tsx
+++ b/src/core/debug-controls/speech-expression-controls.tsx
@@ -1,0 +1,174 @@
+/** 発話反射層の実機調整用 leva controls。 */
+
+import { useFrame } from "@react-three/fiber";
+import { folder, useControls } from "leva";
+import { useRef } from "react";
+import { getThreeRuntime } from "../../runtime/three-runtime";
+import type { RuntimeLevaStore } from "../../runtime/three-runtime/runtime-leva-store";
+import type { Body } from "../body";
+import {
+  DEFAULT_SPEECH_MICROEXPRESSION_PARAMS,
+  type SpeechMicroexpressionParams,
+} from "../body/speech-microexpression-system";
+
+export interface SpeechExpressionControlsProps {
+  readonly store?: RuntimeLevaStore;
+}
+
+export function SpeechExpressionControls({ store }: SpeechExpressionControlsProps) {
+  const runtime = getThreeRuntime();
+  const defaults = DEFAULT_SPEECH_MICROEXPRESSION_PARAMS;
+  const [controls] = useControls(
+    () => ({
+      speech: folder({
+        enabled: { value: true, label: "enabled" },
+        engagementEnabled: { value: defaults.engagementEnabled, label: "CH1 engagement" },
+        blinkEnabled: { value: defaults.blinkEnabled, label: "CH2 phrase blink" },
+        flickEnabled: { value: defaults.flickEnabled, label: "CH3 brow flick" },
+        speechThreshold: {
+          value: defaults.speechThreshold,
+          min: 0,
+          max: 0.5,
+          step: 0.01,
+          label: "speech threshold",
+        },
+        attackMs: {
+          value: defaults.attackMs,
+          min: 50,
+          max: 500,
+          step: 10,
+          label: "attack (ms)",
+        },
+        releaseMs: {
+          value: defaults.releaseMs,
+          min: 100,
+          max: 2_000,
+          step: 25,
+          label: "release (ms)",
+        },
+        engagementBrowWeight: {
+          value: defaults.engagementBrowWeight,
+          min: 0,
+          max: 0.3,
+          step: 0.005,
+          label: "engagement brow",
+        },
+        engagementEyeWeight: {
+          value: defaults.engagementEyeWeight,
+          min: 0,
+          max: 0.3,
+          step: 0.005,
+          label: "engagement eye",
+        },
+        browWeightMax: {
+          value: defaults.browWeightMax,
+          min: 0,
+          max: 0.4,
+          step: 0.005,
+          label: "brow max weight",
+        },
+        eyeWeightMax: {
+          value: defaults.eyeWeightMax,
+          min: 0,
+          max: 0.3,
+          step: 0.005,
+          label: "eye max weight",
+        },
+        gapThresholdMs: {
+          value: defaults.gapThresholdMs,
+          min: 100,
+          max: 800,
+          step: 10,
+          label: "phrase gap (ms)",
+        },
+        blinkProbability: {
+          value: defaults.blinkProbability,
+          min: 0,
+          max: 1,
+          step: 0.05,
+          label: "blink probability",
+        },
+        onsetThreshold: {
+          value: defaults.onsetThreshold,
+          min: 0,
+          max: 1,
+          step: 0.01,
+          label: "onset rise",
+        },
+        onsetMinVolume: {
+          value: defaults.onsetMinVolume,
+          min: 0,
+          max: 1,
+          step: 0.01,
+          label: "onset min volume",
+        },
+        refractoryMs: {
+          value: defaults.refractoryMs,
+          min: 200,
+          max: 4_000,
+          step: 50,
+          label: "refractory (ms)",
+        },
+        flickDurationMs: {
+          value: defaults.flickDurationMs,
+          min: 100,
+          max: 600,
+          step: 10,
+          label: "flick duration (ms)",
+        },
+        flickWeight: {
+          value: defaults.flickWeight,
+          min: 0,
+          max: 0.3,
+          step: 0.005,
+          label: "flick weight",
+        },
+      }),
+    }),
+    { store },
+    [],
+  );
+
+  const params: SpeechMicroexpressionParams = {
+    engagementEnabled: controls.engagementEnabled,
+    blinkEnabled: controls.blinkEnabled,
+    flickEnabled: controls.flickEnabled,
+    speechThreshold: controls.speechThreshold,
+    attackMs: controls.attackMs,
+    releaseMs: controls.releaseMs,
+    engagementBrowWeight: controls.engagementBrowWeight,
+    engagementEyeWeight: controls.engagementEyeWeight,
+    browWeightMax: controls.browWeightMax,
+    eyeWeightMax: controls.eyeWeightMax,
+    gapThresholdMs: controls.gapThresholdMs,
+    blinkProbability: controls.blinkProbability,
+    onsetThreshold: controls.onsetThreshold,
+    onsetMinVolume: controls.onsetMinVolume,
+    refractoryMs: controls.refractoryMs,
+    flickDurationMs: controls.flickDurationMs,
+    flickWeight: controls.flickWeight,
+  };
+  const lastApplied = useRef<{
+    body: Body | null;
+    enabled: boolean;
+    params: SpeechMicroexpressionParams;
+  } | null>(null);
+
+  // Body は controls より後に生成され得るため、render loop 上で instance 変更も拾う。
+  useFrame(() => {
+    const body = runtime.getBody();
+    const previous = lastApplied.current;
+    if (
+      previous?.body === body &&
+      previous.enabled === controls.enabled &&
+      previous.params === params
+    ) {
+      return;
+    }
+    body?.setSpeechExpressionEnabled(controls.enabled);
+    body?.setSpeechExpressionParams(params);
+    lastApplied.current = { body, enabled: controls.enabled, params };
+  });
+
+  return null;
+}

--- a/src/core/global-prompt/prompts.ts
+++ b/src/core/global-prompt/prompts.ts
@@ -112,6 +112,7 @@ Voice comes FIRST, text output comes after.
 - Call voice_say BEFORE writing any text output
 - Detailed explanations, code, and technical content go in text only
 - Keep the spoken phrase short and natural (one sentence max)
+- For clearly emotional dialogue, you may add a mood; it is optional
 - Match tone and phrasing to your character`;
 
 export const VOICE_GUIDE_ON_JA = `## 音声
@@ -123,6 +124,7 @@ export const VOICE_GUIDE_ON_JA = `## 音声
 - voice_say をテキスト出力より先に呼ぶ
 - 詳しい説明、コード、技術的な内容はテキストのみ
 - 声に出すフレーズは短く自然に（一文以内）
+- 感情が明確な発話には mood を添えられる。必須ではない
 - 声のトーンはキャラクターに合わせる`;
 
 export const VOICE_GUIDE_OFF_EN = `## Voice

--- a/src/core/global-prompt/prompts.ts
+++ b/src/core/global-prompt/prompts.ts
@@ -112,7 +112,7 @@ Voice comes FIRST, text output comes after.
 - Call voice_say BEFORE writing any text output
 - Detailed explanations, code, and technical content go in text only
 - Keep the spoken phrase short and natural (one sentence max)
-- For clearly emotional dialogue, you may add a mood; it is optional
+- When your dialogue carries feeling, attach a mood (happy/sad/angry/relaxed/surprised)
 - Match tone and phrasing to your character`;
 
 export const VOICE_GUIDE_ON_JA = `## 音声
@@ -124,7 +124,7 @@ export const VOICE_GUIDE_ON_JA = `## 音声
 - voice_say をテキスト出力より先に呼ぶ
 - 詳しい説明、コード、技術的な内容はテキストのみ
 - 声に出すフレーズは短く自然に（一文以内）
-- 感情が明確な発話には mood を添えられる。必須ではない
+- 気持ちが動いている発話には mood を添える（happy/sad/angry/relaxed/surprised）
 - 声のトーンはキャラクターに合わせる`;
 
 export const VOICE_GUIDE_OFF_EN = `## Voice

--- a/src/runtime/three-runtime/r3f-runtime-root.test.tsx
+++ b/src/runtime/three-runtime/r3f-runtime-root.test.tsx
@@ -99,6 +99,7 @@ import simpleRoomDefinition from "../../../bundled-packs/scenes/simple-room/scen
 import { controlFolder, useYorishiroControls } from "../../sdk/controls";
 import { getSceneRegistry } from "../scene-pack-registry";
 import { R3fRuntimeRoot } from "./r3f-runtime-root";
+import { getRuntimeLevaStore } from "./runtime-leva-store";
 import { getActiveSceneLevaStore } from "./scene-pack-leva-store";
 
 function getMockRegistry(): SceneRegistryHarness {
@@ -134,6 +135,17 @@ afterEach(() => {
 });
 
 describe("R3fRuntimeRoot", () => {
+  it("runtime store に speech folder を既定値どおり登録する", () => {
+    render(<R3fRuntimeRoot />);
+
+    const store = getRuntimeLevaStore();
+    expect(store?.get("speech.enabled")).toBe(true);
+    expect(store?.get("speech.attackMs")).toBe(150);
+    expect(store?.get("speech.releaseMs")).toBe(800);
+    expect(store?.get("speech.blinkProbability")).toBe(0.6);
+    expect(store?.get("speech.refractoryMs")).toBe(1_500);
+  });
+
   it("subscribes to active entry and disposes on unmount", () => {
     const registry = getMockRegistry();
     const afterUnmountRender = vi.fn((props: ScenePackComponentProps) => {

--- a/src/runtime/three-runtime/r3f-runtime-root.tsx
+++ b/src/runtime/three-runtime/r3f-runtime-root.tsx
@@ -16,7 +16,11 @@ import { useFrame } from "@react-three/fiber";
 import { useCreateStore } from "leva";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import type * as THREE from "three";
-import { CameraControls, SceneLayerControls } from "../../core/debug-controls";
+import {
+  CameraControls,
+  SceneLayerControls,
+  SpeechExpressionControls,
+} from "../../core/debug-controls";
 import type { Disposable, Vec3 } from "../../sdk/context";
 import { ControlStoreProvider } from "../../sdk/controls";
 import type { ScenePackCameraAPI } from "../../sdk/scene-pack";
@@ -71,6 +75,7 @@ export function R3fRuntimeRoot({ children }: R3fRuntimeRootProps) {
       ) : null}
       <DefaultAttentionCueLight />
       <CameraControls store={runtimeLevaStore} />
+      <SpeechExpressionControls store={runtimeLevaStore} />
       {children}
     </>
   );

--- a/src/runtime/yorishiro-mcp/tool-handlers.test.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.test.ts
@@ -56,6 +56,7 @@ import {
   createUiActivateHandler,
   createUiSidebarSetHandler,
   createUiTerminalSetHandler,
+  createVoiceSayHandler,
 } from "./tool-handlers";
 
 /**
@@ -2603,6 +2604,66 @@ describe("createSetMotionIntensityHandler", () => {
 
     expect(config.disabledPacks).toEqual(["target"]);
     expect(config.motionIntensity).toBe(2);
+  });
+});
+
+describe("createVoiceSayHandler", () => {
+  it("valid mood と intensity を speak へ透過する", async () => {
+    const speak = vi.fn();
+    const handler = createVoiceSayHandler({ speak, getFrequency: () => "on" });
+
+    await handler({ text: "hello", voice: "Kyoko", mood: "happy", moodIntensity: 0.4 });
+
+    expect(speak).toHaveBeenCalledWith("hello", "Kyoko", {
+      preset: "happy",
+      intensity: 0.4,
+    });
+  });
+
+  it.each(["happy", "sad", "angry", "relaxed", "surprised"])("mood=%s を受理する", async (mood) => {
+    const speak = vi.fn();
+    const handler = createVoiceSayHandler({ speak, getFrequency: () => "on" });
+
+    await handler({ text: "hello", mood });
+
+    expect(speak).toHaveBeenCalledWith("hello", undefined, { preset: mood, intensity: 1 });
+  });
+
+  it("invalid mood は無視して発話を続ける", async () => {
+    const speak = vi.fn();
+    const handler = createVoiceSayHandler({ speak, getFrequency: () => "on" });
+
+    await expect(handler({ text: "hello", mood: "excited", moodIntensity: 0.5 })).resolves.toEqual({
+      spoken: true,
+    });
+    expect(speak).toHaveBeenCalledWith("hello", undefined, undefined);
+  });
+
+  it.each([
+    [-1, 0],
+    [2, 1],
+  ])("moodIntensity=%s を %s にクランプする", async (input, expected) => {
+    const speak = vi.fn();
+    const handler = createVoiceSayHandler({ speak, getFrequency: () => "on" });
+
+    await handler({ text: "hello", mood: "sad", moodIntensity: input });
+
+    expect(speak).toHaveBeenCalledWith("hello", undefined, {
+      preset: "sad",
+      intensity: expected,
+    });
+  });
+
+  it("moodIntensity が number でなければ既定値 1 を使う", async () => {
+    const speak = vi.fn();
+    const handler = createVoiceSayHandler({ speak, getFrequency: () => "on" });
+
+    await handler({ text: "hello", mood: "relaxed", moodIntensity: "strong" });
+
+    expect(speak).toHaveBeenCalledWith("hello", undefined, {
+      preset: "relaxed",
+      intensity: 1,
+    });
   });
 });
 

--- a/src/runtime/yorishiro-mcp/tool-handlers.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.ts
@@ -1819,8 +1819,13 @@ export function createPersonaGoodbyeSwitchHandler(deps: PersonaGoodbyeSwitchDeps
  * ────────────────────────────────────────────────────────── */
 
 export interface VoiceSayDeps {
-  readonly speak: (text: string, voice?: string) => void;
+  readonly speak: (text: string, voice?: string, mood?: VoiceSayMood) => void;
   readonly getFrequency: () => "on" | "off";
+}
+
+export interface VoiceSayMood {
+  readonly preset: "happy" | "sad" | "angry" | "relaxed" | "surprised";
+  readonly intensity: number;
 }
 
 export interface VoiceSayResult {
@@ -1841,7 +1846,25 @@ export function createVoiceSayHandler(deps: VoiceSayDeps) {
       return { spoken: false };
     }
     const voice = typeof r.voice === "string" ? r.voice : undefined;
-    deps.speak(text, voice);
+    const preset =
+      r.mood === "happy" ||
+      r.mood === "sad" ||
+      r.mood === "angry" ||
+      r.mood === "relaxed" ||
+      r.mood === "surprised"
+        ? r.mood
+        : null;
+    const rawIntensity = r.moodIntensity;
+    const mood: VoiceSayMood | undefined = preset
+      ? {
+          preset,
+          intensity:
+            typeof rawIntensity === "number" && Number.isFinite(rawIntensity)
+              ? Math.max(0, Math.min(1, rawIntensity))
+              : 1,
+        }
+      : undefined;
+    deps.speak(text, voice, mood);
     return { spoken: true };
   };
 }


### PR DESCRIPTION
## 概要

発話中の Yori の顔が「idle 用の顔 + 動く口」になっていた問題への対処。2 つの独立した層を追加する。

- **発話反射層（Speech Microexpression）** — リップシンク解析の音響信号から、発話中に顔全体が生理的に賦活する。感情は推定しない（context wall 準拠）。3 チャネル: エンゲージメント envelope（眉・目元の張り）/ フレーズ境界 blink / 韻律眉 flick。
- **voice_say mood** — `voice_say` に optional な `mood` / `moodIntensity` を追加。発話開始で fade-in、発話終了で release される発話粒度の感情同期。

設計の canonical は design-record `2026-07-15-speech-expression-design.md`（設計判断・棄却案）。

## 設計上の要点

- 反射層は ExpressionManager の slot を**使わず**、`applyExpressions` の batch 段で加算合成（lip sync と同型の音響 additive）。reflex source の slot は kind 単位 suppress で idle micro / relaxed を全滅させるため。
- voice_say mood の slot は **(source:"system", kind:"mood")**。(mcp, mood) だと dedup が `body_expression_set` の hold を破壊する。
- 発話中は idle micro の brow / eye も suspend（発話中の顔の所有権は発話反射層へ）。
- 感触パラメータは全部 tentative。leva "speech" folder でチャネル個別 on/off + 帰納チューニング可能。
- mood 省略時の挙動は完全に従来どおり（default 不変）。

## 検証

- tsc / biome / cargo fmt / clippy / cargo test / vitest 1943 (+32) / production build すべて pass
- 実機で動作確認済み（マスター確認済み）

## 既知の磨き残し（実機チューニングの場で扱う）

- 発話終端で mouth が null になると engagement が release envelope を経ずに即 0 になる（現在の微小 weight では知覚困難。振幅を上げる場合は要対処）
- 強い mood 保持中はエンゲージメントの微弱な張りが知覚的に埋もれる。mood 中の反射減衰（ducking）は実機の合算を見て判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)