### PR TITLE
feat: 反射の可視化 — Trigger.description + persona_reflex_list

### DIFF
--- a/bundled-packs/personas/yori-shared/persona-factory.ts
+++ b/bundled-packs/personas/yori-shared/persona-factory.ts
@@ -124,6 +124,7 @@ export function createYoriPersona(args: {
         // Philosophy: docs/philosophy/PHILOSOPHY.md「意識に先立つ反応」
         {
           id: "yori:error",
+          description: "tool 失敗で distressed を発火（Grep / Glob の空振りは benign として抑止）",
           match(event: DispatchEvent) {
             if (event.kind !== "hook-signal") return null;
             if (event.signal.name !== "post-tool-failure") return null;
@@ -155,6 +156,7 @@ export function createYoriPersona(args: {
         // push 結果行が流れない。PostToolUse hook の payload から検知する。
         {
           id: "yori:git-push-success",
+          description: "git push 成功を bash tool の出力から検知して celebrate を発火",
           match(event: DispatchEvent) {
             if (event.kind !== "hook-signal") return null;
             if (event.signal.name !== "post-tool-use") return null;
@@ -181,6 +183,8 @@ export function createYoriPersona(args: {
         // motion/effect の timeline は shortcut 経路と同じ runShootTimeline を共有する。
         {
           id: "yori:idle-shoot",
+          description:
+            "idle 15 分到達時に一度だけ低確率でいたずらの shoot 演出を発火（1 run 最大 1 回）",
           match(event: DispatchEvent) {
             if (event.kind !== "idle") return null;
             if (event.durationMs < SHOOT_IDLE_THRESHOLD_MS) return null;
@@ -199,6 +203,7 @@ export function createYoriPersona(args: {
         // motion/effect の timeline は idle 経路と同じ response handler が持つ。
         {
           id: "yori:shortcut-shoot",
+          description: "synthetic event yori:shoot（init.js ショートカット）で shoot 演出を発火",
           match(event: DispatchEvent) {
             if (event.kind !== "synthetic") return null;
             if (event.name !== SHOOT_SYNTHETIC_EVENT) return null;
@@ -216,6 +221,8 @@ export function createYoriPersona(args: {
         // Internal design-record: specs/2026-04-25-settings-screen-design.md §5
         {
           id: "yori:settings-write-failed",
+          description:
+            "設定 UI の書き込み失敗（synthetic event）で shake なしの settings-error を発火",
           match(event: DispatchEvent) {
             if (event.kind !== "synthetic") return null;
             if (event.name !== "yorishiro-settings:write-failed") return null;

--- a/src-tauri/resources/yorishiro-plugin/commands-en/create.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/create.md
@@ -279,6 +279,16 @@ export default {
 6. If switching now, do not edit `~/.yorishiro/config.json` directly. Use the say-goodbye switch below
 7. If creating only, briefly tell the user the persona was created
 
+### Designing reflexes
+
+Reflexes define which events move the body and how — the other half of the personality, on par with speech. They can be omitted, but choose knowingly:
+
+- **If you omit `reflex`, the persona inherits the bundled default (Yori) reflexes wholesale**: frowning on errors, fireworks on a successful push, a mischievous gunshot after a long absence. That may not fit a serious persona — if so, declare `reflex` explicitly (declaring even one severs the inheritance entirely)
+- The reaction vocabulary is the standard set (`startled` / `contemplative` / `pleased` / `distressed` / `curious` / `focused` / `acknowledging` / `idle-fidget` / `confused` / `bored`) plus arbitrary custom strings. Start with 2-3 reactions and add more after observing them live
+- Give each custom trigger a `description` (one human-readable sentence describing when it fires). The match function's code cannot be read from outside, so this is the only explanation that appears in listings
+- Check what an existing persona reacts to with `persona_reflex_list({ "personaId": "<id>" })` (omit personaId for the active persona). `reflexSource: "inherited-default"` means the bundled defaults are inherited wholesale
+- Reference implementation: `bundled-packs/personas/yori-shared/persona-factory.ts`
+
 ### Say Goodbye and Switch
 
 When the user wants to switch immediately after creating a new persona, say goodbye as the current resident and then call `persona_goodbye_switch`. Do not write `primaryPersona` directly.

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/create.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/create.md
@@ -273,6 +273,16 @@ export default {
 6. 切り替える場合は `~/.yorishiro/config.json` を直接編集しない。下記「お別れして切り替える」を行う
 7. 作るだけで切り替えない場合は、作成完了を短く伝える
 
+### 反射（reflex）を設計する
+
+反射は「どの出来事に体がどう動くか」——口調と同格の、人格のもう半分。省略もできるが、挙動を知った上で選ぶ：
+
+- **reflex を書かない場合、bundled default（Yori）の反射を丸ごと継承する**。エラーで顔をしかめ、push 成功で花火を上げ、長い離席でいたずらの銃を撃つ——真面目な persona には合わないことがある。合わなければ reflex を明示する（1 つでも書けば継承は切れて、全て自前になる）
+- 反応の語彙は standard vocabulary（`startled` / `contemplative` / `pleased` / `distressed` / `curious` / `focused` / `acknowledging` / `idle-fidget` / `confused` / `bored`）+ 任意の custom 文字列。まず 2〜3 反応から始めて、実機で観察してから足す
+- custom trigger には `description`（人間可読の発火条件の一文）を書く。match 関数のコードは外から読めないため、これが一覧表示に載る唯一の説明になる
+- 既存 persona が何に反応するかは `persona_reflex_list({ "personaId": "<id>" })` で確認できる（personaId 省略で active persona）。`reflexSource: "inherited-default"` なら bundled default の丸ごと継承
+- 参考実装: `bundled-packs/personas/yori-shared/persona-factory.ts`
+
 ### お別れして切り替える
 
 新規 persona 作成後にそのまま切り替える場合は、今の住人としてお別れを言ってから `persona_goodbye_switch` を呼ぶ。`primaryPersona` を直接書き換えない。

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -275,6 +275,14 @@ pub struct PersonaGoodbyeSwitchRequest {
     pub vrm_path: Option<String>,
 }
 
+/// `persona_reflex_list` の引数。personaId 省略時は active persona。
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PersonaReflexListRequest {
+    /// 対象 persona pack id（省略時は active persona）。
+    #[serde(default, rename = "personaId")]
+    pub persona_id: Option<String>,
+}
+
 /// `vrm_validate` の引数。
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct VrmValidateRequest {
@@ -1009,6 +1017,25 @@ impl Yorishiro {
         .await
         .map_err(|e| McpError::internal_error(e, None))?;
         unwrap_ts_response(r)
+    }
+
+    /// persona_reflex_list: TS runtime に委譲。persona の反射一覧
+    /// （trigger の宣言と reaction handler の構成）を返す。
+    #[tool(
+        description = "List a persona's reflexes: triggers (id + human-readable description) and responses (reaction -> handlers with label/weight/cooldownMs). Omit personaId for the active persona. reflexSource shows whether the persona defines its own reflexes, inherits the bundled defaults wholesale, or has none. Use before switching personas or when authoring a persona pack."
+    )]
+    async fn persona_reflex_list(
+        &self,
+        Parameters(req): Parameters<PersonaReflexListRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let response = emit_tool_event(
+            &self.app_handle,
+            "persona-reflex-list",
+            json!({ "personaId": req.persona_id }),
+        )
+        .await
+        .map_err(|e| McpError::internal_error(e, None))?;
+        unwrap_ts_response(response)
     }
 
     /// VRM パスの事前検証。モデルの切替は行わない。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1802,6 +1802,7 @@ function App() {
         const {
           createListPacksHandler,
           createPackDiagnoseHandler,
+          createPersonaReflexListHandler,
           createDisablePackHandler,
           createEnablePackHandler,
           createGetPackStateHandler,
@@ -2161,6 +2162,12 @@ function App() {
               const dest = await invoke<string>("import_vrm", { src: path });
               localStorage.setItem(VRM_STORAGE_KEY, dest);
             },
+          }),
+          "persona-reflex-list": createPersonaReflexListHandler({
+            listPersonaEntries: () => personaRegistry.listEntries(),
+            getActivePersonaId: () => personaRegistry.getActivePersonaId(),
+            // loader の personaDefaults と同じ選択（reference 比較で継承判定するため）
+            getDefaultReflex: () => (resolvedLanguage === "ja" ? yoriJaPack : yoriEnPack).reflex,
           }),
           // ── Presence intensity ────────────────────────────
           "presence.set-intensity": createPresenceSetIntensityHandler({

--- a/src/runtime/yorishiro-mcp/tool-handlers.test.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.test.ts
@@ -5,7 +5,13 @@
  * merge 規則と state 更新の correctness のみ確認する。
  */
 
-import type { SpaceEffectRequest, UiContext, UiLayout, UiPackManifest } from "@yorishiro/sdk";
+import type {
+  PersonaDefinition,
+  SpaceEffectRequest,
+  UiContext,
+  UiLayout,
+  UiPackManifest,
+} from "@yorishiro/sdk";
 import type * as THREE from "three";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TweenManager } from "../../core/tween/tween-manager";
@@ -45,6 +51,7 @@ import {
   createLoopAnnounceHandler,
   createPackDiagnoseHandler,
   createPersonaGoodbyeSwitchHandler,
+  createPersonaReflexListHandler,
   createPresenceSetIntensityHandler,
   createSceneActivateHandler,
   createSetMotionIntensityHandler,
@@ -2792,5 +2799,126 @@ describe("createAttentionLightCueHandler", () => {
     const handler = createAttentionLightCueHandler({ trigger });
     const result = await handler({});
     expect(result).toEqual({ triggered: false, reason: "cooldown" });
+  });
+});
+
+describe("createPersonaReflexListHandler", () => {
+  const noop = async () => {};
+
+  const yoriReflex: NonNullable<PersonaDefinition["reflex"]> = {
+    customTriggers: [
+      {
+        id: "yori:git-push-success",
+        description: "git push 成功で celebrate を発火",
+        match: () => null,
+      },
+      // description 未宣言の trigger
+      { id: "yori:error", match: () => null },
+    ],
+    responses: {
+      celebrate: { handlers: [{ label: "fireworks-and-smile", handler: noop }] },
+      "idle-fidget": {
+        handlers: [
+          { weight: 3, label: "look-around", handler: noop },
+          { weight: 1, cooldownMs: 180000, label: "subtle-stretch", handler: noop },
+        ],
+      },
+    },
+  };
+
+  const yoriEntry = {
+    id: "yori",
+    origin: "bundled" as const,
+    persona: { id: "yori", name: "Yori", reflex: yoriReflex } as PersonaDefinition,
+  };
+
+  const makeHandler = (
+    overrides: Partial<Parameters<typeof createPersonaReflexListHandler>[0]> = {},
+  ) =>
+    createPersonaReflexListHandler({
+      listPersonaEntries: () => [yoriEntry],
+      getActivePersonaId: () => "yori",
+      getDefaultReflex: () => yoriReflex,
+      ...overrides,
+    });
+
+  it("personaId 省略時は active persona の trigger / response 一覧を返す", async () => {
+    const result = await makeHandler()({});
+    expect(result.personaId).toBe("yori");
+    expect(result.origin).toBe("bundled");
+    expect(result.triggers).toEqual([
+      { id: "yori:git-push-success", description: "git push 成功で celebrate を発火" },
+      { id: "yori:error", description: null },
+    ]);
+    expect(result.responses).toEqual({
+      celebrate: [{ label: "fireworks-and-smile", weight: 1, cooldownMs: null }],
+      "idle-fidget": [
+        { label: "look-around", weight: 3, cooldownMs: null },
+        { label: "subtle-stretch", weight: 1, cooldownMs: 180000 },
+      ],
+    });
+  });
+
+  it("bundled persona は default reflex と同一 reference でも own と報告する", async () => {
+    const result = await makeHandler()({});
+    expect(result.reflexSource).toBe("own");
+  });
+
+  it("reflex を持たない user persona（loader が default を merge 済み）は inherited-default", async () => {
+    const minimal = {
+      id: "minimal",
+      origin: "user" as const,
+      // loader の applyPersonaDefaults 相当：bundled default の reflex を共有
+      persona: { id: "minimal", name: "最小住人", reflex: yoriReflex } as PersonaDefinition,
+    };
+    const result = await makeHandler({
+      listPersonaEntries: () => [yoriEntry, minimal],
+    })({ personaId: "minimal" });
+    expect(result.reflexSource).toBe("inherited-default");
+    // 継承の場合も「実際に発火するもの」として default の中身を列挙する
+    expect(result.triggers).toHaveLength(2);
+  });
+
+  it("独自 reflex を持つ user persona は own", async () => {
+    const custom = {
+      id: "custom",
+      origin: "user" as const,
+      persona: {
+        id: "custom",
+        name: "独自",
+        reflex: { responses: { pleased: { handlers: [{ handler: noop }] } } },
+      } as PersonaDefinition,
+    };
+    const result = await makeHandler({
+      listPersonaEntries: () => [yoriEntry, custom],
+    })({ personaId: "custom" });
+    expect(result.reflexSource).toBe("own");
+    expect(result.responses).toEqual({
+      pleased: [{ label: null, weight: 1, cooldownMs: null }],
+    });
+  });
+
+  it("reflex が無い（fallback も無効な）persona は none で空一覧", async () => {
+    const bare = {
+      id: "bare",
+      origin: "user" as const,
+      persona: { id: "bare", name: "素" } as PersonaDefinition,
+    };
+    const result = await makeHandler({
+      listPersonaEntries: () => [yoriEntry, bare],
+    })({ personaId: "bare" });
+    expect(result.reflexSource).toBe("none");
+    expect(result.triggers).toEqual([]);
+    expect(result.responses).toEqual({});
+  });
+
+  it("未登録の personaId は既知 id 一覧つきで throw する", async () => {
+    await expect(makeHandler()({ personaId: "ghost" })).rejects.toThrow(/known: yori/);
+  });
+
+  it("active も personaId も無ければ throw する", async () => {
+    await expect(makeHandler({ getActivePersonaId: () => null })({})).rejects.toThrow(
+      /no active persona/,
+    );
   });
 });

--- a/src/runtime/yorishiro-mcp/tool-handlers.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.ts
@@ -12,6 +12,7 @@ import type {
   LoopPhase,
   MotionHandle,
   MotionSnapshot,
+  PersonaDefinition,
   SpaceEffectRequest,
 } from "@yorishiro/sdk";
 import type * as THREE from "three";
@@ -1811,6 +1812,104 @@ export function createPersonaGoodbyeSwitchHandler(deps: PersonaGoodbyeSwitchDeps
     });
 
     return { active: id, reloading: true };
+  };
+}
+
+/* ──────────────────────────────────────────────────────────
+ * persona.reflex-list
+ * ────────────────────────────────────────────────────────── */
+
+export interface PersonaReflexEntryInput {
+  readonly id: string;
+  readonly origin: "bundled" | "user";
+  readonly persona: PersonaDefinition;
+}
+
+export interface PersonaReflexListDeps {
+  /** 登録済み persona の列挙（PersonaRegistry.listEntries 相当）。 */
+  readonly listPersonaEntries: () => ReadonlyArray<PersonaReflexEntryInput>;
+  readonly getActivePersonaId: () => string | null;
+  /**
+   * loader が reflex 省略時の fallback に使う bundled default の reflex。
+   * registry には merge 後の definition が入るため、reference 比較で
+   * 「丸ごと継承」かどうかを判定する。
+   */
+  readonly getDefaultReflex: () => PersonaDefinition["reflex"] | undefined;
+}
+
+export interface PersonaReflexTriggerSummary {
+  readonly id: string;
+  /** Trigger.description（未宣言なら null）。match 条件は introspect できない。 */
+  readonly description: string | null;
+}
+
+export interface PersonaReflexHandlerSummary {
+  readonly label: string | null;
+  readonly weight: number;
+  readonly cooldownMs: number | null;
+}
+
+export interface PersonaReflexListResponse {
+  readonly personaId: string;
+  readonly name: string;
+  readonly origin: "bundled" | "user";
+  /**
+   * own: この persona 自身が reflex を定義 / inherited-default: reflex を
+   * 書いておらず bundled default を丸ごと継承 / none: reflex なし。
+   */
+  readonly reflexSource: "own" | "inherited-default" | "none";
+  readonly triggers: ReadonlyArray<PersonaReflexTriggerSummary>;
+  readonly responses: Readonly<Record<string, ReadonlyArray<PersonaReflexHandlerSummary>>>;
+}
+
+export function createPersonaReflexListHandler(deps: PersonaReflexListDeps) {
+  return async (request: unknown): Promise<PersonaReflexListResponse> => {
+    const r = requestRecord(request);
+    const requested = typeof r.personaId === "string" && r.personaId !== "" ? r.personaId : null;
+    const id = requested ?? deps.getActivePersonaId();
+    if (id === null) {
+      throw new Error("no active persona and no personaId given");
+    }
+    const entries = deps.listPersonaEntries();
+    const entry = entries.find((e) => e.id === id);
+    if (entry === undefined) {
+      const known = entries.map((e) => e.id).join(", ");
+      throw new Error(`persona '${id}' is not registered (known: ${known})`);
+    }
+
+    const reflex = entry.persona.reflex;
+    const reflexSource: PersonaReflexListResponse["reflexSource"] =
+      reflex === undefined
+        ? "none"
+        : entry.origin === "bundled"
+          ? "own"
+          : reflex === deps.getDefaultReflex()
+            ? "inherited-default"
+            : "own";
+
+    const triggers = (reflex?.customTriggers ?? []).map((t) => ({
+      id: t.id,
+      description: t.description ?? null,
+    }));
+
+    const responses: Record<string, PersonaReflexHandlerSummary[]> = {};
+    for (const [reaction, set] of Object.entries(reflex?.responses ?? {})) {
+      if (set === undefined) continue;
+      responses[reaction] = set.handlers.map((h) => ({
+        label: h.label ?? null,
+        weight: h.weight ?? 1,
+        cooldownMs: h.cooldownMs ?? null,
+      }));
+    }
+
+    return {
+      personaId: entry.id,
+      name: entry.persona.name,
+      origin: entry.origin,
+      reflexSource,
+      triggers,
+      responses,
+    };
   };
 }
 

--- a/src/sdk/reaction.d.ts
+++ b/src/sdk/reaction.d.ts
@@ -399,6 +399,12 @@ export interface SyntheticEvent {
  */
 export interface Trigger {
   readonly id: string;
+  /**
+   * 人間可読の発火条件の一文（例:「git push 成功で celebrate を発火」）。
+   * match 関数のコードは外から introspect できないため、`persona_reflex_list`
+   * はこの宣言を一覧に載せる。pack 作者は書くことを推奨。
+   */
+  readonly description?: string;
   /** 複数 trigger が同じ event に match したときの優先度（大きいほど先） */
   readonly priority?: number;
   /**


### PR DESCRIPTION
## 概要（#61 の上に stack）

反射は発火するまで不可視で、「この persona は何に反応するのか」を確認する手段がなかった（shoot が persona によって動いたり動かなかったりする問題の温床）。可視化の P0 として 3 点：

1. **SDK: `Trigger.description`**（optional）— match 関数は外から introspect できないため、発火条件の人間可読な一文を宣言できるようにする。bundled Yori の 5 trigger に実際に記述し、参考実装としての手本にした。
2. **MCP tool `persona_reflex_list`** — persona 単位で triggers（id + description）と responses（reaction → label / weight / cooldownMs）を列挙。`personaId` 省略で active persona。`reflexSource: "own" | "inherited-default" | "none"` で「reflex を書いておらず bundled default を丸ごと継承している」状態が初めて見える。
3. **create.md に「反射（reflex）を設計する」節**（日英）— 継承挙動（省略＝Yori 丸ごと・1 つ書けば全自前）、標準反応語彙 10 種、description の慣習、`persona_reflex_list` での確認方法。

## 検証

- vitest 1960/1960 pass（handler 7 テスト新規）
- cargo test 247 pass、`npm run check` pass

経緯: design-record 2026-07-18-persona-scope-review.md §6

🤖 Generated with [Claude Code](https://claude.com/claude-code)