### PR TITLE
Make Voice Summary a safe GPT Live fallback

### DIFF
--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -178,7 +178,9 @@ MCP tool requestにはRust側のevent作成時点でaudio ownershipの`ownerId` 
 current VoicePlayerのowner ID + generationが完全一致する場合だけ再生する。owner IDはWebViewの
 wall clockではなく、生存中のRust processがWebView incarnationごとに発行する。frontendからRustへの
 ownership更新は同じowner ID内のgenerationで順序付けし、非同期invokeが逆順に完了しても古い更新を
-採用しない。fallbackへのrestore IPCは一時失敗に備えてbounded retryする。
+採用しない。owner登録はcandidate発行と最初のstate更新によるactivationの二段階に分け、前WebViewの
+遅延registerだけではactive leaseを奪えない。owner mismatchはIPC errorとして返し、frontendはcandidateを
+再取得してからreconcileする。fallbackへのrestore IPCは一時失敗に備えてbounded retryする。
 
 ## 今後も守る invariant
 

--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -166,9 +166,17 @@ branchにあるが、Mainへのwiringは未実装である。
 
 GPT Liveは`connecting` / `active`の間だけ唯一の音声ownerとなり、Voice Summaryは
 `idle` / `error`時のfallbackとする。Live開始時はVoicePlayerの再生中音声を停止し、
-合成やclip取得の完了待ちも無効化する。所有中に届いた`voice_say` / `voice_play`は
+合成やclip取得のpublic `completion` / `waitUntilIdle`を即時cancelし、進行中のfetchもabortする。
+cancel後にbackend promiseが完了してもgeneration guardで再生せず、`VoiceHandle.cancellationReason`で
+通常完了・実エラー・host cancelを区別できる。所有中に届いた`voice_say` / `voice_play`は
 `spoken: false` / `played: false`で完了し、切断後に古い要約を再生するqueueは持たない。
 stop、remote close、start failure、session切替でいずれもVoicePlayerを即時復帰させる。
+
+MCP tool requestにはRust側のevent作成時点でaudio ownershipの`ownerEpochMs` / `generation` /
+`fallbackPlaybackEnabled`をstampする。WebView dispatch時のcurrent stateだけで判断すると、Live中に
+作られたrequestがstop後に届いて古い要約を再生できるためである。handlerはrequest provenanceと
+current VoicePlayer stateの両方が許可する場合だけ再生する。frontendからRustへのownership更新は
+epoch + generationで順序付けし、非同期invokeが逆順に完了しても古い更新を採用しない。
 
 ## 今後も守る invariant
 
@@ -251,6 +259,11 @@ experience を失う。
 - timeout後のlate connection、stop後のlate microphoneを解放する
 - remote closed後は一回のクリックで再接続する
 - old attempt/clientがnew active clientを破棄しない
+- synthesis / resolver / fetch待機中のLive開始でpublic completionと`waitUntilIdle`が即時完了する
+- cancel後にfallbackを再有効化してもold generationの音声を再生しない
+- stop / start failure / session切替 / unmountの全経路でfallback playbackを復帰する
+- Live ownership provenance付きの遅延`voice_say` / `voice_play`を復帰後も再生しない
+- clipの実エラーとhost cancellationを`VoiceHandle.cancellationReason`で区別する
 
 加えて実機で、voice turnのTUI表示、TUI approval response、barge-in、session切替、remote close、
 複数subagent稼働中のvoice開始を確認する。

--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -164,9 +164,11 @@ branchにあるが、Mainへのwiringは未実装である。
 
 ### Voice Summaryとの共存
 
-GPT Live接続中にVoice Summaryを自動再生すると音声の重複や割り込みが起きる。GPT Liveをactive時の
-唯一の音声owner、Voice Summaryをfallbackにする方向が妥当だが、抑止範囲、未通知resultの扱い、
-切断後の復帰方法は未決定である。現時点では挙動を変更せず、別decisionで確定する。
+GPT Liveは`connecting` / `active`の間だけ唯一の音声ownerとなり、Voice Summaryは
+`idle` / `error`時のfallbackとする。Live開始時はVoicePlayerの再生中音声を停止し、
+合成やclip取得の完了待ちも無効化する。所有中に届いた`voice_say` / `voice_play`は
+`spoken: false` / `played: false`で完了し、切断後に古い要約を再生するqueueは持たない。
+stop、remote close、start failure、session切替でいずれもVoicePlayerを即時復帰させる。
 
 ## 今後も守る invariant
 

--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -172,11 +172,13 @@ cancel後にbackend promiseが完了してもgeneration guardで再生せず、`
 `spoken: false` / `played: false`で完了し、切断後に古い要約を再生するqueueは持たない。
 stop、remote close、start failure、session切替でいずれもVoicePlayerを即時復帰させる。
 
-MCP tool requestにはRust側のevent作成時点でaudio ownershipの`ownerEpochMs` / `generation` /
+MCP tool requestにはRust側のevent作成時点でaudio ownershipの`ownerId` / `generation` /
 `fallbackPlaybackEnabled`をstampする。WebView dispatch時のcurrent stateだけで判断すると、Live中に
 作られたrequestがstop後に届いて古い要約を再生できるためである。handlerはrequest provenanceと
-current VoicePlayer stateの両方が許可する場合だけ再生する。frontendからRustへのownership更新は
-epoch + generationで順序付けし、非同期invokeが逆順に完了しても古い更新を採用しない。
+current VoicePlayerのowner ID + generationが完全一致する場合だけ再生する。owner IDはWebViewの
+wall clockではなく、生存中のRust processがWebView incarnationごとに発行する。frontendからRustへの
+ownership更新は同じowner ID内のgenerationで順序付けし、非同期invokeが逆順に完了しても古い更新を
+採用しない。fallbackへのrestore IPCは一時失敗に備えてbounded retryする。
 
 ## 今後も守る invariant
 

--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -180,7 +180,8 @@ wall clockではなく、生存中のRust processがWebView incarnationごとに
 ownership更新は同じowner ID内のgenerationで順序付けし、非同期invokeが逆順に完了しても古い更新を
 採用しない。owner登録はcandidate発行と最初のstate更新によるactivationの二段階に分け、前WebViewの
 遅延registerだけではactive leaseを奪えない。owner mismatchはIPC errorとして返し、frontendはcandidateを
-再取得してからreconcileする。fallbackへのrestore IPCは一時失敗に備えてbounded retryする。
+再取得してからreconcileする。ただし古いgeneration / update attemptの後着errorは、より新しい成功済み
+leaseをinvalidateしない。fallbackへのrestore IPCは一時失敗に備えてbounded retryする。
 
 ## 今後も守る invariant
 

--- a/docs/decisions/voice-clip-resolution.md
+++ b/docs/decisions/voice-clip-resolution.md
@@ -21,6 +21,7 @@
   - `http(s)://` / `asset://` / `blob:` — caller が解決済みの URL
 - 解決順序: scoped resolver（persona-aware）→ shared voice map → playable URL passthrough → null
 - 解決失敗は **silent ではない**: `completion` が reject、`startedAt` は `0` のまま。caller は「鳴っていない」を判定できる
+- GPT Live等のhost audio ownerが先にcancelした場合はfailureよりcancelが優先され、`completion`は即時resolve、`startedAt`は`0`のまま、`cancellationReason`に`playback-disabled`等を設定する。cancelより先に確定した解決・fetch失敗は従来通りrejectする
 - pack-local ref の path safety:
   - `./` または `assets/` prefix のみ許容
   - normalize 後の **全 segment** で `.` `..` を拒否

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1674,13 +1674,18 @@ async fn mcp_tool_response(request_id: String, response: serde_json::Value) -> R
 }
 
 #[tauri::command]
+async fn mcp_voice_playback_register_owner() -> Result<String, String> {
+    Ok(mcp::server::register_voice_playback_owner())
+}
+
+#[tauri::command]
 async fn mcp_voice_playback_set_enabled(
-    owner_epoch_ms: u64,
+    owner_id: String,
     generation: u64,
     enabled: bool,
 ) -> Result<(), String> {
     mcp::server::set_voice_playback_provenance(mcp::server::VoicePlaybackProvenance {
-        owner_epoch_ms,
+        owner_id,
         generation,
         fallback_playback_enabled: enabled,
     });
@@ -2414,6 +2419,7 @@ pub fn run() {
             watch_yorishiro_layer,
             stat_file_mtime,
             mcp_tool_response,
+            mcp_voice_playback_register_owner,
             mcp_voice_playback_set_enabled,
             read_journal_memories,
             read_journal_recent,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1688,8 +1688,7 @@ async fn mcp_voice_playback_set_enabled(
         owner_id,
         generation,
         fallback_playback_enabled: enabled,
-    });
-    Ok(())
+    })
 }
 
 // ─── User layer file watcher (Phase 1-b) ────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1673,6 +1673,20 @@ async fn mcp_tool_response(request_id: String, response: serde_json::Value) -> R
     mcp::server::resolve_pending_response(&request_id, response)
 }
 
+#[tauri::command]
+async fn mcp_voice_playback_set_enabled(
+    owner_epoch_ms: u64,
+    generation: u64,
+    enabled: bool,
+) -> Result<(), String> {
+    mcp::server::set_voice_playback_provenance(mcp::server::VoicePlaybackProvenance {
+        owner_epoch_ms,
+        generation,
+        fallback_playback_enabled: enabled,
+    });
+    Ok(())
+}
+
 // ─── User layer file watcher (Phase 1-b) ────────────────────────────
 //
 // `~/.yorishiro/**` を recursive に監視し、debounced event を TS 層の Channel
