### PR TITLE
chore(debug): Speech controls を localStorage opt-in にする

### DIFF
--- a/src/runtime/three-runtime/r3f-runtime-root.test.tsx
+++ b/src/runtime/three-runtime/r3f-runtime-root.test.tsx
@@ -131,11 +131,22 @@ afterEach(() => {
   cleanup();
   getMockRegistry().__reset();
   levaStore.dispose();
+  localStorage.clear();
   vi.clearAllMocks();
 });
 
 describe("R3fRuntimeRoot", () => {
-  it("runtime store に speech folder を既定値どおり登録する", () => {
+  it("speech folder を既定では runtime store に登録しない", () => {
+    render(<R3fRuntimeRoot />);
+
+    const store = getRuntimeLevaStore();
+    expect(store?.getVisiblePaths()).not.toContain("speech.enabled");
+    expect(store?.get("speech.enabled")).toBeUndefined();
+  });
+
+  it("yorishiro:speech-debug が有効なら speech folder を既定値どおり登録する", () => {
+    localStorage.setItem("yorishiro:speech-debug", "1");
+
     render(<R3fRuntimeRoot />);
 
     const store = getRuntimeLevaStore();

--- a/src/runtime/three-runtime/r3f-runtime-root.tsx
+++ b/src/runtime/three-runtime/r3f-runtime-root.tsx
@@ -7,6 +7,12 @@
  *   - debug cube は localStorage opt-in の確認用として残す。
  *     有効化: localStorage.setItem("yorishiro:r3f-debug", "1") + reload
  *     無効化: localStorage.removeItem("yorishiro:r3f-debug") + reload
+ *   - 発話反射層の leva controls も localStorage opt-in。voice_say の発話中しか
+ *     効かない条件依存の調整卓なので、Common panel には常駐させない。mount して
+ *     いない間も body 側の既定値で反射層は動く（Body の初期値と controls の初期
+ *     値が同一なため）。
+ *     有効化: localStorage.setItem("yorishiro:speech-debug", "1") + reload
+ *     無効化: localStorage.removeItem("yorishiro:speech-debug") + reload
  *   - VRM は本 phase では imperative のまま。vrmSlot prop は null を渡す。
  *
  * Internal design-record: specs/2026-05-03-scene-pack-r3f-component.md §4
@@ -37,6 +43,15 @@ export interface R3fRuntimeRootProps {
   readonly children?: ReactNode;
 }
 
+/** localStorage の debug opt-in flag を読む。access 不能な環境では無効扱いにする。 */
+function readDebugFlag(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
+
 export function R3fRuntimeRoot({ children }: R3fRuntimeRootProps) {
   const [activeEntry, setActiveEntry] = useState<ScenePackEntry | null>(null);
   const runtimeLevaStore = useCreateStore();
@@ -51,13 +66,8 @@ export function R3fRuntimeRoot({ children }: R3fRuntimeRootProps) {
     };
   }, []);
 
-  const debugEnabled = useMemo(() => {
-    try {
-      return localStorage.getItem("yorishiro:r3f-debug") === "1";
-    } catch {
-      return false;
-    }
-  }, []);
+  const debugEnabled = useMemo(() => readDebugFlag("yorishiro:r3f-debug"), []);
+  const speechDebugEnabled = useMemo(() => readDebugFlag("yorishiro:speech-debug"), []);
 
   useEffect(() => {
     setRuntimeLevaStore(runtimeLevaStore);
@@ -75,7 +85,7 @@ export function R3fRuntimeRoot({ children }: R3fRuntimeRootProps) {
       ) : null}
       <DefaultAttentionCueLight />
       <CameraControls store={runtimeLevaStore} />
-      <SpeechExpressionControls store={runtimeLevaStore} />
+      {speechDebugEnabled ? <SpeechExpressionControls store={runtimeLevaStore} /> : null}
       {children}
     </>
   );


### PR DESCRIPTION
## 背景

F2 の debug パネル `Common` に `speech` folder（発話反射層の調整 17 項目）が常駐していた。これは voice_say の発話中しか効かない条件依存のパラメータ群で、`Common` の他の住人（`camera`）と条件依存度の桁が違う。項目数でも speech が Common をほぼ占拠していて camera が埋もれていた。

`Common` は「いつ開いても意味があるもの」の場所であるべき、という判断で speech を常駐から外す。

## 変更

`SpeechExpressionControls` を localStorage opt-in の条件 mount にした。同ファイルに既にある `yorishiro:r3f-debug`（debug cube）と同じイディオムに乗せ、flag 読みを `readDebugFlag(key)` に切り出して共用している。

- 有効化: `localStorage.setItem("yorishiro:speech-debug", "1")` + reload
- 無効化: `localStorage.removeItem("yorishiro:speech-debug")` + reload

完全削除にしなかったのは、発話反射層に磨き残し（発話終端の即 0 / 強 mood 中の反射埋もれ）が残っていて、感触パラメータを帰納的に詰める手段を残しておきたいため。

## 挙動は変わらない

mount していない間も反射層は今と同じ設定で動く:

- controls の初期値は全部 `DEFAULT_SPEECH_MICROEXPRESSION_PARAMS` からの写し
- `enabled` の初期値 `true` は Body 側の `speechExpressionEnabled` の既定と一致
- `SpeechMicroexpressionSystem` も DEFAULT で自己初期化

## 副作用（意図的）

opt-in が外れている間は、MCP の `controls_*` の `scope: "common"` からも `speech.*` に触れなくなる（`getVisiblePaths()` 検証を通らないため）。チューニング時に flag を立てれば UI / MCP ともに復帰する。

## 検証

- vitest: 1969 passed / 159 files（既存 1968 + 追加 1）
- `tsc --noEmit`: exit 0
- `biome check .`: 513 files, no fixes
- pre-push hook（tsc / biome / cargo-fmt / cargo-clippy / typedoc-validate）全 pass

テストは「既定では登録しない」「flag ありなら既定値どおり登録する」の 2 本に割った。

**実機確認は未了**。F2 の Common から Speech が消えて camera だけになること、flag を立てれば戻ることの目視が残っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)