### PR TITLE
feat(ui): Cmd+, / Ctrl+, toggles the settings screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4277,7 +4277,7 @@ function App() {
     };
   }, [isUserLayerReady, effectDispatcher]);
 
-  // ── Cmd+R / Ctrl+R で全体 reload ─────────────────────────
+  // ── Cmd+R / Ctrl+R で全体 reload、Cmd+, で settings toggle ──
 
   const [levaHidden, setLevaHidden] = useState(true);
 
@@ -4298,6 +4298,10 @@ function App() {
         event.preventDefault();
         window.location.reload();
       }
+      if (event.code === "Comma" && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        handleOpenSettings();
+      }
       if (event.code === "F2") {
         event.preventDefault();
         setLevaHidden((prev) => !prev);
@@ -4307,7 +4311,7 @@ function App() {
     return () => {
       window.removeEventListener("keydown", onKeyDown, { capture: true });
     };
-  }, []);
+  }, [handleOpenSettings]);
 
   // command run の keyboard 操作（active session）。
   // Cmd+Shift+F: 直近 failed run を reference 化。


### PR DESCRIPTION
## Summary

Adds the standard Cmd+, (Ctrl+, on other platforms) shortcut for the settings screen, wired into the existing global keydown handler. `handleOpenSettings` is already a toggle — it opens settings, or closes them via the same restore logic as the ✕ button — so a second press closes the screen.

Suggested by @tacomanator in #70 (implemented here per CONTRIBUTING.md's no-PRs policy, with a `Co-authored-by:` trailer in the commit — the diff is essentially theirs).

## Verification

- `npm run check` (tsc + biome + rustfmt + clippy): pass
- vitest: 1969 passed (159 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
