### PR TITLE
fix(runtime): support pack-relative imports in TSX transpiler

### DIFF
--- a/src/runtime/user-pack-loader/tsx-transpiler.test.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("esbuild-wasm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("esbuild-wasm")>();
+  return {
+    ...actual,
+    initialize: () => actual.initialize({}),
+  };
+});
+
 import {
   buildTsxEntryUrl,
   isSupportedTsxHostImport,
   isTsxEntryPath,
   resolveRelativeTsxImport,
+  transpileUiTsxEntry,
   tsxHostShimNamedExports,
 } from "./tsx-transpiler";
 
@@ -79,6 +89,34 @@ describe("resolveRelativeTsxImport", () => {
         "/Users/me/.yorishiro/packs/my-room",
       ),
     ).toBeNull();
+  });
+});
+
+describe("transpileUiTsxEntry", () => {
+  it("bundles an entry that imports a pack-local source file", async () => {
+    const entryPath = "/Users/me/.yorishiro/packs/my-room/scene.tsx";
+    const sources = new Map([
+      [entryPath, 'import { roomName } from "./lib/room"; export default { roomName };'],
+      ["/Users/me/.yorishiro/packs/my-room/lib/room.ts", 'export const roomName = "warm-room";'],
+    ]);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const path = new URL(String(input)).pathname;
+      const source = sources.get(path);
+      return source === undefined
+        ? new Response("not found", { status: 404 })
+        : new Response(source, { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const code = await transpileUiTsxEntry(entryPath, {
+        convertFileSrc: (path) => `https://asset.local${path}`,
+      });
+
+      expect(code).toContain("warm-room");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/src/runtime/user-pack-loader/tsx-transpiler.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.ts
@@ -341,7 +341,6 @@ function createPlan4MvpPlugin(
         return {
           path: resolved,
           namespace: USER_SOURCE_NAMESPACE,
-          resolveDir: dirname(resolved),
         };
       });
       build.onResolve({ filter: /.*/ }, (args) => ({


### PR DESCRIPTION
## Summary

- remove the unsupported `resolveDir` field from the esbuild `onResolve` result for pack-relative imports
- add an end-to-end transpiler regression test that bundles a TSX entry with a pack-local source import
- keep browser initialization unchanged while adapting esbuild-wasm initialization only inside the Node test environment

## Root cause

`resolveDir` is valid on esbuild `OnLoadResult`, but not on `OnResolveResult`. esbuild-wasm validates plugin callback results strictly, so any user `scene.tsx` or `ui.tsx` containing a relative import failed before bundling.

## Impact

User packs can split TS/TSX source into pack-local modules such as `./lib/palette`, matching the documented SDK contract.

## Validation

- regression test reproduced `Invalid option from onResolve() ... "resolveDir"` before the fix
- `npx vitest run src/runtime/user-pack-loader/` — 270 tests passed
- `npm run check` — passed
- pre-push checks — TypeScript, Biome, cargo fmt, cargo clippy, and TypeDoc passed
- isolated Tauri E2E using Vite `1432` and MCP `18744`:
  - `enable_pack` returned `{"ok":true}`
  - `pack_diagnose` reported the scene loaded and active
  - a scene imported `./lib/palette.ts` and rendered its `#174f5f` background value
