### PR TITLE
fix(bash): skip DEBUG-trap preexec while a bind -x widget runs

### DIFF
--- a/src-tauri/src/sessions/shell_wrapper.rs
+++ b/src-tauri/src/sessions/shell_wrapper.rs
@@ -935,6 +935,31 @@ mod tests {
     }
 
     #[test]
+    fn bash_preexec_skips_while_readline_line_is_set() {
+        // bind -x widget（fzf の Ctrl-R 等）の実行中も DEBUG trap は発火し、
+        // ready flag を誤消費して phantom run が生まれる（issue #67）。bash は
+        // widget 実行中だけ READLINE_LINE を set するので「set の間は preexec を
+        // 丸ごと skip する」を契約として固定する。pipe 経由では readline が動かず
+        // 本物の widget は起動できないため、変数を事前 set して契約面だけを見る。
+        let Some(combined) = run_bash_with_yorishiro_init_and_rc(
+            "bash-readline-guard",
+            "echo one\nexit\n",
+            "READLINE_LINE=widget-stub\n",
+        ) else {
+            return;
+        };
+
+        assert!(
+            combined.contains("]633;P;Cwd="),
+            "integration did not load: {combined:?}"
+        );
+        assert!(
+            !combined.contains("]633;E;echo\\x20one"),
+            "preexec fired despite READLINE_LINE being set: {combined:?}"
+        );
+    }
+
+    #[test]
     fn fish_escape_splits_od_bytes_before_prefixing_xhh() {
         assert!(INIT_FISH.contains("string split ' '"));
         assert!(INIT_FISH.contains("string match -r '^[0-9a-f][0-9a-f]$'"));

--- a/src-tauri/src/sessions/shell_wrapper/init.bash
+++ b/src-tauri/src/sessions/shell_wrapper/init.bash
@@ -54,6 +54,11 @@ __yorishiro_current_command_line() {
 }
 
 __yorishiro_preexec_invoke_exec() {
+    # bind -x widget（fzf の Ctrl-R 等）の実行中も DEBUG trap は発火する。bash は
+    # widget 実行中だけ READLINE_LINE を set するので、それを目印に skip する。
+    # ready flag を消費する前に抜けることで、次の実 command の marks を守る
+    # （issue #67）。bash 3.x には READLINE_LINE が無く、このガードは素通りする。
+    [ -n "${READLINE_LINE+x}" ] && return 0
     [ "${__yorishiro_preexec_ready:-0}" = "1" ] || return 0
     [ "${__yorishiro_in_preexec:-0}" = "0" ] || return 0
     case "$BASH_COMMAND" in


### PR DESCRIPTION
## Summary

Fixes #67 — in the bash integration, the DEBUG-trap preexec fired for `bind -x` widgets (canonical case: fzf's Ctrl-R). The widget keypress consumed the one-shot `__yorishiro_preexec_ready` flag, emitting a phantom `633;E`/`133;C` labeled as the *previous* command (via `history 1`), and the next real command then ran with no marks at all — its output and exit code were attributed to the phantom run.

The fix is the one-line guard suggested in the issue: bash sets `READLINE_LINE` only while a `bind -x` handler runs, so the preexec hook now returns early in that context — *before* consuming the ready flag, so the next real command keeps its marks.

Diagnosis and fix by @soren-achebe (credited in the commit with `Reported-by:` / `Suggested-by:` trailers); implemented here per CONTRIBUTING.md's no-PRs policy.

## Changes

- `init.bash`: `READLINE_LINE` guard at the top of `__yorishiro_preexec_invoke_exec`, before the ready-flag check
- `shell_wrapper.rs`: regression test `bash_preexec_skips_while_readline_line_is_set` on the existing real-bash test infra (fails without the guard; a pipe can't drive readline, so the test pins the guard's contract rather than a live widget)

## Verification

- `cargo test`: 251 passed (including the new test, which failed before the fix)
- PTY end-to-end harness (pexpect, real `bind -x` Ctrl-R widget) against the fixed `init.bash`:
  - bash 5.3.15, widget: clean — one `E`/`C`/`D` triple per real command, nothing at Ctrl-R (previously: phantom + next command lost its marks)
  - bash 5.3.15, no widget: unchanged
  - bash 3.2.57 (macOS system bash): guard is an inert no-op there (`READLINE_LINE` doesn't exist before bash 4.0) — the phantom remains on 3.x, tracked separately; no regression either way
- `READLINE_LINE` probed from inside a DEBUG trap: set only while the widget body runs, unset for ordinary commands

## Out of scope

- bash 3.x coverage (needs a different mechanism, e.g. the history-number approach sketched in the issue)
- `HISTCONTROL=ignoreboth` / `history 1` mislabeling (independent, noted in the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)