### PR TITLE
fix: use upper case Y for app package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
 
-      # updater artifact（.app.tar.gz + .sig）は両アーキで同名（yorishiro.app.tar.gz）に
+      # updater artifact（.app.tar.gz + .sig）は両アーキで同名（Yorishiro.app.tar.gz）に
       # なるため、arch を含む名前にリネームしてから artifact 化する。この名前が
       # そのまま Release asset 名になり、latest.json の url が指す。
       - name: Stage updater artifacts
@@ -131,7 +131,7 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      # versioned dmg（yorishiro_<ver>_<arch>.dmg）に加えて、バージョンレスの安定名
+      # versioned dmg（Yorishiro_<ver>_<arch>.dmg）に加えて、バージョンレスの安定名
       # コピーを作る。README の `releases/latest/download/<固定名>` 直リンクは、
       # リリース間でファイル名が固定であることが必須なため。
       - name: Stage stable-named assets

--- a/README.ja.md
+++ b/README.ja.md
@@ -60,7 +60,7 @@ brew install --cask sktkkoo/yorishiro/yorishiro
   <a href="https://github.com/sktkkoo/Yorishiro/releases/latest/download/Yorishiro-Intel.dmg"><img src="https://img.shields.io/badge/Intel-8B949E?style=for-the-badge&logo=apple&logoColor=white" alt="Intel版をダウンロード" /></a>
 </p>
 
-ダウンロードした`.dmg`を開き、`yorishiro.app`を`/Applications`にドラッグしてください。署名・公証（notarize）済みのため、特別な操作なしに起動できます。
+ダウンロードした`.dmg`を開き、`Yorishiro.app`を`/Applications`にドラッグしてください。署名・公証（notarize）済みのため、特別な操作なしに起動できます。
 
 インストール後の更新はアプリ内で完結します。設定画面を開くと新しいバージョンを自動で確認し、「更新して再起動」を押すだけで署名検証つきの更新が適用されます。
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Or download the latest build below.
   <a href="https://github.com/sktkkoo/Yorishiro/releases/latest/download/Yorishiro-Intel.dmg"><img src="https://img.shields.io/badge/Intel-8B949E?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Intel" /></a>
 </p>
 
-Open the `.dmg` and drag `yorishiro.app` to `/Applications`. The builds are signed and notarized with an Apple Developer ID, so they launch without any extra steps.
+Open the `.dmg` and drag `Yorishiro.app` to `/Applications`. The builds are signed and notarized with an Apple Developer ID, so they launch without any extra steps.
 
 Updates after install are handled in-app: opening Settings checks for a new version, and a single click on "Update and restart" applies a signature-verified update.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -41,7 +41,7 @@ Notes:
 - Releases before v0.5.3 do not contain the in-app updater, so those installs
   only update via Homebrew (`brew upgrade`) or manual download.
 - The tap needs no per-release work. It only needs manual edits if the `.dmg`
-  naming scheme or the `yorishiro.app` bundle name changes. Also note GitHub
+  naming scheme or the `Yorishiro.app` bundle name changes. Also note GitHub
   disables cron workflows in repos with no activity for 60 days; if releases
   pause that long, re-enable the tap's bump workflow with
   `gh workflow enable bump-yorishiro.yml -R sktkkoo/homebrew-yorishiro`.
@@ -62,7 +62,7 @@ Notes:
   built unsigned bundles only, run:
 
 ```bash
-xattr -cr /Applications/yorishiro.app
+xattr -cr /Applications/Yorishiro.app
 ```
 
 - Launch Yorishiro from Finder.
@@ -106,7 +106,7 @@ xattr -cr /Applications/yorishiro.app
 - Launch with:
 
 ```bash
-YORISHIRO_SAFE_MODE=1 open /Applications/yorishiro.app
+YORISHIRO_SAFE_MODE=1 open /Applications/Yorishiro.app
 ```
 
 - Confirm the window title includes `(Safe Mode)`.

--- a/docs/troubleshooting.ja.md
+++ b/docs/troubleshooting.ja.md
@@ -47,7 +47,7 @@ Safe mode はユーザー pack と `init.js` をスキップします。ユー�
 macOS:
 
 ```bash
-YORISHIRO_SAFE_MODE=1 open /Applications/yorishiro.app
+YORISHIRO_SAFE_MODE=1 open /Applications/Yorishiro.app
 ```
 
 ソースから:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,7 +47,7 @@ Safe mode skips user packs and `init.js`. It does not delete user data.
 macOS:
 
 ```bash
-YORISHIRO_SAFE_MODE=1 open /Applications/yorishiro.app
+YORISHIRO_SAFE_MODE=1 open /Applications/Yorishiro.app
 ```
 
 From source:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "yorishiro",
+  "productName": "Yorishiro",
   "version": "0.6.2",
   "identifier": "dev.yorishiro.app",
   "build": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4277,7 +4277,7 @@ function App() {
     };
   }, [isUserLayerReady, effectDispatcher]);
 
-  // ── Cmd+R / Ctrl+R で全体 reload ─────────────────────────
+  // ── Cmd+R / Ctrl+R で全体 reload、Cmd+, で settings toggle ──
 
   const [levaHidden, setLevaHidden] = useState(true);
 
@@ -4298,6 +4298,10 @@ function App() {
         event.preventDefault();
         window.location.reload();
       }
+      if (event.code === "Comma" && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        handleOpenSettings();
+      }
       if (event.code === "F2") {
         event.preventDefault();
         setLevaHidden((prev) => !prev);
@@ -4307,7 +4311,7 @@ function App() {
     return () => {
       window.removeEventListener("keydown", onKeyDown, { capture: true });
     };
-  }, []);
+  }, [handleOpenSettings]);
 
   // command run の keyboard 操作（active session）。
   // Cmd+Shift+F: 直近 failed run を reference 化。


### PR DESCRIPTION
At least on macOS, apps tend to start in uppercase. I changed Yorishiro for consistency, and it also happens to match the project branding better as well.

<img width="1096" height="480" alt="スクリーンショット 2026-07-26 15 55 31" src="https://github.com/user-attachments/assets/78f45c2d-675b-4724-8a1c-dc94ca014afb" />


I also added cmd+, as a shortcut to toggle settings, which is a widely used convention.