### PR TITLE
fix(fish): pass safe ASCII through in OSC 633 escape

### DIFF
--- a/src-tauri/src/sessions/shell_wrapper.rs
+++ b/src-tauri/src/sessions/shell_wrapper.rs
@@ -960,6 +960,39 @@ mod tests {
     }
 
     #[test]
+    fn fish_escape_passes_safe_ascii_through() {
+        // issue #73: fish 版 escape は全 byte を hex 化していた。zsh/bash と同じく
+        // safe set [A-Za-z0-9_/:.,@%+=-] は素通しする契約を、実 fish で確認する。
+        // fish が無い環境では skip（bash テストと同じ流儀）。
+        let root = fresh_temp_root("fish-escape");
+        let init = root.join("init.fish");
+        fs::write(&init, INIT_FISH).unwrap();
+        let output = match Command::new("fish")
+            .arg("-c")
+            .arg(format!(
+                "source '{}'; __yorishiro_osc633_escape 'echo one/2.txt こ'",
+                init.display()
+            ))
+            .output()
+        {
+            Ok(output) => output,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                let _ = fs::remove_dir_all(&root);
+                return;
+            }
+            Err(err) => panic!("spawn fish: {err}"),
+        };
+        let _ = fs::remove_dir_all(&root);
+        let escaped = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            escaped,
+            "echo\\x20one/2.txt\\x20\\xE3\\x81\\x93",
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
     fn fish_escape_splits_od_bytes_before_prefixing_xhh() {
         assert!(INIT_FISH.contains("string split ' '"));
         assert!(INIT_FISH.contains("string match -r '^[0-9a-f][0-9a-f]$'"));

--- a/src-tauri/src/sessions/shell_wrapper/init.fish
+++ b/src-tauri/src/sessions/shell_wrapper/init.fish
@@ -6,7 +6,14 @@
 function __yorishiro_osc633_escape --argument-names input
     set -l out ""
     for byte in (printf '%s' "$input" | od -An -v -tx1 | string split ' ' | string match -r '^[0-9a-f][0-9a-f]$')
-        set out "$out\\x"(string upper "$byte")
+        # zsh/bash 版と同じ safe set は素通しする（issue #73）。それ以外
+        # （space・記号・UTF-8 継続 byte・改行 = 空 var を含む）は \xHH に escape。
+        set -l char (printf "\\x$byte")
+        if string match -qr -- '^[A-Za-z0-9_/:.,@%+=-]$' "$char"
+            set out "$out$char"
+        else
+            set out "$out\\x"(string upper "$byte")
+        end
     end
     printf '%s' "$out"
 end


### PR DESCRIPTION
## Summary

Fixes #73 — the fish `__yorishiro_osc633_escape` hex-escaped every byte, so `echo one` became `\x65\x63\x68\x6F...`: decoded identically by the runtime, but ~4x the payload and unreadable raw streams. This aligns fish with the zsh/bash versions — bytes in `[A-Za-z0-9_/:.,@%+=-]` pass through, everything else (space, symbols, UTF-8 continuation bytes, control bytes) keeps the `\xHH` form.

Noticed by @soren-achebe in #67 while decoding streams; credited with a `Reported-by:` trailer (the fix code itself is new).

## Verification

- New Rust test `fish_escape_passes_safe_ascii_through` runs the function in a real fish (`fish -c`, graceful skip when fish is absent) — fails on the old implementation, passes now: `echo one/2.txt こ` → `echo\x20one/2.txt\x20\xE3\x81\x93`
- Manual samples in fish 4.x: quotes → `\x22`, pipe → `\x7C`, glob `*` → `\x2A`, Japanese → per-byte UTF-8 escapes; `fish -n` syntax check clean
- `cargo test`: 252 passed; `npm run check` (tsc + biome + rustfmt + clippy): pass
- Existing content-shape test `fish_escape_splits_od_bytes_before_prefixing_xhh` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)