### PR TITLE
fix(bash): detect bind -x widgets on bash 3.x via readline raw mode

### DIFF
--- a/src-tauri/src/sessions/shell_wrapper/init.bash
+++ b/src-tauri/src/sessions/shell_wrapper/init.bash
@@ -57,8 +57,17 @@ __yorishiro_preexec_invoke_exec() {
     # bind -x widget（fzf の Ctrl-R 等）の実行中も DEBUG trap は発火する。bash は
     # widget 実行中だけ READLINE_LINE を set するので、それを目印に skip する。
     # ready flag を消費する前に抜けることで、次の実 command の marks を守る
-    # （issue #67）。bash 3.x には READLINE_LINE が無く、このガードは素通りする。
+    # （issue #67）。
     [ -n "${READLINE_LINE+x}" ] && return 0
+    # bash 3.x には READLINE_LINE が無い。4.0 未満では bind -x handler が readline の
+    # raw mode（-icanon）のまま実行され、確定 command は canonical 復帰後に走る性質で
+    # 見分ける（issue #72、方式は soren-achebe の調査に拠る）。stty は fork を伴うので
+    # 4.0+ では使わない。tty が無い環境では出力が空になり素通りする。
+    if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+        case $(stty -a </dev/tty 2>/dev/null) in
+            *-icanon*) return 0 ;;
+        esac
+    fi
     [ "${__yorishiro_preexec_ready:-0}" = "1" ] || return 0
     [ "${__yorishiro_in_preexec:-0}" = "0" ] || return 0
     case "$BASH_COMMAND" in


### PR DESCRIPTION
## Summary

Fixes #72 — the `READLINE_LINE` guard from #69 doesn't exist before bash 4.0, so the `bind -x` phantom run survived on macOS's system bash 3.2. This adds a version-gated fallback: on pre-4.0 bash, `bind -x` handlers run while the tty is still in readline's raw mode (`-icanon`), so checking `stty -a </dev/tty` inside the DEBUG trap identifies the widget context. One fork per accepted command, on 3.x only; with no tty the check falls through harmlessly.

The guard is adapted from @soren-achebe's snippet — investigated, validated, and shipped in their backscroll (`HISTCMD`/`LINENO`/history-number alternatives ruled out empirically — see #72), and is credited with a `Co-authored-by:` trailer.

## Verification

- PTY + `bind -x` Ctrl-R harness: widget matrix now **clean on bash 3.2.57** (previously: phantom `E` labeled as the previous command + next command lost its marks); **unchanged on 5.3.15** (widget and no-widget)
- `cargo test --lib shell_wrapper`: 20 passed against bash 5.3 in PATH, and 20 passed with `/bin/bash` 3.2 first in PATH (pipe-based tests confirm the no-tty fall-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