@@ -2400,6 +2414,7 @@ pub fn run() {
             watch_yorishiro_layer,
             stat_file_mtime,
             mcp_tool_response,
+            mcp_voice_playback_set_enabled,
             read_journal_memories,
             read_journal_recent,
             journal_record_farewell,

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -38,16 +38,16 @@ const TOOL_EVENT_TIMEOUT: Duration = Duration::from_secs(5);
 static PENDING: LazyLock<Mutex<HashMap<String, oneshot::Sender<Value>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VoicePlaybackProvenance {
-    pub owner_epoch_ms: u64,
+    pub owner_id: String,
     pub generation: u64,
     pub fallback_playback_enabled: bool,
 }
 
 static VOICE_PLAYBACK_PROVENANCE: LazyLock<Mutex<VoicePlaybackProvenance>> = LazyLock::new(|| {
     Mutex::new(VoicePlaybackProvenance {
-        owner_epoch_ms: 0,
+        owner_id: String::new(),
         generation: 0,
         fallback_playback_enabled: true,
     })
@@ -84,11 +84,16 @@ fn lock_voice_playback_provenance() -> std::sync::MutexGuard<'static, VoicePlayb
 fn apply_voice_playback_update(
     current: &mut VoicePlaybackProvenance,
     next: VoicePlaybackProvenance,
-) {
-    let is_newer = next.owner_epoch_ms > current.owner_epoch_ms
-        || (next.owner_epoch_ms == current.owner_epoch_ms && next.generation > current.generation);
-    if is_newer {
+) -> bool {
+    let belongs_to_current_owner = next.owner_id == current.owner_id;
+    let is_newer_or_retry = next.generation > current.generation
+        || (next.generation == current.generation
+            && next.fallback_playback_enabled == current.fallback_playback_enabled);
+    if belongs_to_current_owner && is_newer_or_retry {
         *current = next;
+        true
+    } else {
+        false
     }
 }
 
@@ -96,8 +101,18 @@ pub fn set_voice_playback_provenance(next: VoicePlaybackProvenance) {
     apply_voice_playback_update(&mut lock_voice_playback_provenance(), next);
 }
 
+pub fn register_voice_playback_owner() -> String {
+    let owner_id = uuid::Uuid::new_v4().to_string();
+    *lock_voice_playback_provenance() = VoicePlaybackProvenance {
+        owner_id: owner_id.clone(),
+        generation: 0,
+        fallback_playback_enabled: true,
+    };
+    owner_id
+}
+
 fn voice_playback_provenance() -> VoicePlaybackProvenance {
-    *lock_voice_playback_provenance()
+    lock_voice_playback_provenance().clone()
 }
 
 /// Tauri event で TS 層に tool request を飛ばし、`mcp_tool_response` が返す
@@ -129,7 +144,7 @@ pub async fn emit_tool_event_with_timeout(
         "tool": tool,
         "request": request,
         "voicePlayback": {
-            "ownerEpochMs": voice_playback.owner_epoch_ms,
+            "ownerId": voice_playback.owner_id,
             "generation": voice_playback.generation,
             "fallbackPlaybackEnabled": voice_playback.fallback_playback_enabled,
         },
@@ -261,29 +276,67 @@ mod tests {
     #[test]
     fn voice_playback_provenance_ignores_out_of_order_updates() {
         let mut current = VoicePlaybackProvenance {
-            owner_epoch_ms: 100,
+            owner_id: "current-owner".to_string(),
             generation: 2,
             fallback_playback_enabled: true,
         };
-        apply_voice_playback_update(
+        assert!(!apply_voice_playback_update(
             &mut current,
             VoicePlaybackProvenance {
-                owner_epoch_ms: 100,
+                owner_id: "current-owner".to_string(),
                 generation: 1,
                 fallback_playback_enabled: false,
             },
-        );
+        ));
         assert!(current.fallback_playback_enabled);
 
-        apply_voice_playback_update(
+        assert!(!apply_voice_playback_update(
             &mut current,
             VoicePlaybackProvenance {
-                owner_epoch_ms: 101,
-                generation: 0,
+                owner_id: "stale-owner".to_string(),
+                generation: 3,
                 fallback_playback_enabled: false,
             },
-        );
-        assert_eq!(current.owner_epoch_ms, 101);
+        ));
+        assert_eq!(current.owner_id, "current-owner");
+        assert!(current.fallback_playback_enabled);
+
+        assert!(apply_voice_playback_update(
+            &mut current,
+            VoicePlaybackProvenance {
+                owner_id: "current-owner".to_string(),
+                generation: 3,
+                fallback_playback_enabled: false,
+            },
+        ));
         assert!(!current.fallback_playback_enabled);
+    }
+
+    #[test]
+    fn voice_playback_provenance_accepts_idempotent_retry() {
+        let mut current = VoicePlaybackProvenance {
+            owner_id: "current-owner".to_string(),
+            generation: 2,
+            fallback_playback_enabled: true,
+        };
+
+        assert!(apply_voice_playback_update(
+            &mut current,
+            VoicePlaybackProvenance {
+                owner_id: "current-owner".to_string(),
+                generation: 2,
+                fallback_playback_enabled: true,
+            },
+        ));
+        assert!(current.fallback_playback_enabled);
+    }
+
+    #[test]
+    fn registering_voice_playback_owner_uses_rust_issued_unique_identity() {
+        let first = register_voice_playback_owner();
+        let second = register_voice_playback_owner();
+
+        assert_ne!(first, second);
+        assert_eq!(voice_playback_provenance().owner_id, second);
     }
 }

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -38,6 +38,21 @@ const TOOL_EVENT_TIMEOUT: Duration = Duration::from_secs(5);
 static PENDING: LazyLock<Mutex<HashMap<String, oneshot::Sender<Value>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VoicePlaybackProvenance {
+    pub owner_epoch_ms: u64,
+    pub generation: u64,
+    pub fallback_playback_enabled: bool,
+}
+
+static VOICE_PLAYBACK_PROVENANCE: LazyLock<Mutex<VoicePlaybackProvenance>> = LazyLock::new(|| {
+    Mutex::new(VoicePlaybackProvenance {
+        owner_epoch_ms: 0,
+        generation: 0,
+        fallback_playback_enabled: true,
+    })
+});
+
 /// config.json の mcpPort を読む（不在 / 不正 → None）。
 fn read_configured_port() -> Option<u16> {
     let path = crate::yorishiro_home_path().ok()?.join("config.json");
@@ -58,6 +73,31 @@ fn lock_pending() -> std::sync::MutexGuard<'static, HashMap<String, oneshot::Sen
     PENDING
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn lock_voice_playback_provenance() -> std::sync::MutexGuard<'static, VoicePlaybackProvenance> {
+    VOICE_PLAYBACK_PROVENANCE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn apply_voice_playback_update(
+    current: &mut VoicePlaybackProvenance,
+    next: VoicePlaybackProvenance,
+) {
+    let is_newer = next.owner_epoch_ms > current.owner_epoch_ms
+        || (next.owner_epoch_ms == current.owner_epoch_ms && next.generation > current.generation);
+    if is_newer {
+        *current = next;
+    }
+}
+
+pub fn set_voice_playback_provenance(next: VoicePlaybackProvenance) {
+    apply_voice_playback_update(&mut lock_voice_playback_provenance(), next);
+}
+
+fn voice_playback_provenance() -> VoicePlaybackProvenance {
+    *lock_voice_playback_provenance()
 }
 
 /// Tauri event で TS 層に tool request を飛ばし、`mcp_tool_response` が返す
@@ -82,10 +122,17 @@ pub async fn emit_tool_event_with_timeout(
         guard.insert(request_id.clone(), tx);
     }
 
+    // Stamp request creation, not WebView dispatch, so delayed Live-era voice tools stay suppressed.
+    let voice_playback = voice_playback_provenance();
     let payload = serde_json::json!({
         "requestId": request_id,
         "tool": tool,
         "request": request,
+        "voicePlayback": {
+            "ownerEpochMs": voice_playback.owner_epoch_ms,
+            "generation": voice_playback.generation,
+            "fallbackPlaybackEnabled": voice_playback.fallback_playback_enabled,
+        },
     });
 
     if let Err(err) = app.emit("mcp:tool-request", payload) {
@@ -209,5 +256,34 @@ mod tests {
         let result = resolve_pending_response("00000000-0000-0000-0000-000000000000", Value::Null);
         assert!(result.is_ok());
         assert_eq!(lock_pending().len(), before_len);
+    }
+
+    #[test]
+    fn voice_playback_provenance_ignores_out_of_order_updates() {
+        let mut current = VoicePlaybackProvenance {
+            owner_epoch_ms: 100,
+            generation: 2,
+            fallback_playback_enabled: true,
+        };
+        apply_voice_playback_update(
+            &mut current,
+            VoicePlaybackProvenance {
+                owner_epoch_ms: 100,
+                generation: 1,
+                fallback_playback_enabled: false,
+            },
+        );
+        assert!(current.fallback_playback_enabled);
+
+        apply_voice_playback_update(
+            &mut current,
+            VoicePlaybackProvenance {
+                owner_epoch_ms: 101,
+                generation: 0,
+                fallback_playback_enabled: false,
+            },
+        );
+        assert_eq!(current.owner_epoch_ms, 101);
+        assert!(!current.fallback_playback_enabled);
     }
 }

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -45,13 +45,31 @@ pub struct VoicePlaybackProvenance {
     pub fallback_playback_enabled: bool,
 }
 
-static VOICE_PLAYBACK_PROVENANCE: LazyLock<Mutex<VoicePlaybackProvenance>> = LazyLock::new(|| {
-    Mutex::new(VoicePlaybackProvenance {
-        owner_id: String::new(),
-        generation: 0,
-        fallback_playback_enabled: true,
-    })
-});
+#[derive(Debug)]
+struct VoicePlaybackLeaseState {
+    provenance: VoicePlaybackProvenance,
+    next_registration: u64,
+    active_registration: u64,
+    candidates: HashMap<String, u64>,
+}
+
+impl Default for VoicePlaybackLeaseState {
+    fn default() -> Self {
+        Self {
+            provenance: VoicePlaybackProvenance {
+                owner_id: String::new(),
+                generation: 0,
+                fallback_playback_enabled: true,
+            },
+            next_registration: 0,
+            active_registration: 0,
+            candidates: HashMap::new(),
+        }
+    }
+}
+
+static VOICE_PLAYBACK_LEASE: LazyLock<Mutex<VoicePlaybackLeaseState>> =
+    LazyLock::new(|| Mutex::new(VoicePlaybackLeaseState::default()));
 
 /// config.json の mcpPort を読む（不在 / 不正 → None）。
 fn read_configured_port() -> Option<u16> {
@@ -75,44 +93,60 @@ fn lock_pending() -> std::sync::MutexGuard<'static, HashMap<String, oneshot::Sen
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
-fn lock_voice_playback_provenance() -> std::sync::MutexGuard<'static, VoicePlaybackProvenance> {
-    VOICE_PLAYBACK_PROVENANCE
+fn lock_voice_playback_lease() -> std::sync::MutexGuard<'static, VoicePlaybackLeaseState> {
+    VOICE_PLAYBACK_LEASE
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 fn apply_voice_playback_update(
-    current: &mut VoicePlaybackProvenance,
+    state: &mut VoicePlaybackLeaseState,
     next: VoicePlaybackProvenance,
-) -> bool {
-    let belongs_to_current_owner = next.owner_id == current.owner_id;
-    let is_newer_or_retry = next.generation > current.generation
-        || (next.generation == current.generation
-            && next.fallback_playback_enabled == current.fallback_playback_enabled);
-    if belongs_to_current_owner && is_newer_or_retry {
-        *current = next;
-        true
-    } else {
-        false
+) -> Result<(), String> {
+    let belongs_to_current_owner = next.owner_id == state.provenance.owner_id;
+    let is_newer_or_retry = next.generation > state.provenance.generation
+        || (next.generation == state.provenance.generation
+            && next.fallback_playback_enabled == state.provenance.fallback_playback_enabled);
+    if belongs_to_current_owner {
+        if is_newer_or_retry {
+            state.provenance = next;
+            return Ok(());
+        }
+        return Err("voice playback generation is stale".to_string());
     }
+
+    let Some(registration) = state.candidates.remove(&next.owner_id) else {
+        return Err("voice playback owner is stale or unregistered".to_string());
+    };
+    if registration <= state.active_registration {
+        return Err("voice playback owner registration is stale".to_string());
+    }
+
+    state.active_registration = registration;
+    state
+        .candidates
+        .retain(|_, candidate| *candidate > registration);
+    state.provenance = next;
+    Ok(())
 }
 
-pub fn set_voice_playback_provenance(next: VoicePlaybackProvenance) {
-    apply_voice_playback_update(&mut lock_voice_playback_provenance(), next);
+pub fn set_voice_playback_provenance(next: VoicePlaybackProvenance) -> Result<(), String> {
+    apply_voice_playback_update(&mut lock_voice_playback_lease(), next)
 }
 
 pub fn register_voice_playback_owner() -> String {
     let owner_id = uuid::Uuid::new_v4().to_string();
-    *lock_voice_playback_provenance() = VoicePlaybackProvenance {
-        owner_id: owner_id.clone(),
-        generation: 0,
-        fallback_playback_enabled: true,
-    };
+    register_voice_playback_owner_with_id(&mut lock_voice_playback_lease(), owner_id.clone());
     owner_id
 }
 
+fn register_voice_playback_owner_with_id(state: &mut VoicePlaybackLeaseState, owner_id: String) {
+    state.next_registration = state.next_registration.saturating_add(1);
+    state.candidates.insert(owner_id, state.next_registration);
+}
+
 fn voice_playback_provenance() -> VoicePlaybackProvenance {
-    lock_voice_playback_provenance().clone()
+    lock_voice_playback_lease().provenance.clone()
 }
 
 /// Tauri event で TS 層に tool request を飛ばし、`mcp_tool_response` が返す
@@ -275,68 +309,124 @@ mod tests {
 
     #[test]
     fn voice_playback_provenance_ignores_out_of_order_updates() {
-        let mut current = VoicePlaybackProvenance {
-            owner_id: "current-owner".to_string(),
-            generation: 2,
-            fallback_playback_enabled: true,
+        let mut state = VoicePlaybackLeaseState {
+            provenance: VoicePlaybackProvenance {
+                owner_id: "current-owner".to_string(),
+                generation: 2,
+                fallback_playback_enabled: true,
+            },
+            next_registration: 1,
+            active_registration: 1,
+            candidates: HashMap::new(),
         };
-        assert!(!apply_voice_playback_update(
-            &mut current,
+        assert!(apply_voice_playback_update(
+            &mut state,
             VoicePlaybackProvenance {
                 owner_id: "current-owner".to_string(),
                 generation: 1,
                 fallback_playback_enabled: false,
             },
-        ));
-        assert!(current.fallback_playback_enabled);
+        )
+        .is_err());
+        assert!(state.provenance.fallback_playback_enabled);
 
-        assert!(!apply_voice_playback_update(
-            &mut current,
+        assert!(apply_voice_playback_update(
+            &mut state,
             VoicePlaybackProvenance {
                 owner_id: "stale-owner".to_string(),
                 generation: 3,
                 fallback_playback_enabled: false,
             },
-        ));
-        assert_eq!(current.owner_id, "current-owner");
-        assert!(current.fallback_playback_enabled);
+        )
+        .is_err());
+        assert_eq!(state.provenance.owner_id, "current-owner");
+        assert!(state.provenance.fallback_playback_enabled);
 
         assert!(apply_voice_playback_update(
-            &mut current,
+            &mut state,
             VoicePlaybackProvenance {
                 owner_id: "current-owner".to_string(),
                 generation: 3,
                 fallback_playback_enabled: false,
             },
-        ));
-        assert!(!current.fallback_playback_enabled);
+        )
+        .is_ok());
+        assert!(!state.provenance.fallback_playback_enabled);
     }
 
     #[test]
     fn voice_playback_provenance_accepts_idempotent_retry() {
-        let mut current = VoicePlaybackProvenance {
-            owner_id: "current-owner".to_string(),
-            generation: 2,
-            fallback_playback_enabled: true,
+        let mut state = VoicePlaybackLeaseState {
+            provenance: VoicePlaybackProvenance {
+                owner_id: "current-owner".to_string(),
+                generation: 2,
+                fallback_playback_enabled: true,
+            },
+            next_registration: 1,
+            active_registration: 1,
+            candidates: HashMap::new(),
         };
 
         assert!(apply_voice_playback_update(
-            &mut current,
+            &mut state,
             VoicePlaybackProvenance {
                 owner_id: "current-owner".to_string(),
                 generation: 2,
                 fallback_playback_enabled: true,
             },
-        ));
-        assert!(current.fallback_playback_enabled);
+        )
+        .is_ok());
+        assert!(state.provenance.fallback_playback_enabled);
     }
 
     #[test]
-    fn registering_voice_playback_owner_uses_rust_issued_unique_identity() {
+    fn voice_playback_reordered_registration_and_updates_preserve_the_active_lease() {
+        let mut state = VoicePlaybackLeaseState::default();
+        register_voice_playback_owner_with_id(&mut state, "previous-owner".to_string());
+        register_voice_playback_owner_with_id(&mut state, "current-owner".to_string());
+
+        assert!(apply_voice_playback_update(
+            &mut state,
+            VoicePlaybackProvenance {
+                owner_id: "current-owner".to_string(),
+                generation: 0,
+                fallback_playback_enabled: true,
+            },
+        )
+        .is_ok());
+        assert!(apply_voice_playback_update(
+            &mut state,
+            VoicePlaybackProvenance {
+                owner_id: "previous-owner".to_string(),
+                generation: 1,
+                fallback_playback_enabled: false,
+            },
+        )
+        .is_err());
+
+        register_voice_playback_owner_with_id(&mut state, "delayed-previous-owner".to_string());
+        assert_eq!(state.provenance.owner_id, "current-owner");
+        assert!(apply_voice_playback_update(
+            &mut state,
+            VoicePlaybackProvenance {
+                owner_id: "current-owner".to_string(),
+                generation: 1,
+                fallback_playback_enabled: false,
+            },
+        )
+        .is_ok());
+
+        assert_eq!(state.provenance.owner_id, "current-owner");
+        assert!(!state.provenance.fallback_playback_enabled);
+    }
+
+    #[test]
+    fn registering_voice_playback_owner_issues_unique_candidates_without_stealing() {
+        let before = voice_playback_provenance();
         let first = register_voice_playback_owner();
         let second = register_voice_playback_owner();
 
         assert_ne!(first, second);
-        assert_eq!(voice_playback_provenance().owner_id, second);
+        assert_eq!(voice_playback_provenance(), before);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1180,6 +1180,18 @@ function App() {
     const effectDispatcher = new EffectDispatcher();
     const voicePlayer = new VoicePlayer("Kyoko", new SayTtsEngine());
     const voiceApi = voicePlayer.createVoiceAPI();
+    let voicePlaybackOwnerPromise: Promise<string> | null = null;
+    const getVoicePlaybackOwnerId = (): Promise<string> => {
+      if (voicePlaybackOwnerPromise === null) {
+        voicePlaybackOwnerPromise = invoke<string>("mcp_voice_playback_register_owner").catch(
+          (error) => {
+            voicePlaybackOwnerPromise = null;
+            throw error;
+          },
+        );
+      }
+      return voicePlaybackOwnerPromise;
+    };
     const claimState = getClaimState();
     // Effect Pack infrastructure. screen-shake は body に transform を当てる
     // ことで fixed 子孫（three-runtime の canvas container）も含めて一緒に
@@ -2230,14 +2242,14 @@ function App() {
                 });
             },
             getFrequency: () => voiceFrequency,
-            canPlay: () => voicePlayer.isPlaybackEnabled(),
+            canPlay: (provenance) => voicePlayer.canPlayRequest(provenance),
           }),
           "voice.play": createVoicePlayHandler({
             play: (clipRef, options) => {
               voiceApi.play(clipRef, options);
             },
             getFrequency: () => voiceFrequency,
-            canPlay: () => voicePlayer.isPlaybackEnabled(),
+            canPlay: (provenance) => voicePlayer.canPlayRequest(provenance),
           }),
           // ── Pomodoro ─────────────────────────────────────
           "pomodoro.start": createPomodoroStartHandler({
@@ -2276,7 +2288,7 @@ function App() {
           tool: string;
           request: unknown;
           voicePlayback?: {
-            ownerEpochMs: number;
+            ownerId: string;
             generation: number;
             fallbackPlaybackEnabled: boolean;
           };
@@ -2367,6 +2379,7 @@ function App() {
       effectDispatcher,
       effectPackRunner,
       voicePlayer,
+      getVoicePlaybackOwnerId,
       scenePackRegistry,
       uiPackRegistry,
       packRegistry,
@@ -2386,6 +2399,7 @@ function App() {
     effectDispatcher,
     effectPackRunner,
     voicePlayer,
+    getVoicePlaybackOwnerId,
     scenePackRegistry,
     uiPackRegistry,
     packRegistry,
@@ -3623,8 +3637,10 @@ function App() {
     applyLipSyncSource: applyRealtimeLipSyncSource,
     setFallbackPlaybackEnabled: async (enabled) => {
       const ownership = voicePlayer.setPlaybackEnabled(enabled);
+      const ownerId = await getVoicePlaybackOwnerId();
+      voicePlayer.setPlaybackOwnerId(ownerId);
       await invoke("mcp_voice_playback_set_enabled", {
-        ownerEpochMs: ownership.ownerEpochMs,
+        ownerId,
         generation: ownership.generation,
         enabled: ownership.fallbackPlaybackEnabled,
       });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2230,12 +2230,14 @@ function App() {
                 });
             },
             getFrequency: () => voiceFrequency,
+            canPlay: () => voicePlayer.isPlaybackEnabled(),
           }),
           "voice.play": createVoicePlayHandler({
             play: (clipRef, options) => {
               voiceApi.play(clipRef, options);
             },
             getFrequency: () => voiceFrequency,
+            canPlay: () => voicePlayer.isPlaybackEnabled(),
           }),
           // ── Pomodoro ─────────────────────────────────────
           "pomodoro.start": createPomodoroStartHandler({
@@ -3612,6 +3614,7 @@ function App() {
     available: codexVoiceAvailable,
     fallbackLipSyncSource: voicePlayer,
     applyLipSyncSource: applyRealtimeLipSyncSource,
+    setFallbackPlaybackEnabled: (enabled) => voicePlayer.setPlaybackEnabled(enabled),
   });
 
   const handleBodyReady = useCallback(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2271,19 +2271,26 @@ function App() {
           restorePresenceFromPrompt();
         };
 
-        await listen<{ requestId: string; tool: string; request: unknown }>(
-          "mcp:tool-request",
-          async (event) => {
-            const result = await dispatchToolEvent(handlers, {
-              tool: event.payload.tool,
-              request: event.payload.request,
-            });
-            await invoke("mcp_tool_response", {
-              requestId: event.payload.requestId,
-              response: result,
-            });
-          },
-        );
+        await listen<{
+          requestId: string;
+          tool: string;
+          request: unknown;
+          voicePlayback?: {
+            ownerEpochMs: number;
+            generation: number;
+            fallbackPlaybackEnabled: boolean;
+          };
+        }>("mcp:tool-request", async (event) => {
+          const result = await dispatchToolEvent(handlers, {
+            tool: event.payload.tool,
+            request: event.payload.request,
+            context: { voicePlayback: event.payload.voicePlayback },
+          });
+          await invoke("mcp_tool_response", {
+            requestId: event.payload.requestId,
+            response: result,
+          });
+        });
         appLog.write({
           phase: "mcp-channel",
           note: "mcp:tool-request listener attached",
@@ -3614,7 +3621,14 @@ function App() {
     available: codexVoiceAvailable,
     fallbackLipSyncSource: voicePlayer,
     applyLipSyncSource: applyRealtimeLipSyncSource,
-    setFallbackPlaybackEnabled: (enabled) => voicePlayer.setPlaybackEnabled(enabled),
+    setFallbackPlaybackEnabled: async (enabled) => {
+      const ownership = voicePlayer.setPlaybackEnabled(enabled);
+      await invoke("mcp_voice_playback_set_enabled", {
+        ownerEpochMs: ownership.ownerEpochMs,
+        generation: ownership.generation,
+        enabled: ownership.fallbackPlaybackEnabled,
+      });
+    },
   });
 
   const handleBodyReady = useCallback(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1181,16 +1181,27 @@ function App() {
     const voicePlayer = new VoicePlayer("Kyoko", new SayTtsEngine());
     const voiceApi = voicePlayer.createVoiceAPI();
     let voicePlaybackOwnerPromise: Promise<string> | null = null;
+    let voicePlaybackOwnerId: string | null = null;
     const getVoicePlaybackOwnerId = (): Promise<string> => {
       if (voicePlaybackOwnerPromise === null) {
-        voicePlaybackOwnerPromise = invoke<string>("mcp_voice_playback_register_owner").catch(
-          (error) => {
+        voicePlaybackOwnerPromise = invoke<string>("mcp_voice_playback_register_owner")
+          .then((ownerId) => {
+            voicePlaybackOwnerId = ownerId;
+            voicePlayer.setPlaybackOwnerId(ownerId);
+            return ownerId;
+          })
+          .catch((error) => {
             voicePlaybackOwnerPromise = null;
             throw error;
-          },
-        );
+          });
       }
       return voicePlaybackOwnerPromise;
+    };
+    const invalidateVoicePlaybackOwner = (ownerId: string): void => {
+      if (voicePlaybackOwnerId !== ownerId) return;
+      voicePlayer.clearPlaybackOwnerId(ownerId);
+      voicePlaybackOwnerId = null;
+      voicePlaybackOwnerPromise = null;
     };
     const claimState = getClaimState();
     // Effect Pack infrastructure. screen-shake は body に transform を当てる
@@ -2380,6 +2391,7 @@ function App() {
       effectPackRunner,
       voicePlayer,
       getVoicePlaybackOwnerId,
+      invalidateVoicePlaybackOwner,
       scenePackRegistry,
       uiPackRegistry,
       packRegistry,
@@ -2400,6 +2412,7 @@ function App() {
     effectPackRunner,
     voicePlayer,
     getVoicePlaybackOwnerId,
+    invalidateVoicePlaybackOwner,
     scenePackRegistry,
     uiPackRegistry,
     packRegistry,
@@ -3638,12 +3651,16 @@ function App() {
     setFallbackPlaybackEnabled: async (enabled) => {
       const ownership = voicePlayer.setPlaybackEnabled(enabled);
       const ownerId = await getVoicePlaybackOwnerId();
-      voicePlayer.setPlaybackOwnerId(ownerId);
-      await invoke("mcp_voice_playback_set_enabled", {
-        ownerId,
-        generation: ownership.generation,
-        enabled: ownership.fallbackPlaybackEnabled,
-      });
+      try {
+        await invoke("mcp_voice_playback_set_enabled", {
+          ownerId,
+          generation: ownership.generation,
+          enabled: ownership.fallbackPlaybackEnabled,
+        });
+      } catch (error) {
+        invalidateVoicePlaybackOwner(ownerId);
+        throw error;
+      }
     },
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,7 @@ import { registerSceneLayerBridge } from "./core/scene/scene-layer-bridge";
 import { EffectDispatcher, EffectPackRunner, Renderer } from "./core/space";
 import { Time } from "./core/time";
 import { applyLayout, type LayoutTargets, resetLayout } from "./core/ui-layout";
-import { SayTtsEngine, VoicePlayer } from "./core/voice";
+import { SayTtsEngine, VoicePlaybackLeaseSync, VoicePlayer } from "./core/voice";
 import {
   changeStrings,
   getStrings,
@@ -1180,29 +1180,11 @@ function App() {
     const effectDispatcher = new EffectDispatcher();
     const voicePlayer = new VoicePlayer("Kyoko", new SayTtsEngine());
     const voiceApi = voicePlayer.createVoiceAPI();
-    let voicePlaybackOwnerPromise: Promise<string> | null = null;
-    let voicePlaybackOwnerId: string | null = null;
-    const getVoicePlaybackOwnerId = (): Promise<string> => {
-      if (voicePlaybackOwnerPromise === null) {
-        voicePlaybackOwnerPromise = invoke<string>("mcp_voice_playback_register_owner")
-          .then((ownerId) => {
-            voicePlaybackOwnerId = ownerId;
-            voicePlayer.setPlaybackOwnerId(ownerId);
-            return ownerId;
-          })
-          .catch((error) => {
-            voicePlaybackOwnerPromise = null;
-            throw error;
-          });
-      }
-      return voicePlaybackOwnerPromise;
-    };
-    const invalidateVoicePlaybackOwner = (ownerId: string): void => {
-      if (voicePlaybackOwnerId !== ownerId) return;
-      voicePlayer.clearPlaybackOwnerId(ownerId);
-      voicePlaybackOwnerId = null;
-      voicePlaybackOwnerPromise = null;
-    };
+    const voicePlaybackLeaseSync = new VoicePlaybackLeaseSync(voicePlayer, {
+      registerOwner: () => invoke<string>("mcp_voice_playback_register_owner"),
+      update: ({ ownerId, generation, enabled }) =>
+        invoke("mcp_voice_playback_set_enabled", { ownerId, generation, enabled }),
+    });
     const claimState = getClaimState();
     // Effect Pack infrastructure. screen-shake は body に transform を当てる
     // ことで fixed 子孫（three-runtime の canvas container）も含めて一緒に
@@ -2390,8 +2372,7 @@ function App() {
       effectDispatcher,
       effectPackRunner,
       voicePlayer,
-      getVoicePlaybackOwnerId,
-      invalidateVoicePlaybackOwner,
+      voicePlaybackLeaseSync,
       scenePackRegistry,
       uiPackRegistry,
       packRegistry,
@@ -2411,8 +2392,7 @@ function App() {
     effectDispatcher,
     effectPackRunner,
     voicePlayer,
-    getVoicePlaybackOwnerId,
-    invalidateVoicePlaybackOwner,
+    voicePlaybackLeaseSync,
     scenePackRegistry,
     uiPackRegistry,
     packRegistry,
@@ -3648,20 +3628,7 @@ function App() {
     available: codexVoiceAvailable,
     fallbackLipSyncSource: voicePlayer,
     applyLipSyncSource: applyRealtimeLipSyncSource,
-    setFallbackPlaybackEnabled: async (enabled) => {
-      const ownership = voicePlayer.setPlaybackEnabled(enabled);
-      const ownerId = await getVoicePlaybackOwnerId();
-      try {
-        await invoke("mcp_voice_playback_set_enabled", {
-          ownerId,
-          generation: ownership.generation,
-          enabled: ownership.fallbackPlaybackEnabled,
-        });
-      } catch (error) {
-        invalidateVoicePlaybackOwner(ownerId);
-        throw error;
-      }
-    },
+    setFallbackPlaybackEnabled: (enabled) => voicePlaybackLeaseSync.setEnabled(enabled),
   });
 
   const handleBodyReady = useCallback(

--- a/src/core/voice/index.ts
+++ b/src/core/voice/index.ts
@@ -4,5 +4,6 @@ export type { MouthValues } from "./mouth-values";
 export { MOUTH_KEYS, ZERO_MOUTH } from "./mouth-values";
 export type { TtsEngine } from "./tts-engine";
 export { SayTtsEngine } from "./tts-engine";
+export { VoicePlaybackLeaseSync } from "./voice-playback-lease-sync";
 export type { VoiceClipResolver } from "./voice-player";
 export { VoicePlayer } from "./voice-player";

--- a/src/core/voice/voice-playback-lease-sync.test.ts
+++ b/src/core/voice/voice-playback-lease-sync.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { VoicePlaybackLeaseSync } from "./voice-playback-lease-sync";
+import { VoicePlayer } from "./voice-player";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve()),
+}));
+
+function deferred(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+  readonly reject: (error: Error) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("VoicePlaybackLeaseSync", () => {
+  it("keeps the owner when stop succeeds before the older start claim rejects", async () => {
+    const startUpdate = deferred();
+    const stopUpdate = deferred();
+    const update = vi
+      .fn()
+      .mockReturnValueOnce(startUpdate.promise)
+      .mockReturnValueOnce(stopUpdate.promise);
+    const player = new VoicePlayer();
+    const sync = new VoicePlaybackLeaseSync(player, {
+      registerOwner: vi.fn(async () => "owner-a"),
+      update,
+    });
+
+    const start = sync.setEnabled(false);
+    void start.catch(() => {});
+    await flushUpdates();
+    const stop = sync.setEnabled(true);
+    await flushUpdates();
+
+    stopUpdate.resolve();
+    await stop;
+    startUpdate.reject(new Error("stale generation"));
+    await expect(start).rejects.toThrow("stale generation");
+
+    expect(update.mock.calls.map(([state]) => state.generation)).toEqual([1, 2]);
+    expect(player.getPlaybackOwnershipState().ownerId).toBe("owner-a");
+  });
+
+  it("ignores an older same-generation transport failure after a newer attempt succeeds", async () => {
+    const olderUpdate = deferred();
+    const newerUpdate = deferred();
+    const registerOwner = vi.fn(async () => "owner-a");
+    const player = new VoicePlayer();
+    const sync = new VoicePlaybackLeaseSync(player, {
+      registerOwner,
+      update: vi
+        .fn()
+        .mockReturnValueOnce(olderUpdate.promise)
+        .mockReturnValueOnce(newerUpdate.promise),
+    });
+
+    const older = sync.setEnabled(true);
+    void older.catch(() => {});
+    await flushUpdates();
+    const newer = sync.setEnabled(true);
+    await flushUpdates();
+
+    newerUpdate.resolve();
+    await newer;
+    olderUpdate.reject(new Error("late transport failure"));
+    await expect(older).rejects.toThrow("late transport failure");
+
+    expect(registerOwner).toHaveBeenCalledTimes(1);
+    expect(player.getPlaybackOwnershipState().ownerId).toBe("owner-a");
+  });
+
+  it("reacquires after the latest update fails", async () => {
+    const registerOwner = vi.fn().mockResolvedValueOnce("owner-a").mockResolvedValueOnce("owner-b");
+    const update = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("owner mismatch"))
+      .mockResolvedValueOnce(undefined);
+    const player = new VoicePlayer();
+    const sync = new VoicePlaybackLeaseSync(player, { registerOwner, update });
+
+    await expect(sync.setEnabled(false)).rejects.toThrow("owner mismatch");
+    await sync.setEnabled(true);
+
+    expect(registerOwner).toHaveBeenCalledTimes(2);
+    expect(player.getPlaybackOwnershipState().ownerId).toBe("owner-b");
+  });
+});

--- a/src/core/voice/voice-playback-lease-sync.ts
+++ b/src/core/voice/voice-playback-lease-sync.ts
@@ -1,0 +1,76 @@
+import type { VoicePlaybackOwnershipState, VoicePlayer } from "./voice-player";
+
+export interface VoicePlaybackLeaseUpdate {
+  readonly ownerId: string;
+  readonly generation: number;
+  readonly enabled: boolean;
+}
+
+export interface VoicePlaybackLeaseTransport {
+  readonly registerOwner: () => Promise<string>;
+  readonly update: (state: VoicePlaybackLeaseUpdate) => Promise<void>;
+}
+
+export class VoicePlaybackLeaseSync {
+  private ownerPromise: Promise<string> | null = null;
+  private ownerId: string | null = null;
+  private latestUpdateAttempt = 0;
+
+  constructor(
+    private readonly player: VoicePlayer,
+    private readonly transport: VoicePlaybackLeaseTransport,
+  ) {}
+
+  async setEnabled(enabled: boolean): Promise<void> {
+    const ownership = this.player.setPlaybackEnabled(enabled);
+    const attempt = ++this.latestUpdateAttempt;
+    const ownerId = await this.getOwnerId();
+
+    try {
+      await this.transport.update({
+        ownerId,
+        generation: ownership.generation,
+        enabled: ownership.fallbackPlaybackEnabled,
+      });
+    } catch (error) {
+      if (this.canInvalidate(ownerId, ownership, attempt)) this.invalidate(ownerId);
+      throw error;
+    }
+  }
+
+  private getOwnerId(): Promise<string> {
+    if (this.ownerPromise !== null) return this.ownerPromise;
+
+    const registration = this.transport.registerOwner();
+    const pending = registration
+      .then((ownerId) => {
+        this.ownerId = ownerId;
+        this.player.setPlaybackOwnerId(ownerId);
+        return ownerId;
+      })
+      .catch((error) => {
+        if (this.ownerPromise === pending) this.ownerPromise = null;
+        throw error;
+      });
+    this.ownerPromise = pending;
+    return pending;
+  }
+
+  private canInvalidate(
+    ownerId: string,
+    ownership: VoicePlaybackOwnershipState,
+    attempt: number,
+  ): boolean {
+    return (
+      attempt === this.latestUpdateAttempt &&
+      ownerId === this.ownerId &&
+      ownership.generation === this.player.getPlaybackOwnershipState().generation
+    );
+  }
+
+  private invalidate(ownerId: string): void {
+    this.player.clearPlaybackOwnerId(ownerId);
+    this.ownerId = null;
+    this.ownerPromise = null;
+  }
+}

--- a/src/core/voice/voice-player.test.ts
+++ b/src/core/voice/voice-player.test.ts
@@ -310,6 +310,61 @@ describe("VoicePlayer (engine あり — Web Audio)", () => {
     expect(player.isPlaybackEnabled()).toBe(false);
   });
 
+  it("Rust-issued owner ID と current generation が一致する request だけを許可する", () => {
+    const player = new VoicePlayer();
+    player.setPlaybackOwnerId("rust-owner-1");
+    const initial = player.getPlaybackOwnershipState();
+
+    expect(
+      player.canPlayRequest({
+        ownerId: "rust-owner-1",
+        generation: initial.generation,
+        fallbackPlaybackEnabled: true,
+      }),
+    ).toBe(true);
+
+    player.setPlaybackEnabled(false);
+    player.setPlaybackEnabled(true);
+
+    expect(
+      player.canPlayRequest({
+        ownerId: "rust-owner-1",
+        generation: initial.generation,
+        fallbackPlaybackEnabled: true,
+      }),
+    ).toBe(false);
+    expect(
+      player.canPlayRequest({
+        ownerId: "previous-rust-owner",
+        generation: 2,
+        fallbackPlaybackEnabled: true,
+      }),
+    ).toBe(false);
+    expect(
+      player.canPlayRequest({
+        ownerId: "rust-owner-1",
+        generation: 2,
+        fallbackPlaybackEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("playback owner identity does not depend on wall-clock ordering", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValueOnce(200).mockReturnValueOnce(100);
+    try {
+      const first = new VoicePlayer();
+      const second = new VoicePlayer();
+      first.setPlaybackOwnerId("rust-owner-first");
+      second.setPlaybackOwnerId("rust-owner-second");
+
+      expect(first.getPlaybackOwnershipState().ownerId).toBe("rust-owner-first");
+      expect(second.getPlaybackOwnershipState().ownerId).toBe("rust-owner-second");
+      expect(now).not.toHaveBeenCalled();
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   it("合成中に再生を無効化した発話は、後から完了しても再生しない", async () => {
     let resolveSynth: (audio: ArrayBuffer) => void = () => {};
     const engine: TtsEngine = {

--- a/src/core/voice/voice-player.test.ts
+++ b/src/core/voice/voice-player.test.ts
@@ -174,7 +174,7 @@ describe("VoicePlayer (engine なし — OS TTS フォールバック)", () => {
     await flushPlaybackStart();
 
     expect(handle.startedAt).toBeGreaterThan(0);
-    expect(mockFetch).toHaveBeenCalledWith("/voice.wav");
+    expect(mockFetch).toHaveBeenCalledWith("/voice.wav", { signal: expect.any(AbortSignal) });
     expect(mockAudioContext.decodeAudioData).toHaveBeenCalledTimes(1);
     expect(mockAudioContext.createBuffer).not.toHaveBeenCalled();
 
@@ -189,6 +189,19 @@ describe("VoicePlayer (engine なし — OS TTS フォールバック)", () => {
 
     await expect(handle.completion).rejects.toThrow("Unable to resolve voice clip");
     expect(handle.startedAt).toBe(0);
+    expect(handle.cancellationReason).toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("再生無効中の play() は typed cancellation として完了する", async () => {
+    const player = new VoicePlayer();
+    player.setPlaybackEnabled(false);
+
+    const handle = player.createVoiceAPI().play("clip:missing");
+
+    await expect(handle.completion).resolves.toBeUndefined();
+    expect(handle.startedAt).toBe(0);
+    expect(handle.cancellationReason).toBe("playback-disabled");
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -312,11 +325,99 @@ describe("VoicePlayer (engine あり — Web Audio)", () => {
     const handle = player.createVoiceAPI().say("合成中");
 
     player.setPlaybackEnabled(false);
-    resolveSynth(createMinimalWav());
     await handle.completion;
+
+    expect(handle.cancellationReason).toBe("playback-disabled");
+    await expect(player.waitUntilIdle(100)).resolves.toBeUndefined();
+
+    player.setPlaybackEnabled(true);
+    resolveSynth(createMinimalWav());
+    await flushPlaybackStart();
 
     expect(mockAudioContext.createBufferSource).not.toHaveBeenCalled();
     expect(mockInvoke).toHaveBeenCalledWith("tts_stop", {});
+  });
+
+  it("clip resolver 待機中の completion を即時 cancel し、再有効化後も再生しない", async () => {
+    let resolveClip: (url: string) => void = () => {};
+    const player = new VoicePlayer();
+    const api = player.createVoiceAPI({
+      resolveClip: () =>
+        new Promise<string>((resolve) => {
+          resolveClip = resolve;
+        }),
+    });
+    const handle = api.play("clip:pending");
+    await Promise.resolve();
+
+    player.setPlaybackEnabled(false);
+    await handle.completion;
+    expect(handle.cancellationReason).toBe("playback-disabled");
+    await expect(player.waitUntilIdle(100)).resolves.toBeUndefined();
+
+    player.setPlaybackEnabled(true);
+    resolveClip("/late.wav");
+    await flushPlaybackStart();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockAudioContext.createBufferSource).not.toHaveBeenCalled();
+  });
+
+  it("clip fetch 待機中は AbortSignal を中断して completion を即時 cancel する", async () => {
+    let fetchSignal: AbortSignal | undefined;
+    mockFetch.mockImplementationOnce(
+      (_url: string, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          fetchSignal = init?.signal ?? undefined;
+          fetchSignal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+    const player = new VoicePlayer();
+    const api = player.createVoiceAPI({ resolveClip: () => "/pending.wav" });
+    const handle = api.play("clip:pending");
+    await flushPlaybackStart();
+
+    player.setPlaybackEnabled(false);
+    await handle.completion;
+
+    expect(fetchSignal?.aborted).toBe(true);
+    expect(handle.cancellationReason).toBe("playback-disabled");
+    await expect(player.waitUntilIdle(100)).resolves.toBeUndefined();
+    expect(mockAudioContext.createBufferSource).not.toHaveBeenCalled();
+  });
+
+  it("cancel 後に再有効化しても古い synthesis generation は新しい発話を置き換えない", async () => {
+    let resolveOldSynth: (audio: ArrayBuffer) => void = () => {};
+    const engine: TtsEngine = {
+      name: "mock",
+      synthesize: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<ArrayBuffer>((resolve) => {
+              resolveOldSynth = resolve;
+            }),
+        )
+        .mockResolvedValueOnce(createMinimalWav()),
+    };
+    const player = new VoicePlayer(undefined, engine);
+    const api = player.createVoiceAPI();
+    const oldHandle = api.say("old");
+
+    player.setPlaybackEnabled(false);
+    await oldHandle.completion;
+    player.setPlaybackEnabled(true);
+    api.say("new");
+    await flushPlaybackStart();
+    const newSource = mockAudioContext.createBufferSource.mock.results[0].value;
+
+    resolveOldSynth(createMinimalWav());
+    await flushPlaybackStart();
+
+    expect(mockAudioContext.createBufferSource).toHaveBeenCalledTimes(1);
+    expect(newSource.stop).not.toHaveBeenCalled();
   });
 
   it("say() は VoiceHandle を返す", () => {

--- a/src/core/voice/voice-player.test.ts
+++ b/src/core/voice/voice-player.test.ts
@@ -285,6 +285,40 @@ describe("VoicePlayer (engine あり — Web Audio)", () => {
     expect(mockInvoke).not.toHaveBeenCalledWith("tts_speak", expect.anything());
   });
 
+  it("再生無効中は新しい発話を合成しない", async () => {
+    const engine = createMockEngine();
+    const player = new VoicePlayer(undefined, engine);
+    player.setPlaybackEnabled(false);
+
+    const handle = player.createVoiceAPI().say("スキップ");
+
+    await expect(handle.completion).resolves.toBeUndefined();
+    expect(engine.synthesize).not.toHaveBeenCalled();
+    expect(player.isPlaybackEnabled()).toBe(false);
+  });
+
+  it("合成中に再生を無効化した発話は、後から完了しても再生しない", async () => {
+    let resolveSynth: (audio: ArrayBuffer) => void = () => {};
+    const engine: TtsEngine = {
+      name: "mock",
+      synthesize: vi.fn(
+        () =>
+          new Promise<ArrayBuffer>((resolve) => {
+            resolveSynth = resolve;
+          }),
+      ),
+    };
+    const player = new VoicePlayer(undefined, engine);
+    const handle = player.createVoiceAPI().say("合成中");
+
+    player.setPlaybackEnabled(false);
+    resolveSynth(createMinimalWav());
+    await handle.completion;
+
+    expect(mockAudioContext.createBufferSource).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledWith("tts_stop", {});
+  });
+
   it("say() は VoiceHandle を返す", () => {
     const engine = createMockEngine();
     const player = new VoicePlayer(undefined, engine);

--- a/src/core/voice/voice-player.test.ts
+++ b/src/core/voice/voice-player.test.ts
@@ -365,6 +365,18 @@ describe("VoicePlayer (engine あり — Web Audio)", () => {
     }
   });
 
+  it("only clears the owner ID that lost its Rust lease", () => {
+    const player = new VoicePlayer();
+    player.setPlaybackOwnerId("current-owner");
+
+    player.clearPlaybackOwnerId("stale-owner");
+    expect(player.getPlaybackOwnershipState().ownerId).toBe("current-owner");
+
+    player.clearPlaybackOwnerId("current-owner");
+    player.setPlaybackOwnerId("reacquired-owner");
+    expect(player.getPlaybackOwnershipState().ownerId).toBe("reacquired-owner");
+  });
+
   it("合成中に再生を無効化した発話は、後から完了しても再生しない", async () => {
     let resolveSynth: (audio: ArrayBuffer) => void = () => {};
     const engine: TtsEngine = {

--- a/src/core/voice/voice-player.ts
+++ b/src/core/voice/voice-player.ts
@@ -133,6 +133,10 @@ export class VoicePlayer {
     this.playbackOwnerId = ownerId;
   }
 
+  clearPlaybackOwnerId(ownerId: string): void {
+    if (this.playbackOwnerId === ownerId) this.playbackOwnerId = null;
+  }
+
   canPlayRequest(provenance: VoicePlaybackProvenanceStamp | undefined): boolean {
     return (
       provenance !== undefined &&

--- a/src/core/voice/voice-player.ts
+++ b/src/core/voice/voice-player.ts
@@ -43,6 +43,8 @@ export class VoicePlayer {
   private readonly mouthCallbackScratch = createMouthValues();
   /** 進行中の発話（合成中〜再生完了）。waitUntilIdle の待ち対象。 */
   private readonly inFlight = new Set<Promise<void>>();
+  private playbackEnabled = true;
+  private playbackGeneration = 0;
 
   constructor(voice?: string, engine?: TtsEngine) {
     this.voice = voice ?? null;
@@ -81,6 +83,21 @@ export class VoicePlayer {
         new Promise<void>((resolve) => setTimeout(resolve, remaining)),
       ]);
     }
+  }
+
+  /** GPT Live など別の audio owner がいる間、VoicePlayer の全再生を抑止する。 */
+  setPlaybackEnabled(enabled: boolean): void {
+    if (this.playbackEnabled === enabled) return;
+    this.playbackEnabled = enabled;
+    this.playbackGeneration += 1;
+    if (!enabled) {
+      this.stopPlayback();
+      void invoke("tts_stop", {});
+    }
+  }
+
+  isPlaybackEnabled(): boolean {
+    return this.playbackEnabled;
   }
 
   /** 発話の completion を in-flight として追跡する。失敗も完了として扱う。 */
@@ -125,23 +142,26 @@ export class VoicePlayer {
   private sayViaWebAudio(text: string, options?: SayOptions): VoiceHandle {
     const startedAt = Date.now();
     const playbackId = this.createPlaybackId();
+    const playbackGeneration = this.playbackGeneration;
     let stopped = false;
 
     const completion = (async () => {
+      if (!this.isPlaybackCurrent(playbackGeneration)) return;
       try {
         const audioData = await this.engine?.synthesize(text, this.voice ?? undefined);
-        if (!audioData || stopped) return;
+        if (!audioData || stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
 
         const ctx = await ensureAudioContextRunning();
+        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
 
         this.ensureGraph(ctx);
 
         const audioBuffer = await decodeAudioData(ctx, audioData);
-        if (stopped) return;
+        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
 
         await this.playBuffer(playbackId, ctx, audioBuffer, normalizeVolume(options?.volume));
       } catch (error) {
-        if (stopped) return;
+        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
         this.stopPlayback(playbackId);
         console.error("[voice] Web Audio TTS failed; lip sync cannot run.", error);
         await invoke("tts_speak", { text, voice: this.voice });
@@ -186,11 +206,13 @@ export class VoicePlayer {
   ): VoiceHandle {
     let startedAt = 0;
     const playbackId = this.createPlaybackId();
+    const playbackGeneration = this.playbackGeneration;
     let stopped = false;
 
     const completion = (async () => {
+      if (!this.isPlaybackCurrent(playbackGeneration)) return;
       const url = await this.resolveClipUrl(clipRef, resolveClip);
-      if (stopped) return;
+      if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
       if (url === null) {
         throw new Error(`Unable to resolve voice clip '${clipRef}'`);
       }
@@ -201,14 +223,15 @@ export class VoicePlayer {
           throw new Error(`HTTP ${response.status}`);
         }
         const audioData = await response.arrayBuffer();
-        if (stopped) return;
+        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
 
         const ctx = await ensureAudioContextRunning();
+        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
 
         this.ensureGraph(ctx);
 
         const audioBuffer = await decodeAudioData(ctx, audioData);
-        if (stopped) return;
+        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
 
         await this.playBuffer(
           playbackId,
@@ -220,7 +243,7 @@ export class VoicePlayer {
           },
         );
       } catch (error) {
-        if (!stopped) {
+        if (!stopped && this.isPlaybackCurrent(playbackGeneration)) {
           console.error(`[voice] Failed to play clip '${clipRef}'.`, error);
           throw error;
         }
@@ -388,10 +411,12 @@ export class VoicePlayer {
   // ---------------------------------------------------------------------------
 
   private sayViaOsTts(text: string): VoiceHandle {
-    const completion = invoke("tts_speak", {
-      text,
-      voice: this.voice,
-    }).then(() => {});
+    const completion = this.playbackEnabled
+      ? invoke("tts_speak", {
+          text,
+          voice: this.voice,
+        }).then(() => {})
+      : Promise.resolve();
     this.trackCompletion(completion);
 
     return {
@@ -405,6 +430,10 @@ export class VoicePlayer {
     const id = this.nextPlaybackId;
     this.nextPlaybackId += 1;
     return id;
+  }
+
+  private isPlaybackCurrent(generation: number): boolean {
+    return this.playbackEnabled && generation === this.playbackGeneration;
   }
 }
 

--- a/src/core/voice/voice-player.ts
+++ b/src/core/voice/voice-player.ts
@@ -18,8 +18,14 @@ const FADE_OUT_MS = 150;
 
 export type VoiceClipResolver = (clipRef: VoiceClipRef) => Promise<string | null> | string | null;
 
+export interface VoicePlaybackProvenanceStamp {
+  readonly ownerId: string;
+  readonly generation: number;
+  readonly fallbackPlaybackEnabled: boolean;
+}
+
 export interface VoicePlaybackOwnershipState {
-  readonly ownerEpochMs: number;
+  readonly ownerId: string | null;
   readonly generation: number;
   readonly fallbackPlaybackEnabled: boolean;
 }
@@ -59,7 +65,7 @@ export class VoicePlayer {
   /** 進行中の発話（合成中〜再生完了）。waitUntilIdle の待ち対象。 */
   private readonly inFlight = new Set<Promise<void>>();
   private readonly operations = new Set<VoicePlaybackOperation>();
-  private readonly playbackOwnerEpochMs = Date.now();
+  private playbackOwnerId: string | null = null;
   private playbackEnabled = true;
   private playbackGeneration = 0;
 
@@ -119,9 +125,28 @@ export class VoicePlayer {
     return this.playbackEnabled;
   }
 
+  setPlaybackOwnerId(ownerId: string): void {
+    if (ownerId === "") throw new Error("Voice playback owner ID must not be empty");
+    if (this.playbackOwnerId !== null && this.playbackOwnerId !== ownerId) {
+      throw new Error("Voice playback owner ID cannot change during a WebView incarnation");
+    }
+    this.playbackOwnerId = ownerId;
+  }
+
+  canPlayRequest(provenance: VoicePlaybackProvenanceStamp | undefined): boolean {
+    return (
+      provenance !== undefined &&
+      this.playbackOwnerId !== null &&
+      provenance.ownerId === this.playbackOwnerId &&
+      provenance.generation === this.playbackGeneration &&
+      provenance.fallbackPlaybackEnabled &&
+      this.playbackEnabled
+    );
+  }
+
   getPlaybackOwnershipState(): VoicePlaybackOwnershipState {
     return {
-      ownerEpochMs: this.playbackOwnerEpochMs,
+      ownerId: this.playbackOwnerId,
       generation: this.playbackGeneration,
       fallbackPlaybackEnabled: this.playbackEnabled,
     };

--- a/src/core/voice/voice-player.ts
+++ b/src/core/voice/voice-player.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type {
   SayOptions,
   VoiceAPI,
+  VoiceCancellationReason,
   VoiceClipRef,
   VoiceHandle,
   VoicePlayOptions,
@@ -16,6 +17,20 @@ import { isPlayableVoiceUrl, resolveSharedVoiceRef } from "./voice-clip-resolver
 const FADE_OUT_MS = 150;
 
 export type VoiceClipResolver = (clipRef: VoiceClipRef) => Promise<string | null> | string | null;
+
+export interface VoicePlaybackOwnershipState {
+  readonly ownerEpochMs: number;
+  readonly generation: number;
+  readonly fallbackPlaybackEnabled: boolean;
+}
+
+interface VoicePlaybackOperation {
+  readonly generation: number;
+  readonly abortController: AbortController;
+  readonly cancellation: Promise<void>;
+  cancellationReason: VoiceCancellationReason | undefined;
+  cancel(reason: VoiceCancellationReason): void;
+}
 
 /**
  * TTS 音声を Web Audio パイプラインで再生する VoicePlayer。
@@ -43,6 +58,8 @@ export class VoicePlayer {
   private readonly mouthCallbackScratch = createMouthValues();
   /** 進行中の発話（合成中〜再生完了）。waitUntilIdle の待ち対象。 */
   private readonly inFlight = new Set<Promise<void>>();
+  private readonly operations = new Set<VoicePlaybackOperation>();
+  private readonly playbackOwnerEpochMs = Date.now();
   private playbackEnabled = true;
   private playbackGeneration = 0;
 
@@ -86,18 +103,28 @@ export class VoicePlayer {
   }
 
   /** GPT Live など別の audio owner がいる間、VoicePlayer の全再生を抑止する。 */
-  setPlaybackEnabled(enabled: boolean): void {
-    if (this.playbackEnabled === enabled) return;
+  setPlaybackEnabled(enabled: boolean): VoicePlaybackOwnershipState {
+    if (this.playbackEnabled === enabled) return this.getPlaybackOwnershipState();
     this.playbackEnabled = enabled;
     this.playbackGeneration += 1;
     if (!enabled) {
+      this.cancelOperations("playback-disabled");
       this.stopPlayback();
       void invoke("tts_stop", {});
     }
+    return this.getPlaybackOwnershipState();
   }
 
   isPlaybackEnabled(): boolean {
     return this.playbackEnabled;
+  }
+
+  getPlaybackOwnershipState(): VoicePlaybackOwnershipState {
+    return {
+      ownerEpochMs: this.playbackOwnerEpochMs,
+      generation: this.playbackGeneration,
+      fallbackPlaybackEnabled: this.playbackEnabled,
+    };
   }
 
   /** 発話の completion を in-flight として追跡する。失敗も完了として扱う。 */
@@ -123,6 +150,7 @@ export class VoicePlayer {
         this.playClip(clipRef, playOptions, options.resolveClip),
 
       silence: (_fadeMs?: number): void => {
+        this.cancelOperations("stopped");
         this.stopPlayback();
         invoke("tts_stop", {});
       },
@@ -130,6 +158,8 @@ export class VoicePlayer {
   }
 
   dispose(): void {
+    this.playbackGeneration += 1;
+    this.cancelOperations("disposed");
     this.stopPlayback();
     this.disconnectGraph();
     this.onMouthValues = null;
@@ -142,37 +172,39 @@ export class VoicePlayer {
   private sayViaWebAudio(text: string, options?: SayOptions): VoiceHandle {
     const startedAt = Date.now();
     const playbackId = this.createPlaybackId();
-    const playbackGeneration = this.playbackGeneration;
-    let stopped = false;
+    const operation = this.createOperation();
 
-    const completion = (async () => {
-      if (!this.isPlaybackCurrent(playbackGeneration)) return;
+    const work = (async () => {
+      if (!this.isOperationCurrent(operation)) return;
       try {
         const audioData = await this.engine?.synthesize(text, this.voice ?? undefined);
-        if (!audioData || stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
+        if (!audioData || !this.isOperationCurrent(operation)) return;
 
         const ctx = await ensureAudioContextRunning();
-        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
+        if (!this.isOperationCurrent(operation)) return;
 
         this.ensureGraph(ctx);
 
         const audioBuffer = await decodeAudioData(ctx, audioData);
-        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
+        if (!this.isOperationCurrent(operation)) return;
 
         await this.playBuffer(playbackId, ctx, audioBuffer, normalizeVolume(options?.volume));
       } catch (error) {
-        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
+        if (!this.isOperationCurrent(operation)) return;
         this.stopPlayback(playbackId);
         console.error("[voice] Web Audio TTS failed; lip sync cannot run.", error);
         await invoke("tts_speak", { text, voice: this.voice });
       }
     })();
-    this.trackCompletion(completion);
+    const completion = this.completeOperation(operation, work);
 
     return {
       startedAt,
+      get cancellationReason() {
+        return operation.cancellationReason;
+      },
       stop: () => {
-        stopped = true;
+        operation.cancel("stopped");
         this.stopPlayback(playbackId);
         void invoke("tts_stop", {});
         return Promise.resolve();
@@ -206,32 +238,31 @@ export class VoicePlayer {
   ): VoiceHandle {
     let startedAt = 0;
     const playbackId = this.createPlaybackId();
-    const playbackGeneration = this.playbackGeneration;
-    let stopped = false;
+    const operation = this.createOperation();
 
-    const completion = (async () => {
-      if (!this.isPlaybackCurrent(playbackGeneration)) return;
+    const work = (async () => {
+      if (!this.isOperationCurrent(operation)) return;
       const url = await this.resolveClipUrl(clipRef, resolveClip);
-      if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
+      if (!this.isOperationCurrent(operation)) return;
       if (url === null) {
         throw new Error(`Unable to resolve voice clip '${clipRef}'`);
       }
 
       try {
-        const response = await fetch(url);
+        const response = await fetch(url, { signal: operation.abortController.signal });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
         const audioData = await response.arrayBuffer();
-        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
+        if (!this.isOperationCurrent(operation)) return;
 
         const ctx = await ensureAudioContextRunning();
-        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
+        if (!this.isOperationCurrent(operation)) return;
 
         this.ensureGraph(ctx);
 
         const audioBuffer = await decodeAudioData(ctx, audioData);
-        if (stopped || !this.isPlaybackCurrent(playbackGeneration)) return;
+        if (!this.isOperationCurrent(operation)) return;
 
         await this.playBuffer(
           playbackId,
@@ -243,21 +274,24 @@ export class VoicePlayer {
           },
         );
       } catch (error) {
-        if (!stopped && this.isPlaybackCurrent(playbackGeneration)) {
+        if (this.isOperationCurrent(operation)) {
           console.error(`[voice] Failed to play clip '${clipRef}'.`, error);
           throw error;
         }
       }
     })();
+    const completion = this.completeOperation(operation, work);
     void completion.catch(() => {});
-    this.trackCompletion(completion);
 
     return {
       get startedAt() {
         return startedAt;
       },
+      get cancellationReason() {
+        return operation.cancellationReason;
+      },
       stop: () => {
-        stopped = true;
+        operation.cancel("stopped");
         this.stopPlayback(playbackId);
         return Promise.resolve();
       },
@@ -411,19 +445,45 @@ export class VoicePlayer {
   // ---------------------------------------------------------------------------
 
   private sayViaOsTts(text: string): VoiceHandle {
-    const completion = this.playbackEnabled
+    const operation = this.createOperation();
+    const work = this.isOperationCurrent(operation)
       ? invoke("tts_speak", {
           text,
           voice: this.voice,
         }).then(() => {})
       : Promise.resolve();
-    this.trackCompletion(completion);
+    const completion = this.completeOperation(operation, work);
 
     return {
       startedAt: Date.now(),
-      stop: () => invoke("tts_stop", {}).then(() => {}),
+      get cancellationReason() {
+        return operation.cancellationReason;
+      },
+      stop: () => {
+        operation.cancel("stopped");
+        return invoke("tts_stop", {}).then(() => {});
+      },
       completion,
     };
+  }
+
+  private createOperation(): VoicePlaybackOperation {
+    const operation = createVoicePlaybackOperation(this.playbackGeneration);
+    this.operations.add(operation);
+    if (!this.playbackEnabled) operation.cancel("playback-disabled");
+    return operation;
+  }
+
+  private completeOperation(operation: VoicePlaybackOperation, work: Promise<void>): Promise<void> {
+    const completion = Promise.race([work, operation.cancellation]).finally(() => {
+      this.operations.delete(operation);
+    });
+    this.trackCompletion(completion);
+    return completion;
+  }
+
+  private cancelOperations(reason: VoiceCancellationReason): void {
+    for (const operation of this.operations) operation.cancel(reason);
   }
 
   private createPlaybackId(): number {
@@ -432,9 +492,34 @@ export class VoicePlayer {
     return id;
   }
 
-  private isPlaybackCurrent(generation: number): boolean {
-    return this.playbackEnabled && generation === this.playbackGeneration;
+  private isOperationCurrent(operation: VoicePlaybackOperation): boolean {
+    return (
+      operation.cancellationReason === undefined &&
+      this.playbackEnabled &&
+      operation.generation === this.playbackGeneration
+    );
   }
+}
+
+function createVoicePlaybackOperation(generation: number): VoicePlaybackOperation {
+  const abortController = new AbortController();
+  let resolveCancellation: () => void = () => {};
+  const cancellation = new Promise<void>((resolve) => {
+    resolveCancellation = resolve;
+  });
+  const operation: VoicePlaybackOperation = {
+    generation,
+    abortController,
+    cancellation,
+    cancellationReason: undefined,
+    cancel(reason) {
+      if (operation.cancellationReason !== undefined) return;
+      operation.cancellationReason = reason;
+      abortController.abort();
+      resolveCancellation();
+    },
+  };
+  return operation;
 }
 
 async function resolveWith(

--- a/src/runtime/codex-realtime/use-codex-realtime.test.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.test.ts
@@ -65,6 +65,7 @@ function setup(starts: Promise<void>[]) {
   };
   const fallback: LipSyncSource = { sampleMouth: () => ({ ...ZERO_MOUTH }) };
   const applyLipSyncSource = vi.fn<(source: LipSyncSource) => void>();
+  const setFallbackPlaybackEnabled = vi.fn<(enabled: boolean) => void>();
   const hook = renderHook(
     ({ sessionId, available }) =>
       useCodexRealtime({
@@ -72,14 +73,36 @@ function setup(starts: Promise<void>[]) {
         available,
         fallbackLipSyncSource: fallback,
         applyLipSyncSource,
+        setFallbackPlaybackEnabled,
         createClient,
       }),
     { initialProps: { sessionId: "main", available: true } },
   );
-  return { ...hook, clients, fallback, applyLipSyncSource };
+  return { ...hook, clients, fallback, applyLipSyncSource, setFallbackPlaybackEnabled };
 }
 
 describe("useCodexRealtime", () => {
+  it("connecting から GPT Live が audio を所有し、remote close 後に fallback を戻す", async () => {
+    const start = deferred();
+    const { result, clients, setFallbackPlaybackEnabled } = setup([start.promise]);
+
+    act(() => {
+      void result.current.toggle();
+    });
+    expect(result.current.state.status).toBe("connecting");
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(false);
+
+    act(() => {
+      clients[0].emit({ status: "active", billing: "subscription" });
+    });
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(false);
+
+    act(() => {
+      clients[0].emit({ status: "idle" });
+    });
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
+  });
+
   it("connecting中のsession切替後にstartが失敗してもidleをerrorで上書きしない", async () => {
     const start = deferred();
     const { result, rerender, clients, fallback, applyLipSyncSource } = setup([start.promise]);

--- a/src/runtime/codex-realtime/use-codex-realtime.test.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.test.ts
@@ -292,4 +292,61 @@ describe("useCodexRealtime", () => {
     expect(clients[0].stop).toHaveBeenCalledTimes(1);
     expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
   });
+
+  it.each([
+    "stop",
+    "error",
+    "remote-close",
+    "session-switch",
+  ] as const)("%s path retries a rejected fallback ownership restore", async (path) => {
+    vi.useFakeTimers();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let rustFallbackEnabled = true;
+    let rejectNextRestore = false;
+    const setFallbackPlaybackEnabled = vi.fn(async (enabled: boolean) => {
+      if (enabled && rejectNextRestore) {
+        rejectNextRestore = false;
+        throw new Error("transient restore IPC failure");
+      }
+      rustFallbackEnabled = enabled;
+    });
+
+    try {
+      const { result, clients, rerender, unmount } = setup(
+        [Promise.resolve()],
+        setFallbackPlaybackEnabled,
+      );
+      await act(async () => {
+        await result.current.toggle();
+      });
+      act(() => {
+        clients[0].emit({ status: "active", billing: "subscription" });
+      });
+      expect(rustFallbackEnabled).toBe(false);
+      rejectNextRestore = true;
+
+      if (path === "stop") {
+        act(() => result.current.stop());
+      } else if (path === "error") {
+        act(() => clients[0].emit({ status: "error", error: "connection failed" }));
+      } else if (path === "remote-close") {
+        act(() => clients[0].emit({ status: "idle" }));
+      } else {
+        rerender({ sessionId: "other", available: false });
+      }
+
+      await act(async () => {
+        await Promise.resolve();
+        await vi.runAllTimersAsync();
+      });
+
+      expect(rustFallbackEnabled).toBe(true);
+      expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
+      expect(setFallbackPlaybackEnabled.mock.calls.filter(([enabled]) => enabled)).toHaveLength(3);
+      unmount();
+    } finally {
+      consoleError.mockRestore();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/runtime/codex-realtime/use-codex-realtime.test.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.test.ts
@@ -40,10 +40,10 @@ class FakeClient implements CodexRealtimeClientLike {
     return this.status;
   }
 
-  start(): Promise<void> {
+  readonly start = vi.fn((): Promise<void> => {
     this.emit({ status: "connecting" });
     return this.startResult;
-  }
+  });
 
   sampleMouth(out?: MouthValues): MouthValues {
     return out ?? { ...ZERO_MOUTH };
@@ -55,7 +55,10 @@ class FakeClient implements CodexRealtimeClientLike {
   }
 }
 
-function setup(starts: Promise<void>[]) {
+function setup(
+  starts: Promise<void>[],
+  setFallbackPlaybackEnabled: (enabled: boolean) => void | Promise<void> = vi.fn(),
+) {
   const clients: FakeClient[] = [];
   const createClient: CodexRealtimeClientFactory = (_sessionId, onStateChange) => {
     const startResult = starts[clients.length] ?? Promise.resolve();
@@ -65,7 +68,6 @@ function setup(starts: Promise<void>[]) {
   };
   const fallback: LipSyncSource = { sampleMouth: () => ({ ...ZERO_MOUTH }) };
   const applyLipSyncSource = vi.fn<(source: LipSyncSource) => void>();
-  const setFallbackPlaybackEnabled = vi.fn<(enabled: boolean) => void>();
   const hook = renderHook(
     ({ sessionId, available }) =>
       useCodexRealtime({
@@ -82,6 +84,12 @@ function setup(starts: Promise<void>[]) {
 }
 
 describe("useCodexRealtime", () => {
+  it("mount 時に Rust 側 ownership provenance を fallback へ同期する", () => {
+    const { setFallbackPlaybackEnabled } = setup([]);
+
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
+  });
+
   it("connecting から GPT Live が audio を所有し、remote close 後に fallback を戻す", async () => {
     const start = deferred();
     const { result, clients, setFallbackPlaybackEnabled } = setup([start.promise]);
@@ -103,9 +111,52 @@ describe("useCodexRealtime", () => {
     expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
   });
 
+  it("ownership provenance の claim 完了前には client を開始しない", async () => {
+    const ownershipClaim = deferred();
+    const setFallbackPlaybackEnabled = vi.fn((enabled: boolean) =>
+      enabled ? undefined : ownershipClaim.promise,
+    );
+    const { result, clients } = setup([Promise.resolve()], setFallbackPlaybackEnabled);
+
+    let toggle: Promise<void> = Promise.resolve();
+    act(() => {
+      toggle = result.current.toggle();
+    });
+    expect(clients[0].start).not.toHaveBeenCalled();
+
+    await act(async () => {
+      ownershipClaim.resolve();
+      await toggle;
+    });
+
+    expect(clients[0].start).toHaveBeenCalledTimes(1);
+  });
+
+  it("ownership provenance の claim 待機中に stop した client は後から開始しない", async () => {
+    const ownershipClaim = deferred();
+    const setFallbackPlaybackEnabled = vi.fn((enabled: boolean) =>
+      enabled ? undefined : ownershipClaim.promise,
+    );
+    const { result, clients } = setup([Promise.resolve()], setFallbackPlaybackEnabled);
+
+    let toggle: Promise<void> = Promise.resolve();
+    act(() => {
+      toggle = result.current.toggle();
+      result.current.stop();
+    });
+    await act(async () => {
+      ownershipClaim.resolve();
+      await toggle;
+    });
+
+    expect(clients[0].start).not.toHaveBeenCalled();
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
+  });
+
   it("connecting中のsession切替後にstartが失敗してもidleをerrorで上書きしない", async () => {
     const start = deferred();
-    const { result, rerender, clients, fallback, applyLipSyncSource } = setup([start.promise]);
+    const { result, rerender, clients, fallback, applyLipSyncSource, setFallbackPlaybackEnabled } =
+      setup([start.promise]);
 
     act(() => {
       void result.current.toggle();
@@ -116,6 +167,7 @@ describe("useCodexRealtime", () => {
     expect(clients[0].stop).toHaveBeenCalledTimes(1);
     expect(result.current.state).toEqual({ status: "idle" });
     expect(applyLipSyncSource).toHaveBeenLastCalledWith(fallback);
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
 
     await act(async () => {
       start.reject(new Error("stale start failure"));
@@ -124,6 +176,26 @@ describe("useCodexRealtime", () => {
 
     expect(result.current.state).toEqual({ status: "idle" });
     expect(clients[0].stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("current start failure 後に fallback playback を戻す", async () => {
+    const start = deferred();
+    const { result, clients, setFallbackPlaybackEnabled } = setup([start.promise]);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    let toggle: Promise<void> = Promise.resolve();
+    act(() => {
+      toggle = result.current.toggle();
+    });
+    await act(async () => {
+      start.reject(new Error("start failed"));
+      await toggle;
+    });
+
+    expect(clients[0].stop).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toEqual({ status: "error", error: "start failed" });
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
+    consoleError.mockRestore();
   });
 
   it("remote closedのidleで所有権を解放し、次の1クリックで再接続する", async () => {
@@ -165,7 +237,9 @@ describe("useCodexRealtime", () => {
   });
 
   it("明示stopを先に所有権解除し、後着のclosed/error通知をidleへ戻さない", async () => {
-    const { result, clients, fallback, applyLipSyncSource } = setup([Promise.resolve()]);
+    const { result, clients, fallback, applyLipSyncSource, setFallbackPlaybackEnabled } = setup([
+      Promise.resolve(),
+    ]);
 
     await act(async () => {
       await result.current.toggle();
@@ -181,10 +255,12 @@ describe("useCodexRealtime", () => {
     expect(result.current.state).toEqual({ status: "idle" });
     expect(result.current.getLipSyncSource()).toBe(fallback);
     expect(applyLipSyncSource).toHaveBeenLastCalledWith(fallback);
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
   });
 
   it("error後にsessionを切り替えると旧sessionのerrorをidleへ戻す", async () => {
-    const { result, rerender, clients, fallback, applyLipSyncSource } = setup([Promise.resolve()]);
+    const { result, rerender, clients, fallback, applyLipSyncSource, setFallbackPlaybackEnabled } =
+      setup([Promise.resolve()]);
 
     await act(async () => {
       await result.current.toggle();
@@ -198,5 +274,22 @@ describe("useCodexRealtime", () => {
 
     expect(result.current.state).toEqual({ status: "idle" });
     expect(applyLipSyncSource).toHaveBeenLastCalledWith(fallback);
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
+  });
+
+  it("unmount 中に client を止めて fallback playback を戻す", async () => {
+    const { result, clients, unmount, setFallbackPlaybackEnabled } = setup([Promise.resolve()]);
+
+    await act(async () => {
+      await result.current.toggle();
+    });
+    act(() => {
+      clients[0].emit({ status: "active", billing: "subscription" });
+    });
+
+    unmount();
+
+    expect(clients[0].stop).toHaveBeenCalledTimes(1);
+    expect(setFallbackPlaybackEnabled).toHaveBeenLastCalledWith(true);
   });
 });

--- a/src/runtime/codex-realtime/use-codex-realtime.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.ts
@@ -36,6 +36,8 @@ interface UseCodexRealtimeResult {
 const defaultCreateClient: CodexRealtimeClientFactory = (sessionId, onStateChange) =>
   new CodexRealtimeClient(sessionId, onStateChange);
 
+const FALLBACK_RESTORE_RETRY_DELAYS_MS = [50, 200] as const;
+
 /** App が所有する realtime client を一つに限定し、古い client の通知を遮断する。 */
 export function useCodexRealtime({
   sessionId,
@@ -51,6 +53,8 @@ export function useCodexRealtime({
   const setFallbackPlaybackEnabledRef = useRef(setFallbackPlaybackEnabled);
   const createClientRef = useRef(createClient);
   const sessionIdRef = useRef(sessionId);
+  const fallbackPlaybackTransitionRef = useRef(0);
+  const fallbackPlaybackRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [state, setState] = useState<CodexRealtimeState>({ status: "idle" });
 
   fallbackRef.current = fallbackLipSyncSource;
@@ -62,18 +66,47 @@ export function useCodexRealtime({
     applyLipSyncSourceRef.current(fallbackRef.current);
   }, []);
 
-  const restoreFallbackPlayback = useCallback(() => {
-    try {
-      const pending = setFallbackPlaybackEnabledRef.current(true);
-      if (pending) {
-        void pending.catch((error) => {
-          console.error("[codex-realtime] failed to restore fallback playback ownership", error);
-        });
-      }
-    } catch (error) {
-      console.error("[codex-realtime] failed to restore fallback playback ownership", error);
+  const beginFallbackPlaybackTransition = useCallback(() => {
+    fallbackPlaybackTransitionRef.current += 1;
+    if (fallbackPlaybackRetryTimerRef.current !== null) {
+      clearTimeout(fallbackPlaybackRetryTimerRef.current);
+      fallbackPlaybackRetryTimerRef.current = null;
     }
+    return fallbackPlaybackTransitionRef.current;
   }, []);
+
+  const restoreFallbackPlayback = useCallback(() => {
+    const transition = beginFallbackPlaybackTransition();
+    let retryIndex = 0;
+
+    const retry = (error: unknown): void => {
+      console.error("[codex-realtime] failed to restore fallback playback ownership", error);
+      if (fallbackPlaybackTransitionRef.current !== transition) return;
+      const delay = FALLBACK_RESTORE_RETRY_DELAYS_MS[retryIndex];
+      if (delay === undefined) return;
+      retryIndex += 1;
+      fallbackPlaybackRetryTimerRef.current = setTimeout(() => {
+        fallbackPlaybackRetryTimerRef.current = null;
+        if (fallbackPlaybackTransitionRef.current === transition) attempt();
+      }, delay);
+    };
+
+    const attempt = (): void => {
+      try {
+        const pending = setFallbackPlaybackEnabledRef.current(true);
+        if (pending) void pending.catch(retry);
+      } catch (error) {
+        retry(error);
+      }
+    };
+
+    attempt();
+  }, [beginFallbackPlaybackTransition]);
+
+  const claimFallbackPlayback = useCallback((): void | Promise<void> => {
+    beginFallbackPlaybackTransition();
+    return setFallbackPlaybackEnabledRef.current(false);
+  }, [beginFallbackPlaybackTransition]);
 
   const stop = useCallback(() => {
     const client = clientRef.current;
@@ -123,7 +156,7 @@ export function useCodexRealtime({
 
     try {
       // Claim request provenance before connecting so delayed Live-era voice tools remain suppressed.
-      const pendingOwnershipClaim = setFallbackPlaybackEnabledRef.current(false);
+      const pendingOwnershipClaim = claimFallbackPlayback();
       if (pendingOwnershipClaim) await pendingOwnershipClaim;
       if (clientRef.current !== client) return;
       await client.start();
@@ -138,7 +171,7 @@ export function useCodexRealtime({
       restoreFallbackPlayback();
       restoreFallback();
     }
-  }, [restoreFallback, restoreFallbackPlayback, sessionId, stop]);
+  }, [claimFallbackPlayback, restoreFallback, restoreFallbackPlayback, sessionId, stop]);
 
   useEffect(() => {
     const sessionChanged = sessionIdRef.current !== sessionId;

--- a/src/runtime/codex-realtime/use-codex-realtime.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.ts
@@ -22,6 +22,7 @@ interface UseCodexRealtimeOptions {
   readonly available: boolean;
   readonly fallbackLipSyncSource: LipSyncSource;
   readonly applyLipSyncSource: (source: LipSyncSource) => void;
+  readonly setFallbackPlaybackEnabled?: (enabled: boolean) => void;
   readonly createClient?: CodexRealtimeClientFactory;
 }
 
@@ -41,17 +42,20 @@ export function useCodexRealtime({
   available,
   fallbackLipSyncSource,
   applyLipSyncSource,
+  setFallbackPlaybackEnabled = () => {},
   createClient = defaultCreateClient,
 }: UseCodexRealtimeOptions): UseCodexRealtimeResult {
   const clientRef = useRef<CodexRealtimeClientLike | null>(null);
   const fallbackRef = useRef(fallbackLipSyncSource);
   const applyLipSyncSourceRef = useRef(applyLipSyncSource);
+  const setFallbackPlaybackEnabledRef = useRef(setFallbackPlaybackEnabled);
   const createClientRef = useRef(createClient);
   const sessionIdRef = useRef(sessionId);
   const [state, setState] = useState<CodexRealtimeState>({ status: "idle" });
 
   fallbackRef.current = fallbackLipSyncSource;
   applyLipSyncSourceRef.current = applyLipSyncSource;
+  setFallbackPlaybackEnabledRef.current = setFallbackPlaybackEnabled;
   createClientRef.current = createClient;
 
   const restoreFallback = useCallback(() => {
@@ -64,6 +68,7 @@ export function useCodexRealtime({
     clientRef.current = null;
     client?.stop();
     setState({ status: "idle" });
+    setFallbackPlaybackEnabledRef.current(true);
     restoreFallback();
   }, [restoreFallback]);
 
@@ -82,6 +87,7 @@ export function useCodexRealtime({
         clientRef.current = null;
         client.stop();
         setState(nextState);
+        setFallbackPlaybackEnabledRef.current(true);
         restoreFallback();
         return;
       }
@@ -90,6 +96,7 @@ export function useCodexRealtime({
         // remote closed 後の次クリックを、新規 start として扱えるよう解放する。
         clientRef.current = null;
         setState(nextState);
+        setFallbackPlaybackEnabledRef.current(true);
         restoreFallback();
         return;
       }
@@ -100,6 +107,8 @@ export function useCodexRealtime({
       }
     });
     clientRef.current = client;
+    // connecting 開始時点から GPT Live を唯一の audio owner にする。
+    setFallbackPlaybackEnabledRef.current(false);
 
     try {
       await client.start();
@@ -111,6 +120,7 @@ export function useCodexRealtime({
       const message = error instanceof Error ? error.message : String(error);
       console.error("[codex-realtime] start failed", error);
       setState({ status: "error", error: message });
+      setFallbackPlaybackEnabledRef.current(true);
       restoreFallback();
     }
   }, [restoreFallback, sessionId, stop]);
@@ -126,6 +136,7 @@ export function useCodexRealtime({
       const client = clientRef.current;
       clientRef.current = null;
       client?.stop();
+      setFallbackPlaybackEnabledRef.current(true);
     };
   }, []);
 

--- a/src/runtime/codex-realtime/use-codex-realtime.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.ts
@@ -22,7 +22,7 @@ interface UseCodexRealtimeOptions {
   readonly available: boolean;
   readonly fallbackLipSyncSource: LipSyncSource;
   readonly applyLipSyncSource: (source: LipSyncSource) => void;
-  readonly setFallbackPlaybackEnabled?: (enabled: boolean) => void;
+  readonly setFallbackPlaybackEnabled?: (enabled: boolean) => void | Promise<void>;
   readonly createClient?: CodexRealtimeClientFactory;
 }
 
@@ -62,15 +62,28 @@ export function useCodexRealtime({
     applyLipSyncSourceRef.current(fallbackRef.current);
   }, []);
 
+  const restoreFallbackPlayback = useCallback(() => {
+    try {
+      const pending = setFallbackPlaybackEnabledRef.current(true);
+      if (pending) {
+        void pending.catch((error) => {
+          console.error("[codex-realtime] failed to restore fallback playback ownership", error);
+        });
+      }
+    } catch (error) {
+      console.error("[codex-realtime] failed to restore fallback playback ownership", error);
+    }
+  }, []);
+
   const stop = useCallback(() => {
     const client = clientRef.current;
     // stop() 内の同期 idle 通知も stale 扱いにするため、先に所有権を外す。
     clientRef.current = null;
     client?.stop();
     setState({ status: "idle" });
-    setFallbackPlaybackEnabledRef.current(true);
+    restoreFallbackPlayback();
     restoreFallback();
-  }, [restoreFallback]);
+  }, [restoreFallback, restoreFallbackPlayback]);
 
   const toggle = useCallback(async () => {
     if (clientRef.current) {
@@ -87,7 +100,7 @@ export function useCodexRealtime({
         clientRef.current = null;
         client.stop();
         setState(nextState);
-        setFallbackPlaybackEnabledRef.current(true);
+        restoreFallbackPlayback();
         restoreFallback();
         return;
       }
@@ -96,7 +109,7 @@ export function useCodexRealtime({
         // remote closed 後の次クリックを、新規 start として扱えるよう解放する。
         clientRef.current = null;
         setState(nextState);
-        setFallbackPlaybackEnabledRef.current(true);
+        restoreFallbackPlayback();
         restoreFallback();
         return;
       }
@@ -107,10 +120,12 @@ export function useCodexRealtime({
       }
     });
     clientRef.current = client;
-    // connecting 開始時点から GPT Live を唯一の audio owner にする。
-    setFallbackPlaybackEnabledRef.current(false);
 
     try {
+      // Claim request provenance before connecting so delayed Live-era voice tools remain suppressed.
+      const pendingOwnershipClaim = setFallbackPlaybackEnabledRef.current(false);
+      if (pendingOwnershipClaim) await pendingOwnershipClaim;
+      if (clientRef.current !== client) return;
       await client.start();
     } catch (error) {
       // client 自身の error 通知、stop、session 切替で所有権を失った後なら無視する。
@@ -120,10 +135,10 @@ export function useCodexRealtime({
       const message = error instanceof Error ? error.message : String(error);
       console.error("[codex-realtime] start failed", error);
       setState({ status: "error", error: message });
-      setFallbackPlaybackEnabledRef.current(true);
+      restoreFallbackPlayback();
       restoreFallback();
     }
-  }, [restoreFallback, sessionId, stop]);
+  }, [restoreFallback, restoreFallbackPlayback, sessionId, stop]);
 
   useEffect(() => {
     const sessionChanged = sessionIdRef.current !== sessionId;
@@ -132,13 +147,15 @@ export function useCodexRealtime({
   }, [available, sessionId, stop]);
 
   useEffect(() => {
+    // Re-stamp the default owner after a WebView reload because the Rust MCP process can survive it.
+    restoreFallbackPlayback();
     return () => {
       const client = clientRef.current;
       clientRef.current = null;
       client?.stop();
-      setFallbackPlaybackEnabledRef.current(true);
+      restoreFallbackPlayback();
     };
-  }, []);
+  }, [restoreFallbackPlayback]);
 
   const getLipSyncSource = useCallback(
     () => (clientRef.current?.getStatus() === "active" ? clientRef.current : fallbackRef.current),

--- a/src/runtime/yorishiro-mcp/event-channel.test.ts
+++ b/src/runtime/yorishiro-mcp/event-channel.test.ts
@@ -61,7 +61,7 @@ describe("dispatchToolEvent", () => {
       "voice.say": async (_request, context) => context?.voicePlayback,
     };
     const voicePlayback = {
-      ownerEpochMs: 100,
+      ownerId: "rust-owner-1",
       generation: 3,
       fallbackPlaybackEnabled: false,
     };

--- a/src/runtime/yorishiro-mcp/event-channel.test.ts
+++ b/src/runtime/yorishiro-mcp/event-channel.test.ts
@@ -55,4 +55,23 @@ describe("dispatchToolEvent", () => {
       reason: "inner failure",
     });
   });
+
+  it("passes request creation provenance to the selected handler", async () => {
+    const handlers: ToolHandlerMap = {
+      "voice.say": async (_request, context) => context?.voicePlayback,
+    };
+    const voicePlayback = {
+      ownerEpochMs: 100,
+      generation: 3,
+      fallbackPlaybackEnabled: false,
+    };
+
+    const result = await dispatchToolEvent(handlers, {
+      tool: "voice.say",
+      request: { text: "delayed" },
+      context: { voicePlayback },
+    });
+
+    expect(result).toEqual({ ok: true, payload: voicePlayback });
+  });
 });

--- a/src/runtime/yorishiro-mcp/event-channel.ts
+++ b/src/runtime/yorishiro-mcp/event-channel.ts
@@ -9,13 +9,24 @@
  * Internal design-record: 2026-04-18-phase-1c-rescue-and-mcp.md Section 4.5
  */
 
-export type ToolHandler = (request: unknown) => Promise<unknown>;
+export interface VoicePlaybackProvenance {
+  readonly ownerEpochMs: number;
+  readonly generation: number;
+  readonly fallbackPlaybackEnabled: boolean;
+}
+
+export interface ToolInvocationContext {
+  readonly voicePlayback?: VoicePlaybackProvenance;
+}
+
+export type ToolHandler = (request: unknown, context?: ToolInvocationContext) => Promise<unknown>;
 
 export type ToolHandlerMap = Record<string, ToolHandler>;
 
 export interface ToolEvent {
   readonly tool: string;
   readonly request: unknown;
+  readonly context?: ToolInvocationContext;
 }
 
 export type ToolResponse =
@@ -31,7 +42,7 @@ export async function dispatchToolEvent(
     return { ok: false, reason: `unknown tool: ${event.tool}` };
   }
   try {
-    const payload = await handler(event.request);
+    const payload = await handler(event.request, event.context);
     return { ok: true, payload };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);

--- a/src/runtime/yorishiro-mcp/event-channel.ts
+++ b/src/runtime/yorishiro-mcp/event-channel.ts
@@ -9,14 +9,10 @@
  * Internal design-record: 2026-04-18-phase-1c-rescue-and-mcp.md Section 4.5
  */
 
-export interface VoicePlaybackProvenance {
-  readonly ownerEpochMs: number;
-  readonly generation: number;
-  readonly fallbackPlaybackEnabled: boolean;
-}
+import type { VoicePlaybackProvenanceStamp } from "../../core/voice/voice-player";
 
 export interface ToolInvocationContext {
-  readonly voicePlayback?: VoicePlaybackProvenance;
+  readonly voicePlayback?: VoicePlaybackProvenanceStamp;
 }
 
 export type ToolHandler = (request: unknown, context?: ToolInvocationContext) => Promise<unknown>;

--- a/src/runtime/yorishiro-mcp/tool-handlers.test.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.test.ts
@@ -2685,9 +2685,40 @@ describe("createVoiceSayHandler", () => {
         { text: "stale live summary" },
         {
           voicePlayback: {
-            ownerEpochMs: 100,
+            ownerId: "rust-owner-1",
             generation: 1,
             fallbackPlaybackEnabled: false,
+          },
+        },
+      ),
+    ).resolves.toEqual({ spoken: false });
+    expect(speak).not.toHaveBeenCalled();
+  });
+
+  it("Live cycle 前の enabled request は current generation と一致しないため発話しない", async () => {
+    const speak = vi.fn();
+    const current = {
+      ownerId: "rust-owner-1",
+      generation: 2,
+      fallbackPlaybackEnabled: true,
+    };
+    const handler = createVoiceSayHandler({
+      speak,
+      getFrequency: () => "on",
+      canPlay: (provenance) =>
+        provenance?.ownerId === current.ownerId &&
+        provenance.generation === current.generation &&
+        provenance.fallbackPlaybackEnabled === current.fallbackPlaybackEnabled,
+    });
+
+    await expect(
+      handler(
+        { text: "pre-live summary" },
+        {
+          voicePlayback: {
+            ownerId: "rust-owner-1",
+            generation: 0,
+            fallbackPlaybackEnabled: true,
           },
         },
       ),
@@ -2784,9 +2815,33 @@ describe("createVoicePlayHandler", () => {
         { clipRef: "voice:greeting" },
         {
           voicePlayback: {
-            ownerEpochMs: 100,
+            ownerId: "rust-owner-1",
             generation: 1,
             fallbackPlaybackEnabled: false,
+          },
+        },
+      ),
+    ).resolves.toEqual({ played: false });
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  it("前の WebView owner が作った enabled clip request は再生しない", async () => {
+    const play = vi.fn();
+    const handler = createVoicePlayHandler({
+      play,
+      getFrequency: () => "on",
+      canPlay: (provenance) =>
+        provenance?.ownerId === "current-rust-owner" && provenance.generation === 0,
+    });
+
+    await expect(
+      handler(
+        { clipRef: "voice:greeting" },
+        {
+          voicePlayback: {
+            ownerId: "previous-rust-owner",
+            generation: 0,
+            fallbackPlaybackEnabled: true,
           },
         },
       ),

--- a/src/runtime/yorishiro-mcp/tool-handlers.test.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.test.ts
@@ -2672,6 +2672,29 @@ describe("createVoiceSayHandler", () => {
     expect(speak).not.toHaveBeenCalled();
   });
 
+  it("GPT Live ownership 中に作成された遅延 request は復帰後も発話しない", async () => {
+    const speak = vi.fn();
+    const handler = createVoiceSayHandler({
+      speak,
+      getFrequency: () => "on",
+      canPlay: () => true,
+    });
+
+    await expect(
+      handler(
+        { text: "stale live summary" },
+        {
+          voicePlayback: {
+            ownerEpochMs: 100,
+            generation: 1,
+            fallbackPlaybackEnabled: false,
+          },
+        },
+      ),
+    ).resolves.toEqual({ spoken: false });
+    expect(speak).not.toHaveBeenCalled();
+  });
+
   it("valid mood と intensity を speak へ透過する", async () => {
     const speak = vi.fn();
     const handler = createVoiceSayHandler({ speak, getFrequency: () => "on" });
@@ -2745,6 +2768,29 @@ describe("createVoicePlayHandler", () => {
     });
 
     await expect(handler({ clipRef: "voice:greeting" })).resolves.toEqual({ played: false });
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  it("GPT Live ownership 中に作成された遅延 clip request は復帰後も再生しない", async () => {
+    const play = vi.fn();
+    const handler = createVoicePlayHandler({
+      play,
+      getFrequency: () => "on",
+      canPlay: () => true,
+    });
+
+    await expect(
+      handler(
+        { clipRef: "voice:greeting" },
+        {
+          voicePlayback: {
+            ownerEpochMs: 100,
+            generation: 1,
+            fallbackPlaybackEnabled: false,
+          },
+        },
+      ),
+    ).resolves.toEqual({ played: false });
     expect(play).not.toHaveBeenCalled();
   });
 });

--- a/src/runtime/yorishiro-mcp/tool-handlers.test.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.test.ts
@@ -63,6 +63,7 @@ import {
   createUiActivateHandler,
   createUiSidebarSetHandler,
   createUiTerminalSetHandler,
+  createVoicePlayHandler,
   createVoiceSayHandler,
 } from "./tool-handlers";
 
@@ -2659,6 +2660,18 @@ describe("createSetMotionIntensityHandler", () => {
 });
 
 describe("createVoiceSayHandler", () => {
+  it("audio owner が別にいる間は発話を破棄する", async () => {
+    const speak = vi.fn();
+    const handler = createVoiceSayHandler({
+      speak,
+      getFrequency: () => "on",
+      canPlay: () => false,
+    });
+
+    await expect(handler({ text: "hello" })).resolves.toEqual({ spoken: false });
+    expect(speak).not.toHaveBeenCalled();
+  });
+
   it("valid mood と intensity を speak へ透過する", async () => {
     const speak = vi.fn();
     const handler = createVoiceSayHandler({ speak, getFrequency: () => "on" });
@@ -2721,6 +2734,20 @@ describe("createVoiceSayHandler", () => {
 /* ──────────────────────────────────────────────────────────
  * createUiSidebarSetHandler — loud-unavailable
  * ────────────────────────────────────────────────────────── */
+
+describe("createVoicePlayHandler", () => {
+  it("audio owner が別にいる間は clip 再生を破棄する", async () => {
+    const play = vi.fn();
+    const handler = createVoicePlayHandler({
+      play,
+      getFrequency: () => "on",
+      canPlay: () => false,
+    });
+
+    await expect(handler({ clipRef: "voice:greeting" })).resolves.toEqual({ played: false });
+    expect(play).not.toHaveBeenCalled();
+  });
+});
 
 describe("createUiSidebarSetHandler loud-unavailable", () => {
   // loud-unavailable: presence 解決不能時、ui.sidebar.set は width を書かず

--- a/src/runtime/yorishiro-mcp/tool-handlers.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.ts
@@ -37,6 +37,7 @@ import {
 import type { LoadReport } from "../user-pack-loader/load-report";
 import type { UserPackEntry } from "../user-pack-loader/user-pack-loader";
 import type { UserPackRegistry } from "../user-pack-loader/user-pack-registry";
+import type { ToolInvocationContext } from "./event-channel";
 
 export interface PackStatusEntry {
   readonly id: string;
@@ -1984,8 +1985,14 @@ export interface VoiceSayResult {
  * - "off": 常に破棄（global prompt で voice_say を呼ばないよう指示済み）
  */
 export function createVoiceSayHandler(deps: VoiceSayDeps) {
-  return async (request: unknown): Promise<VoiceSayResult> => {
-    if (deps.getFrequency() === "off" || deps.canPlay?.() === false) return { spoken: false };
+  return async (request: unknown, context?: ToolInvocationContext): Promise<VoiceSayResult> => {
+    if (
+      deps.getFrequency() === "off" ||
+      context?.voicePlayback?.fallbackPlaybackEnabled === false ||
+      deps.canPlay?.() === false
+    ) {
+      return { spoken: false };
+    }
     const r = requestRecord(request);
     const text = r.text;
     if (typeof text !== "string" || text === "") {
@@ -2036,8 +2043,14 @@ export interface VoicePlayResult {
  * pack-local の `./...` `assets/...` は VoicePlayer 側で resolve 失敗扱いとなる。
  */
 export function createVoicePlayHandler(deps: VoicePlayDeps) {
-  return async (request: unknown): Promise<VoicePlayResult> => {
-    if (deps.getFrequency() === "off" || deps.canPlay?.() === false) return { played: false };
+  return async (request: unknown, context?: ToolInvocationContext): Promise<VoicePlayResult> => {
+    if (
+      deps.getFrequency() === "off" ||
+      context?.voicePlayback?.fallbackPlaybackEnabled === false ||
+      deps.canPlay?.() === false
+    ) {
+      return { played: false };
+    }
     const r = requestRecord(request);
     const clipRef = r.clipRef;
     if (typeof clipRef !== "string" || clipRef === "") {

--- a/src/runtime/yorishiro-mcp/tool-handlers.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.ts
@@ -19,6 +19,7 @@ import type * as THREE from "three";
 import type { Body, ExpressionKind } from "../../core/body";
 import { colorLerp } from "../../core/tween/lerp";
 import type { TweenManager } from "../../core/tween/tween-manager";
+import type { VoicePlaybackProvenanceStamp } from "../../core/voice/voice-player";
 import type { AmenityPackRegistry } from "../amenity-pack-registry";
 import type { ManualCueResult } from "../attention-light-cue/cue-store";
 import type { ApplyPresenceResult } from "../presence-intensity/presence-intensity";
@@ -1967,7 +1968,7 @@ export function createPersonaReflexListHandler(deps: PersonaReflexListDeps) {
 export interface VoiceSayDeps {
   readonly speak: (text: string, voice?: string, mood?: VoiceSayMood) => void;
   readonly getFrequency: () => "on" | "off";
-  readonly canPlay?: () => boolean;
+  readonly canPlay?: (provenance: VoicePlaybackProvenanceStamp | undefined) => boolean;
 }
 
 export interface VoiceSayMood {
@@ -1989,7 +1990,7 @@ export function createVoiceSayHandler(deps: VoiceSayDeps) {
     if (
       deps.getFrequency() === "off" ||
       context?.voicePlayback?.fallbackPlaybackEnabled === false ||
-      deps.canPlay?.() === false
+      deps.canPlay?.(context?.voicePlayback) === false
     ) {
       return { spoken: false };
     }
@@ -2029,7 +2030,7 @@ export function createVoiceSayHandler(deps: VoiceSayDeps) {
 export interface VoicePlayDeps {
   readonly play: (clipRef: string, options?: { readonly volume?: number }) => void;
   readonly getFrequency: () => "on" | "off";
-  readonly canPlay?: () => boolean;
+  readonly canPlay?: (provenance: VoicePlaybackProvenanceStamp | undefined) => boolean;
 }
 
 export interface VoicePlayResult {
@@ -2047,7 +2048,7 @@ export function createVoicePlayHandler(deps: VoicePlayDeps) {
     if (
       deps.getFrequency() === "off" ||
       context?.voicePlayback?.fallbackPlaybackEnabled === false ||
-      deps.canPlay?.() === false
+      deps.canPlay?.(context?.voicePlayback) === false
     ) {
       return { played: false };
     }

--- a/src/runtime/yorishiro-mcp/tool-handlers.ts
+++ b/src/runtime/yorishiro-mcp/tool-handlers.ts
@@ -1966,6 +1966,7 @@ export function createPersonaReflexListHandler(deps: PersonaReflexListDeps) {
 export interface VoiceSayDeps {
   readonly speak: (text: string, voice?: string, mood?: VoiceSayMood) => void;
   readonly getFrequency: () => "on" | "off";
+  readonly canPlay?: () => boolean;
 }
 
 export interface VoiceSayMood {
@@ -1984,7 +1985,7 @@ export interface VoiceSayResult {
  */
 export function createVoiceSayHandler(deps: VoiceSayDeps) {
   return async (request: unknown): Promise<VoiceSayResult> => {
-    if (deps.getFrequency() === "off") return { spoken: false };
+    if (deps.getFrequency() === "off" || deps.canPlay?.() === false) return { spoken: false };
     const r = requestRecord(request);
     const text = r.text;
     if (typeof text !== "string" || text === "") {
@@ -2021,6 +2022,7 @@ export function createVoiceSayHandler(deps: VoiceSayDeps) {
 export interface VoicePlayDeps {
   readonly play: (clipRef: string, options?: { readonly volume?: number }) => void;
   readonly getFrequency: () => "on" | "off";
+  readonly canPlay?: () => boolean;
 }
 
 export interface VoicePlayResult {
@@ -2035,7 +2037,7 @@ export interface VoicePlayResult {
  */
 export function createVoicePlayHandler(deps: VoicePlayDeps) {
   return async (request: unknown): Promise<VoicePlayResult> => {
-    if (deps.getFrequency() === "off") return { played: false };
+    if (deps.getFrequency() === "off" || deps.canPlay?.() === false) return { played: false };
     const r = requestRecord(request);
     const clipRef = r.clipRef;
     if (typeof clipRef !== "string" || clipRef === "") {

--- a/src/sdk/context.d.ts
+++ b/src/sdk/context.d.ts
@@ -545,8 +545,19 @@ export interface VoicePlayOptions {
   volume?: number;
 }
 
+/** Host-side reason why a voice operation completed without reaching natural playback completion. */
+export type VoiceCancellationReason = "playback-disabled" | "stopped" | "disposed";
+
 export interface VoiceHandle {
   readonly startedAt: number;
+  /**
+   * Set when the host cancels playback. In that case `completion` resolves immediately even if
+   * synthesis, clip resolution, or fetch cleanup is still finishing in the background.
+   *
+   * A real clip resolution or fetch failure that wins before cancellation still rejects
+   * `completion`; callers can therefore distinguish failure from host cancellation.
+   */
+  readonly cancellationReason?: VoiceCancellationReason;
   stop(fadeMs?: number): Promise<void>;
   readonly completion: Promise<void>;
 }


### PR DESCRIPTION
Closes #78

## Summary

- make Voice Summary playback a fallback while GPT Live is connecting or active
- cancel in-flight synthesis, clip resolution, fetches, and playback immediately when GPT Live takes audio ownership
- stamp MCP voice requests with playback-owner provenance so delayed requests cannot play after GPT Live disconnects
- harden owner registration, generation ordering, lease reconciliation, and bounded fallback restoration retries across WebView lifecycle races
- expose cancellation reasons so host cancellation remains distinguishable from real playback failures
- document the resulting GPT Live and Voice Summary ownership contract

## Why

Voice Summary and GPT Live could otherwise overlap or replay a stale summary after a Live session ended. Asynchronous IPC and delayed voice requests also created races where an older WebView or ownership update could overwrite the active playback lease.

## Design overview

- GPT Live is the sole audio owner while it is connecting or active.
- Voice Summary resumes as the fallback in idle or error states.
- Ownership generations prevent delayed requests from an earlier Live session from playing later.
- Host cancellation and genuine playback failures remain distinguishable.
- Agent State Expression callbacks from #84 and Voice Summary playback ownership are both preserved in the shared Realtime hook.

## Impact

This changes WebView and Rust/MCP playback ownership, Realtime lifecycle handling, cancellation semantics, fallback lip-sync source restoration, and the shared `useCodexRealtime` integration point.

## Validation

- focused Realtime, Voice Summary, and Agent State Expression tests: 91 passed
- `npm run check`
- `npm run test:run -- --reporter=dot` (166 files, 2,096 tests)
- pre-push hook: TypeScript, Biome, Cargo fmt, Clippy, and TypeDoc validation
- `git diff --check`

## Integration note

The branch was updated after #84 merged. The two conflicts in `src/App.tsx` and `use-codex-realtime.ts` were resolved by retaining both the Voice Summary playback lease and the Agent State Expression callback wiring.
