### PR TITLE
Support terminal background opacity

### DIFF
--- a/src-tauri/resources/yorishiro-plugin/commands-en/help.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/help.md
@@ -146,7 +146,7 @@ Use `controls_transition({ scope: "common", values, durationMs })` for camera mo
 | Tool | Arguments | Purpose |
 |---|---|---|
 | `ui_sidebar_set(...)` | width, optional durationMs | Set sidebar width in px, optionally animated |
-| `ui_terminal_set(...)` | opacity, optional durationMs | Set terminal opacity, optionally animated |
+| `ui_terminal_set(...)` | optional opacity, backgroundOpacity, durationMs | Set terminal or background opacity, optionally animated |
 
 ### Runtime State
 

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/help.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/help.md
@@ -146,7 +146,7 @@ ui pack は `ctx.state` で独自の key-value を持ち、`get_ui_state` / `set
 | tool | 引数 | 説明 |
 |---|---|---|
 | `ui_sidebar_set(...)` | width, durationMs? | サイドバー幅を設定（px、durationMs で滑らか補間） |
-| `ui_terminal_set(...)` | opacity, durationMs? | ターミナル透明度を設定（durationMs で滑らか補間） |
+| `ui_terminal_set(...)` | opacity?, backgroundOpacity?, durationMs? | ターミナル全体または背景のみの不透明度を設定（durationMs で滑らか補間） |
 
 ### 全体 state
 

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -323,12 +323,16 @@ fn validate_vrm_file(path: &str) -> Result<std::path::PathBuf, String> {
     Ok(expanded)
 }
 
-/// `ui_terminal_set` の引数。terminal container の opacity を操作する。
+/// `ui_terminal_set` の引数。terminal 全体と背景の opacity を操作する。
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct UiTerminalSetRequest {
     /// Terminal container opacity 0-1。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<f32>,
+    /// Terminal background opacity 0-1。文字の opacity には影響しない。
+    #[serde(rename = "backgroundOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_opacity: Option<f32>,
     /// 補間時間（ms）。省略 / 0 で即時反映。
     #[serde(rename = "durationMs")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -843,8 +847,10 @@ impl Yorishiro {
         emit_to(&self.app_handle, "body.motion.cancel", json!({})).await
     }
 
-    /// terminal container の opacity を設定する。durationMs > 0 で TweenManager による滑らか補間。
-    #[tool(description = "Set terminal opacity. Supports smooth interpolation via durationMs.")]
+    /// terminal 全体または背景の opacity を設定する。durationMs > 0 で TweenManager による滑らか補間。
+    #[tool(
+        description = "Set terminal or terminal-background opacity. Supports smooth interpolation via durationMs."
+    )]
     async fn ui_terminal_set(
         &self,
         Parameters(req): Parameters<UiTerminalSetRequest>,
@@ -854,6 +860,7 @@ impl Yorishiro {
             "ui.terminal.set",
             json!({
                 "opacity": req.opacity,
+                "backgroundOpacity": req.background_opacity,
                 "durationMs": req.duration_ms,
             }),
         )

--- a/src/App.css
+++ b/src/App.css
@@ -679,7 +679,7 @@ body,
   background-color: var(--yorishiro-bg);
 }
 
-/* layout 由来：terminal 背景のみ透明化（文字は不透明のまま、背後の
+/* layout 由来：terminal 背景のみ半透明化（文字は不透明のまま、背後の
    character/scene が透ける）。runtime が container に xterm-bg-transparent を
    付けたときだけ各 background-painting layer を透過。通常 terminal は不変。 */
 .xterm-singleton-container.xterm-bg-transparent,
@@ -687,6 +687,19 @@ body,
 .xterm-singleton-container.xterm-bg-transparent .xterm-viewport,
 .xterm-singleton-container.xterm-bg-transparent .xterm-screen {
   background: transparent !important;
+}
+
+/* placeholder の左 padding は文字用に xterm 本体を右へずらすため、そのままだと
+   半透明背景と隣接する枠の間だけ scene が素通しになる。背景板だけ同じ幅ぶん延長する。 */
+.xterm-singleton-container.xterm-bg-transparent::after {
+  position: absolute;
+  top: 0;
+  right: 100%;
+  bottom: 0;
+  width: var(--terminal-placeholder-pad-left, 0px);
+  pointer-events: none;
+  content: "";
+  background: var(--terminal-background-color, transparent);
 }
 
 /* ── Sidebar top row ────────────────────────────────── */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2110,6 +2110,15 @@ function App() {
               const ids = queryMountedSessionIds();
               return ids.length === 0 ? 1 : getTerminalRuntime(ids[0]).getOpacity();
             },
+            setTerminalBackgroundOpacity: (value) => {
+              for (const id of queryMountedSessionIds()) {
+                getTerminalRuntime(id).setBackgroundOpacity(value);
+              }
+            },
+            getTerminalBackgroundOpacity: () => {
+              const ids = queryMountedSessionIds();
+              return ids.length === 0 ? 1 : getTerminalRuntime(ids[0]).getBackgroundOpacity();
+            },
             tweenManager: getThreeRuntime().getTweenManager(),
           }),
           "ui.sidebar.set": createUiSidebarSetHandler({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -696,7 +696,7 @@ function queryMountedSessionIds(): string[] {
 interface TerminalPresentation {
   readonly hidden: boolean;
   readonly opacity: number;
-  readonly backgroundTransparent: boolean;
+  readonly backgroundOpacity: number;
 }
 
 function terminalLayoutForcesSinglePane(layout: UiLayout | null): boolean {
@@ -717,11 +717,17 @@ function resolveTerminalPresentation(
     receivesLayout && typeof terminalLayout?.opacity === "number"
       ? Math.min(1, Math.max(0, terminalLayout.opacity))
       : 1;
+  const backgroundOpacity =
+    receivesLayout && typeof terminalLayout?.backgroundOpacity === "number"
+      ? Math.min(1, Math.max(0, terminalLayout.backgroundOpacity))
+      : receivesLayout && terminalLayout?.transparentBackground === true
+        ? 0
+        : 1;
 
   return {
     hidden: !receivesLayout || hiddenByLayout,
     opacity,
-    backgroundTransparent: receivesLayout && terminalLayout?.transparentBackground === true,
+    backgroundOpacity,
   };
 }
 
@@ -735,7 +741,7 @@ function applyTerminalPresentation(sessionId: string, presentation: TerminalPres
   const runtime = getTerminalRuntime(sessionId);
   runtime.setHidden(presentation.hidden);
   runtime.setOpacity(presentation.opacity);
-  runtime.setBackgroundTransparent(presentation.backgroundTransparent);
+  runtime.setBackgroundOpacity(presentation.backgroundOpacity);
 }
 // presence による sidebar 幅 mutation の単一 writer。
 // --sidebar-width は host 既定 presence の内部詳細として残置（P4 で default-shell pack へ降格）。

--- a/src/runtime/terminal-runtime/terminal-runtime.test.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.test.ts
@@ -1159,8 +1159,25 @@ describe("TerminalRuntime", () => {
 
     expect(themeBg()).toBe("rgba(18,52,86,0.5)");
     expect(xtermSingleton().style.background).toBe("transparent");
+    expect(xtermSingleton().style.getPropertyValue("--terminal-background-color")).toBe(
+      "rgba(18,52,86,0.5)",
+    );
     expect(xtermSingleton().classList.contains("xterm-bg-transparent")).toBe(true);
     expect(runtime.getBackgroundOpacity()).toBe(0.5);
+  });
+
+  it("syncAttachedRect は文字用の左 padding を背景板の延長幅として保持する", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const stub = document.createElement("div");
+    stub.style.paddingLeft = "10px";
+    document.body.appendChild(stub);
+
+    runtime.attachTo(stub);
+
+    expect(xtermSingleton().style.getPropertyValue("--terminal-placeholder-pad-left")).toBe("10px");
+
+    runtime.detachContainer();
+    stub.remove();
   });
 
   it("背景 alpha 適用中の setTheme は新しい scene 背景色へ alpha を再適用する", () => {
@@ -1181,6 +1198,7 @@ describe("TerminalRuntime", () => {
     runtime.setBackgroundOpacity(1);
     expect(themeBg()).toBe("#123456");
     expect(xtermSingleton().style.background).toBe("");
+    expect(xtermSingleton().style.getPropertyValue("--terminal-background-color")).toBe("");
     expect(xtermSingleton().classList.contains("xterm-bg-transparent")).toBe(false);
   });
 

--- a/src/runtime/terminal-runtime/terminal-runtime.test.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.test.ts
@@ -255,7 +255,9 @@ vi.mock("../../bindings/tauri-commands", () => ({
   sessionWrite: mockState.sessionWrite,
 }));
 
-const { disposeTerminalRuntime, getTerminalRuntime } = await import("./terminal-runtime");
+const { disposeTerminalRuntime, getTerminalRuntime, hexToRgba } = await import(
+  "./terminal-runtime"
+);
 
 const shellSpec = { kind: "shell" as const, integration: true };
 
@@ -1123,39 +1125,62 @@ describe("TerminalRuntime", () => {
     stub.remove();
   });
 
-  // setBackgroundTransparent — 背景のみ透明・文字は不透明のまま。
+  // setBackgroundOpacity — 背景のみ半透明・文字は不透明のまま。
   // theme.background の値と、container に付く scoped class の両方を確認する。
   const themeBg = (): unknown => {
     const term = mockState.terminals[0] as unknown as { options: { theme?: unknown } };
     return (term.options.theme as { background?: unknown } | undefined)?.background;
   };
 
-  it("setBackgroundTransparent(true) で theme.background が透明色になり class が付く", () => {
-    const runtime = getTerminalRuntime("shell-1");
-    runtime.setBackgroundTransparent(true);
+  it("hexToRgba は hex 色を指定 alpha の rgba に変換する", () => {
+    expect(hexToRgba("#171422", 0.55)).toBe("rgba(23,20,34,0.55)");
+  });
 
-    expect(themeBg()).toBe("rgba(0,0,0,0)");
+  it("hexToRgba は既存 rgba の色成分を保って alpha を置換する", () => {
+    expect(hexToRgba("rgba(23, 20, 34, 0.8)", 0.4)).toBe("rgba(23,20,34,0.4)");
+  });
+
+  it("hexToRgba は不正な色を既定背景色へ fallback し alpha を clamp する", () => {
+    expect(hexToRgba("not-a-color", 2)).toBe("rgba(20,22,25,1)");
+  });
+
+  it("setBackgroundOpacity(0) で theme.background が透明色になり class が付く", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    runtime.setBackgroundOpacity(0);
+
+    expect(themeBg()).toBe("rgba(20,22,25,0)");
     expect(xtermSingleton().classList.contains("xterm-bg-transparent")).toBe(true);
   });
 
-  it("bgTransparent 中の setTheme は不透明 background を上書きしない（flag-reassert）", () => {
+  it("setBackgroundOpacity(0.5) は scene 背景色を半透明化し class を付ける", () => {
     const runtime = getTerminalRuntime("shell-1");
-    runtime.setBackgroundTransparent(true);
+    runtime.setTheme({ background: "#123456" });
+    runtime.setBackgroundOpacity(0.5);
+
+    expect(themeBg()).toBe("rgba(18,52,86,0.5)");
+    expect(xtermSingleton().style.background).toBe("transparent");
+    expect(xtermSingleton().classList.contains("xterm-bg-transparent")).toBe(true);
+    expect(runtime.getBackgroundOpacity()).toBe(0.5);
+  });
+
+  it("背景 alpha 適用中の setTheme は新しい scene 背景色へ alpha を再適用する", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    runtime.setBackgroundOpacity(0.5);
     runtime.setTheme({ background: "#123456" });
 
-    // scene 由来の不透明 background は透明で再上書きされる
-    expect(themeBg()).toBe("rgba(0,0,0,0)");
+    expect(themeBg()).toBe("rgba(18,52,86,0.5)");
     expect(xtermSingleton().classList.contains("xterm-bg-transparent")).toBe(true);
   });
 
-  it("setBackgroundTransparent(false) で直近 theme の background へ復帰し class が外れる", () => {
+  it("setBackgroundOpacity(1) で直近 theme の background へ復帰し class が外れる", () => {
     const runtime = getTerminalRuntime("shell-1");
     runtime.setTheme({ background: "#123456" });
-    runtime.setBackgroundTransparent(true);
-    expect(themeBg()).toBe("rgba(0,0,0,0)");
+    runtime.setBackgroundOpacity(0.5);
+    expect(themeBg()).toBe("rgba(18,52,86,0.5)");
 
-    runtime.setBackgroundTransparent(false);
+    runtime.setBackgroundOpacity(1);
     expect(themeBg()).toBe("#123456");
+    expect(xtermSingleton().style.background).toBe("");
     expect(xtermSingleton().classList.contains("xterm-bg-transparent")).toBe(false);
   });
 
@@ -1172,7 +1197,7 @@ describe("TerminalRuntime", () => {
       white: "#ffffff",
     });
     // bgTransparent 中は flag-reassert で透明のまま
-    expect(themeBg()).toBe("rgba(0,0,0,0)");
+    expect(themeBg()).toBe("rgba(171,205,239,0)");
 
     runtime.setBackgroundTransparent(false);
     expect(themeBg()).toBe("#abcdef");
@@ -1186,7 +1211,7 @@ describe("TerminalRuntime", () => {
     runtime.setBackgroundTransparent(true);
     // background キーなし（merged theme は stale な "rgba(0,0,0,0)"）
     runtime.setTheme({ foreground: "#ffffff" });
-    expect(themeBg()).toBe("rgba(0,0,0,0)");
+    expect(themeBg()).toBe("rgba(18,52,86,0)");
 
     runtime.setBackgroundTransparent(false);
     // 直近の「本物の」background へ戻る（透明を焼き込んでいない）

--- a/src/runtime/terminal-runtime/terminal-runtime.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.ts
@@ -75,6 +75,35 @@ export const DEFAULT_TERMINAL_THEME: XTermTheme = {
 };
 
 /**
+ * terminal 背景色を指定 alpha の rgba に変換する。
+ * scene が既に rgb/rgba を渡している場合も色成分を保ち、不正値は既定背景色へ戻す。
+ */
+export function hexToRgba(background: string, alpha: number): string {
+  const clampedAlpha = clamp01(alpha);
+  const hex = /^#([0-9a-f]{6})$/i.exec(background.trim());
+  if (hex) {
+    const value = Number.parseInt(hex[1], 16);
+    return `rgba(${(value >> 16) & 255},${(value >> 8) & 255},${value & 255},${clampedAlpha})`;
+  }
+
+  const rgb =
+    /^rgba?\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)(?:\s*,\s*(?:\d+(?:\.\d+)?|\.\d+)\s*)?\)$/i.exec(
+      background.trim(),
+    );
+  if (rgb) {
+    const channels = rgb.slice(1, 4).map(Number);
+    if (channels.every((channel) => Number.isFinite(channel) && channel >= 0 && channel <= 255)) {
+      return `rgba(${channels[0]},${channels[1]},${channels[2]},${clampedAlpha})`;
+    }
+  }
+
+  if (background !== DEFAULT_TERMINAL_THEME.background) {
+    return hexToRgba(DEFAULT_TERMINAL_THEME.background ?? "#141619", clampedAlpha);
+  }
+  return `rgba(20,22,25,${clampedAlpha})`;
+}
+
+/**
  * TerminalRuntime implementation. See types.ts for the contract.
  *
  * Key design choices (internal design-record: 2026-04-17-terminal-runtime-singleton.md):
@@ -129,9 +158,9 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   private disposed = false;
   private hidden = false;
   private opacity = 1;
-  private bgTransparent = false;
+  private bgAlpha = 1;
   private attentionCueIntensity = 0;
-  /** 直近 setTheme でマージされた背景色。bgTransparent 解除時の復帰先。 */
+  /** 直近 setTheme で明示された背景色。背景 alpha の色元・不透明化時の復帰先。 */
   private currentThemeBackground: string | undefined;
   private startGeneration = 0;
   private ptyExitUnlisten: (() => void) | null = null;
@@ -166,8 +195,8 @@ class TerminalRuntimeImpl implements TerminalRuntime {
       fontSize: 13,
       cursorBlink: true,
       allowProposedApi: true,
-      // 透明 background を合成可能にする。不透明 background のときは描画結果が
-      // 同一（無害）で、setBackgroundTransparent(true) で初めて効く。
+      // alpha 付き background を合成可能にする。不透明 background のときは描画結果が
+      // 同一（無害）で、setBackgroundOpacity(<1) で初めて効く。
       allowTransparency: true,
       scrollback: 5000,
     });
@@ -303,24 +332,34 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   }
 
   /**
-   * layout 由来：terminal の背景のみ透明にする（文字は前景色で不透明のまま）。
-   * xterm theme.background を透明色にし、singleton container の CSS 背景も透明化する。
-   * setTheme は scene 由来の不透明 background を上書きするため、bgTransparent 中は
-   * setTheme 後に再適用する（hidden/opacity の flag-reassert と同型）。
+   * layout 由来：terminal の背景だけに不透明度（0-1）を適用する。
+   * 文字は前景色で不透明のまま、背景色には直近 scene theme の色を使う。
    */
+  setBackgroundOpacity(alpha: number): void {
+    this.bgAlpha = clamp01(alpha);
+    this.applyBackgroundOpacity();
+  }
+
+  getBackgroundOpacity(): number {
+    return this.bgAlpha;
+  }
+
+  /** @deprecated setBackgroundOpacity(transparent ? 0 : 1) を使う。 */
   setBackgroundTransparent(transparent: boolean): void {
-    this.bgTransparent = transparent;
-    this.applyBackgroundTransparency();
+    this.setBackgroundOpacity(transparent ? 0 : 1);
   }
 
   /**
-   * bgTransparent フラグを theme.background と container の見た目に反映する。
-   * 透明時は theme.background を rgba(0,0,0,0) にし、背景を塗る各 xterm child を
-   * scoped class で透過させる。解除時は直近 setTheme の背景色（無ければ既定）へ戻す。
+   * 背景 alpha を theme.background と container の見た目に反映する。
+   * alpha < 1 では背景を塗る各 xterm child も scoped class で透過させる。
    */
-  private applyBackgroundTransparency(): void {
-    if (this.bgTransparent) {
-      this.term.options.theme = { ...this.term.options.theme, background: "rgba(0,0,0,0)" };
+  private applyBackgroundOpacity(): void {
+    if (this.bgAlpha < 1) {
+      const background = this.currentThemeBackground ?? DEFAULT_TERMINAL_THEME.background;
+      this.term.options.theme = {
+        ...this.term.options.theme,
+        background: hexToRgba(background ?? "#141619", this.bgAlpha),
+      };
       this.xtermContainer.style.background = "transparent";
     } else {
       const restored = this.currentThemeBackground ?? DEFAULT_TERMINAL_THEME.background;
@@ -328,7 +367,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
       // 空文字で inline 背景を外し CSS（--yorishiro-bg）へ戻す。
       this.xtermContainer.style.background = "";
     }
-    this.xtermContainer.classList.toggle("xterm-bg-transparent", this.bgTransparent);
+    this.xtermContainer.classList.toggle("xterm-bg-transparent", this.bgAlpha < 1);
   }
 
   setAttentionCueIntensity(intensity: number): void {
@@ -494,16 +533,15 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   setTheme(theme: Partial<XTermTheme>): void {
     if (this.disposed) return;
     this.term.options.theme = { ...this.term.options.theme, ...theme };
-    // bgTransparent 解除時の復帰先。merged theme から拾うと、bgTransparent 中に
+    // 背景不透明化時の復帰先。merged theme から拾うと、背景 alpha 適用中に
     // background キーを持たない partial setTheme が来たとき stale な
     // "rgba(0,0,0,0)" を復帰先に焼き込んでしまう（stuck-transparent）。
     // 引数 theme が明示的に string background を運んだときだけ更新する。
     if (typeof theme.background === "string") {
       this.currentThemeBackground = theme.background;
     }
-    // bgTransparent が立っているなら scene 由来の不透明 background を透明で
-    // 再上書きする（hidden/opacity の flag-reassert と同型）。
-    this.applyBackgroundTransparency();
+    // scene 由来の background が変わっても保持中の alpha を再適用する。
+    this.applyBackgroundOpacity();
     // Theme update can leave renderer dimensions stale when scene switches
     // coincide with layout changes, so force a fresh fit before refresh.
     this.refit();

--- a/src/runtime/terminal-runtime/terminal-runtime.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.ts
@@ -356,16 +356,19 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   private applyBackgroundOpacity(): void {
     if (this.bgAlpha < 1) {
       const background = this.currentThemeBackground ?? DEFAULT_TERMINAL_THEME.background;
+      const alphaBackground = hexToRgba(background ?? "#141619", this.bgAlpha);
       this.term.options.theme = {
         ...this.term.options.theme,
-        background: hexToRgba(background ?? "#141619", this.bgAlpha),
+        background: alphaBackground,
       };
       this.xtermContainer.style.background = "transparent";
+      this.xtermContainer.style.setProperty("--terminal-background-color", alphaBackground);
     } else {
       const restored = this.currentThemeBackground ?? DEFAULT_TERMINAL_THEME.background;
       this.term.options.theme = { ...this.term.options.theme, background: restored };
       // 空文字で inline 背景を外し CSS（--yorishiro-bg）へ戻す。
       this.xtermContainer.style.background = "";
+      this.xtermContainer.style.removeProperty("--terminal-background-color");
     }
     this.xtermContainer.classList.toggle("xterm-bg-transparent", this.bgAlpha < 1);
   }
@@ -1447,6 +1450,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     const padBottom = parseFloat(cs.paddingBottom) || 0;
     const w = Math.max(0, Math.floor(rect.width - padLeft - padRight));
     const h = Math.max(0, Math.floor(rect.height - padTop - padBottom));
+    this.xtermContainer.style.setProperty("--terminal-placeholder-pad-left", `${padLeft}px`);
     this.xtermContainer.style.top = `${rect.top + padTop}px`;
     this.xtermContainer.style.left = `${rect.left + padLeft}px`;
     this.xtermContainer.style.width = `${w}px`;

--- a/src/runtime/terminal-runtime/types.ts
+++ b/src/runtime/terminal-runtime/types.ts
@@ -168,9 +168,15 @@ export interface TerminalRuntime {
   getOpacity(): number;
 
   /**
-   * layout 由来：terminal の背景のみ透明化する（文字は不透明のまま）。
-   * scene の theme 変更をまたいでもフラグから再適用され、戻らない。
+   * layout 由来：terminal の背景だけに不透明度（0-1）を適用する。
+   * 文字は不透明のまま、scene の theme 変更後も保持した alpha を再適用する。
    */
+  setBackgroundOpacity(alpha: number): void;
+
+  /** 現在の layout 由来背景不透明度。未設定時は 1。 */
+  getBackgroundOpacity(): number;
+
+  /** @deprecated setBackgroundOpacity(transparent ? 0 : 1) を使う。 */
   setBackgroundTransparent(transparent: boolean): void;
 
   /**

--- a/src/runtime/yorishiro-mcp/tool-handlers.test.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.test.ts
@@ -2046,6 +2046,8 @@ describe("createUiTerminalSetHandler", () => {
     const handler = createUiTerminalSetHandler({
       setTerminalOpacity: () => {},
       getTerminalOpacity: () => 1,
+      setTerminalBackgroundOpacity: () => {},
+      getTerminalBackgroundOpacity: () => 1,
       tweenManager: tm,
     });
     const result = await handler({ opacity: 0.5, durationMs: 400 });
@@ -2061,11 +2063,53 @@ describe("createUiTerminalSetHandler", () => {
         setTo = v;
       },
       getTerminalOpacity: () => 1,
+      setTerminalBackgroundOpacity: () => {},
+      getTerminalBackgroundOpacity: () => 1,
       tweenManager: tm,
     });
     const result = await handler({ opacity: 0.5 });
     expect(result.tweening).toBeUndefined();
     expect(setTo).toBe(0.5);
+  });
+
+  it("backgroundOpacity を独立した key で tween する", async () => {
+    const tm = new TweenManager();
+    const handler = createUiTerminalSetHandler({
+      setTerminalOpacity: () => {},
+      getTerminalOpacity: () => 1,
+      setTerminalBackgroundOpacity: () => {},
+      getTerminalBackgroundOpacity: () => 0.8,
+      tweenManager: tm,
+    });
+
+    const result = await handler({ backgroundOpacity: 0.5, durationMs: 600 });
+
+    expect(result).toEqual({ backgroundOpacity: 0.5, tweening: true });
+    expect(tm.isActive("ui.terminal.backgroundOpacity")).toBe(true);
+    expect(tm.isActive("ui.terminal.opacity")).toBe(false);
+  });
+
+  it("opacity と backgroundOpacity を同時に即時反映する", async () => {
+    const tm = new TweenManager();
+    let opacity = -1;
+    let backgroundOpacity = -1;
+    const handler = createUiTerminalSetHandler({
+      setTerminalOpacity: (value) => {
+        opacity = value;
+      },
+      getTerminalOpacity: () => 1,
+      setTerminalBackgroundOpacity: (value) => {
+        backgroundOpacity = value;
+      },
+      getTerminalBackgroundOpacity: () => 1,
+      tweenManager: tm,
+    });
+
+    const result = await handler({ opacity: 0.7, backgroundOpacity: 0.45 });
+
+    expect(result).toEqual({ opacity: 0.7, backgroundOpacity: 0.45 });
+    expect(opacity).toBe(0.7);
+    expect(backgroundOpacity).toBe(0.45);
   });
 });
 

--- a/src/runtime/yorishiro-mcp/tool-handlers.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.ts
@@ -1508,11 +1508,14 @@ export function __resetMcpMotionHandleForTesting(): void {
 export interface UiTerminalSetDeps {
   readonly setTerminalOpacity: (value: number) => void;
   readonly getTerminalOpacity: () => number;
+  readonly setTerminalBackgroundOpacity: (value: number) => void;
+  readonly getTerminalBackgroundOpacity: () => number;
   readonly tweenManager: TweenManager;
 }
 
 export interface UiTerminalSetResult {
   readonly opacity?: number;
+  readonly backgroundOpacity?: number;
   readonly tweening?: boolean;
 }
 
@@ -1521,26 +1524,53 @@ export function createUiTerminalSetHandler(deps: UiTerminalSetDeps) {
     const r = requestRecord(request);
     const opacity =
       typeof r.opacity === "number" && Number.isFinite(r.opacity) ? clamp01(r.opacity) : undefined;
+    const backgroundOpacity =
+      typeof r.backgroundOpacity === "number" && Number.isFinite(r.backgroundOpacity)
+        ? clamp01(r.backgroundOpacity)
+        : undefined;
     const durationMs =
       typeof r.durationMs === "number" && Number.isFinite(r.durationMs) && r.durationMs > 0
         ? r.durationMs
         : 0;
 
-    if (opacity === undefined) {
+    if (opacity === undefined && backgroundOpacity === undefined) {
       return {};
     }
 
     if (durationMs > 0) {
-      deps.tweenManager.start("ui.terminal.opacity", opacity, durationMs, deps.setTerminalOpacity, {
-        from: deps.getTerminalOpacity(),
-      });
-      return { opacity, tweening: true };
+      if (opacity !== undefined) {
+        deps.tweenManager.start(
+          "ui.terminal.opacity",
+          opacity,
+          durationMs,
+          deps.setTerminalOpacity,
+          {
+            from: deps.getTerminalOpacity(),
+          },
+        );
+      }
+      if (backgroundOpacity !== undefined) {
+        deps.tweenManager.start(
+          "ui.terminal.backgroundOpacity",
+          backgroundOpacity,
+          durationMs,
+          deps.setTerminalBackgroundOpacity,
+          { from: deps.getTerminalBackgroundOpacity() },
+        );
+      }
+      return { opacity, backgroundOpacity, tweening: true };
     }
 
-    // 即時: active な tween を cancel + 直接 set
-    deps.tweenManager.cancel("ui.terminal.opacity");
-    deps.setTerminalOpacity(opacity);
-    return { opacity };
+    // 即時: 指定された値に対応する active tween だけを cancel + 直接 set
+    if (opacity !== undefined) {
+      deps.tweenManager.cancel("ui.terminal.opacity");
+      deps.setTerminalOpacity(opacity);
+    }
+    if (backgroundOpacity !== undefined) {
+      deps.tweenManager.cancel("ui.terminal.backgroundOpacity");
+      deps.setTerminalBackgroundOpacity(backgroundOpacity);
+    }
+    return { opacity, backgroundOpacity };
   };
 }
 

--- a/src/sdk/ui-pack.d.ts
+++ b/src/sdk/ui-pack.d.ts
@@ -62,7 +62,12 @@ export interface UiLayout {
         };
     /** terminal 全体の不透明度 0-1。1=不透明（既定）。<1 で背後の character/scene が透ける。MCP `ui.terminal.set {opacity}` と対称。 */
     readonly opacity?: number;
-    /** true で terminal の背景のみ透明化（文字は不透明のまま）。背後の character/scene が見える没入用。MCP 対称。 */
+    /** 0=透明〜1=不透明（既定）。1 未満では文字を不透明に保ったまま、背後の scene が透ける。 */
+    readonly backgroundOpacity?: number;
+    /**
+     * true は backgroundOpacity: 0 の別名。
+     * @deprecated backgroundOpacity: 0 を使う。
+     */
     readonly transparentBackground?: boolean;
   };
   readonly character?: {


### PR DESCRIPTION
## What changed

- add `backgroundOpacity` to UI pack terminal presentation with the legacy `transparentBackground` fallback
- apply scene-tinted RGBA backgrounds in the terminal runtime and keep xterm transparency in sync
- expose independent terminal background-opacity control through `ui_terminal_set`
- bridge the terminal background into the adjacent frame padding so no visible gap remains
- update SDK types, help text, and runtime/MCP tests

## Why

UI packs previously had only a boolean transparent-background switch. This made it impossible to place a readable semi-transparent terminal over a scene, and the terminal container's text inset could reveal a gap between the tinted panel and the window frame.

## Impact

UI packs can now set a value from `0` to `1`, for example:

```ts
terminal: {
  presentation: {
    backgroundOpacity: 0.45,
  },
}
```

Existing packs that use `transparentBackground` remain compatible.

## Validation

- `npm run check`
- full Vitest suite: 159 files, 1968 tests
- pre-push hooks: TypeScript, Biome, Rust fmt, Clippy, and TypeDoc validation
- manual verification with the immersive split UI over scene backgrounds
