### PR TITLE
Fix Codex realtime voice after /clear

### DIFF
--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -47,8 +47,9 @@ Codex session の起動は次の 3 要素に分ける。
 1. Rust が random loopback port で `codex app-server --listen ws://127.0.0.1:<port>` を起動
 2. PTY 内の Codex TUI を `codex --remote <endpoint>` で同じ server へ接続
 3. Rust の realtime bridge が Origin header なしで同じ server へ接続
-4. WebView の `CodexRealtimeClient` は Tauri Channel 経由で `thread/loaded/list` を送り、
-   複数件なら `thread/read` の `parentThreadId` で subagent を除外した唯一の top-level thread を選ぶ
+4. WebView の thread tracker は voice が停止中も `thread/started` を監視して TUI の current thread ID を保持する。
+   `CodexRealtimeClient` は Tauri Channel 経由の `thread/loaded/list` と `thread/read` で、その ID が
+   loaded な top-level thread であることを再検証する
 5. 選んだ thread で `thread/realtime/start` の realtime v3 + WebRTC transport を開始
 
 app-server process は `PtySession` が所有する。spawn 途中の失敗、session kill、Drop の
@@ -119,7 +120,9 @@ Codex 0.146.0 で次を実測した。
 ### thread targeting
 
 `thread/loaded/list` は active TUI thread を返す API ではない。loaded ID を文字列 sort した一覧であり、
-`data[0]` は active thread を意味しない。先頭採用は禁止する。
+`data[0]` は active thread を意味しない。さらに TUI が `/clear` や thread 切替で unsubscribe しても、
+app-server は無購読・無活動の thread を grace period 中 loaded のまま保持する。先頭採用と「top-level が
+複数なら即エラー」のどちらも current thread の判定には使えない。
 
 Main Agent が agent team を動かすと同じ app-server に複数 thread が loaded になるが、これは異常では
 ない。対象は次の手順で決める。
@@ -127,13 +130,15 @@ Main Agent が agent team を動かすと同じ app-server に複数 thread が 
 1. `thread/loaded/list` を取得する
 2. 各 ID を `thread/read({ includeTurns: false })` で読む
 3. `parentThreadId === null` の top-level thread だけを候補にする
-4. top-level が一つなら、その ID で realtime を開始する
-5. subagent の終了と read が競合した場合は、最新の loaded snapshot からやり直す
-6. top-level が複数なら推測せず fail closed する
+4. tracker が保持する latest top-level `thread/started` ID と照合する
+5. 一致する loaded top-level があれば、その ID で realtime を開始する
+6. tracker の初期 discovery 時だけ、top-level が一つならその ID を初期値にする
+7. subagent の終了と read が競合した場合は、最新の loaded snapshot からやり直す
+8. tracker に明示 ID がなく top-level が複数なら推測せず fail closed する
 
 Codex v2 Thread schema は `parentThreadId` を subagent の場合だけ設定する。recency、配列順、statusから
-active threadを推測してはならない。upstreamがactive threadの明示query / notificationを提供した場合は、
-この選択を明示IDへ置き換える。
+active threadを推測してはならない。`thread/started` は全 initialized connection へ broadcast されるため、
+session 中継続する tracker が `/clear` と `/resume` の切替を明示 ID として記録する。
 
 ### approval ownership
 

--- a/src/runtime/codex-realtime/codex-realtime-client.test.ts
+++ b/src/runtime/codex-realtime/codex-realtime-client.test.ts
@@ -553,6 +553,21 @@ describe("CodexRealtimeClient", () => {
     expect(client.getStatus()).toBe("error");
   });
 
+  it("uses the tracker-selected top-level thread while a cleared thread remains loaded", async () => {
+    bridge.loadedThreadResponses = [["cleared-thread", "current-thread"]];
+    bridge.loadedThreadParents = { "cleared-thread": null, "current-thread": null };
+    const client = new CodexRealtimeClient("main-session", undefined, {
+      getPreferredThreadId: () => "current-thread",
+    });
+
+    await client.start();
+
+    expect(
+      bridge.sent.find((message) => message.method === "thread/realtime/start")?.params,
+    ).toMatchObject({ threadId: "current-thread" });
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
   it("fails closed when thread/read omits the subagent relationship", async () => {
     bridge.loadedThreadResponses = [["thread-1", "thread-2"]];
     bridge.loadedThreadParents = { "thread-1": null, "thread-2": undefined };

--- a/src/runtime/codex-realtime/codex-realtime-client.ts
+++ b/src/runtime/codex-realtime/codex-realtime-client.ts
@@ -27,6 +27,7 @@ export interface CodexRealtimeState {
 export interface CodexRealtimeClientOptions {
   readonly stateExpressionCallbacks?: StateExpressionSchedulerCallbacks;
   readonly stateExpressionController?: RealtimeStateExpressionControllerOptions;
+  readonly getPreferredThreadId?: () => string | null;
 }
 
 interface JsonRpcMessage {
@@ -90,6 +91,7 @@ export class CodexRealtimeClient implements LipSyncSource {
   private stopping = false;
   private startAttemptEpoch = 0;
   private readonly stateExpressionController: RealtimeStateExpressionController | null;
+  private readonly getPreferredThreadId: () => string | null;
 
   constructor(
     sessionId: string,
@@ -98,6 +100,7 @@ export class CodexRealtimeClient implements LipSyncSource {
   ) {
     this.sessionId = sessionId;
     this.onStateChange = onStateChange;
+    this.getPreferredThreadId = options.getPreferredThreadId ?? (() => null);
     this.stateExpressionController = options.stateExpressionCallbacks
       ? new RealtimeStateExpressionController(
           options.stateExpressionCallbacks,
@@ -271,12 +274,16 @@ export class CodexRealtimeClient implements LipSyncSource {
     }
 
     const uniquePrimaryThreadIds = [...new Set(primaryThreadIds)];
-    if (uniquePrimaryThreadIds.length > 1) {
+    const preferredThreadId = this.getPreferredThreadId();
+    const candidate =
+      preferredThreadId && uniquePrimaryThreadIds.includes(preferredThreadId)
+        ? preferredThreadId
+        : uniquePrimaryThreadIds[0];
+    if (uniquePrimaryThreadIds.length > 1 && candidate !== preferredThreadId) {
       throw new Error(
         "Multiple top-level Codex threads are loaded; voice connection was not started.",
       );
     }
-    const candidate = uniquePrimaryThreadIds[0];
     if (!candidate) return null;
 
     let revalidated: unknown;

--- a/src/runtime/codex-realtime/codex-thread-tracker.test.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.test.ts
@@ -21,6 +21,10 @@ const bridge = vi.hoisted(() => ({
   pendingReads: false,
   readResponders: [] as Array<() => void>,
   disconnect: vi.fn(async () => {}),
+  connect: vi.fn(async ({ onMessage }: { onMessage: FakeChannel<string> }): Promise<string> => {
+    bridge.channel = onMessage;
+    return `tracker-connection-${bridge.connect.mock.calls.length}`;
+  }),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -30,12 +34,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 vi.mock("../../bindings/tauri-commands", () => ({
-  sessionRealtimeConnect: vi.fn(
-    async ({ onMessage }: { onMessage: FakeChannel<string> }): Promise<string> => {
-      bridge.channel = onMessage;
-      return "tracker-connection";
-    },
-  ),
+  sessionRealtimeConnect: bridge.connect,
   sessionRealtimeDisconnect: bridge.disconnect,
   sessionRealtimeSend: vi.fn(async ({ message }: { message: string }): Promise<void> => {
     const request = JSON.parse(message) as SentMessage;
@@ -72,6 +71,7 @@ describe("CodexThreadTracker", () => {
     bridge.pendingReads = false;
     bridge.readResponders = [];
     bridge.disconnect.mockClear();
+    bridge.connect.mockClear();
   });
 
   it("uses the sole top-level thread as its startup value", async () => {
@@ -132,5 +132,27 @@ describe("CodexThreadTracker", () => {
 
     expect(tracker.getCurrentThreadId()).toBe("thread-after-clear");
     tracker.stop();
+  });
+
+  it("reconnects after an unexpected bridge closure", async () => {
+    vi.useFakeTimers();
+    const tracker = new CodexThreadTracker("main-session");
+    await tracker.start();
+    expect(tracker.getCurrentThreadId()).toBe("thread-1");
+    expect(bridge.connect).toHaveBeenCalledTimes(1);
+
+    bridge.loadedThreads = ["thread-1", "thread-after-clear"];
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "yorishiro/realtime-bridge/closed",
+        params: { message: "closed" },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(bridge.connect).toHaveBeenCalledTimes(2);
+    expect(tracker.getCurrentThreadId()).toBeNull();
+    tracker.stop();
+    vi.useRealTimers();
   });
 });

--- a/src/runtime/codex-realtime/codex-thread-tracker.test.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CodexThreadTracker } from "./codex-thread-tracker";
+
+interface FakeChannel<T> {
+  onmessage: (message: T) => void;
+}
+
+interface SentMessage {
+  readonly id?: number;
+  readonly method?: string;
+  readonly params?: Record<string, unknown>;
+}
+
+const bridge = vi.hoisted(() => ({
+  channel: null as FakeChannel<string> | null,
+  sent: [] as SentMessage[],
+  loadedThreads: ["thread-1"] as string[],
+  parents: {} as Record<string, string | null>,
+  pendingReads: false,
+  readResponders: [] as Array<() => void>,
+  disconnect: vi.fn(async () => {}),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: class<T> {
+    onmessage: (message: T) => void = () => {};
+  },
+}));
+
+vi.mock("../../bindings/tauri-commands", () => ({
+  sessionRealtimeConnect: vi.fn(
+    async ({ onMessage }: { onMessage: FakeChannel<string> }): Promise<string> => {
+      bridge.channel = onMessage;
+      return "tracker-connection";
+    },
+  ),
+  sessionRealtimeDisconnect: bridge.disconnect,
+  sessionRealtimeSend: vi.fn(async ({ message }: { message: string }): Promise<void> => {
+    const request = JSON.parse(message) as SentMessage;
+    bridge.sent.push(request);
+    if (request.id === undefined) return;
+    const respond = (result: unknown) =>
+      queueMicrotask(() => bridge.channel?.onmessage(JSON.stringify({ id: request.id, result })));
+    if (request.method === "initialize") {
+      respond({});
+    } else if (request.method === "thread/loaded/list") {
+      respond({ data: bridge.loadedThreads });
+    } else if (request.method === "thread/read") {
+      const threadId = request.params?.threadId;
+      const sendRead = () =>
+        respond({
+          thread: {
+            id: threadId,
+            parentThreadId:
+              typeof threadId === "string" ? (bridge.parents[threadId] ?? null) : null,
+          },
+        });
+      if (bridge.pendingReads) bridge.readResponders.push(sendRead);
+      else sendRead();
+    }
+  }),
+}));
+
+describe("CodexThreadTracker", () => {
+  beforeEach(() => {
+    bridge.channel = null;
+    bridge.sent = [];
+    bridge.loadedThreads = ["thread-1"];
+    bridge.parents = {};
+    bridge.pendingReads = false;
+    bridge.readResponders = [];
+    bridge.disconnect.mockClear();
+  });
+
+  it("uses the sole top-level thread as its startup value", async () => {
+    const tracker = new CodexThreadTracker("main-session");
+
+    await tracker.start();
+
+    expect(tracker.getCurrentThreadId()).toBe("thread-1");
+    tracker.stop();
+  });
+
+  it("tracks the top-level thread started by /clear while ignoring subagents", async () => {
+    const tracker = new CodexThreadTracker("main-session");
+    await tracker.start();
+
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/started",
+        params: { thread: { id: "subagent", parentThreadId: "thread-1" } },
+      }),
+    );
+    expect(tracker.getCurrentThreadId()).toBe("thread-1");
+
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/started",
+        params: { thread: { id: "thread-after-clear", parentThreadId: null } },
+      }),
+    );
+    expect(tracker.getCurrentThreadId()).toBe("thread-after-clear");
+    tracker.stop();
+  });
+
+  it("does not guess from multiple top-level threads when it missed their start events", async () => {
+    bridge.loadedThreads = ["thread-1", "thread-2"];
+    const tracker = new CodexThreadTracker("main-session");
+
+    await tracker.start();
+
+    expect(tracker.getCurrentThreadId()).toBeNull();
+    tracker.stop();
+  });
+
+  it("does not overwrite a broadcast thread with an older discovery snapshot", async () => {
+    bridge.pendingReads = true;
+    const tracker = new CodexThreadTracker("main-session");
+    const started = tracker.start();
+    await vi.waitFor(() => expect(bridge.readResponders).toHaveLength(1));
+
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/started",
+        params: { thread: { id: "thread-after-clear", parentThreadId: null } },
+      }),
+    );
+    bridge.readResponders.shift()?.();
+    await started;
+
+    expect(tracker.getCurrentThreadId()).toBe("thread-after-clear");
+    tracker.stop();
+  });
+});

--- a/src/runtime/codex-realtime/codex-thread-tracker.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.ts
@@ -1,0 +1,192 @@
+import { Channel } from "@tauri-apps/api/core";
+import {
+  sessionRealtimeConnect,
+  sessionRealtimeDisconnect,
+  sessionRealtimeSend,
+} from "../../bindings/tauri-commands";
+
+interface PendingRequest {
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (reason: Error) => void;
+}
+
+interface JsonRpcMessage {
+  readonly id?: unknown;
+  readonly method?: unknown;
+  readonly params?: unknown;
+  readonly result?: unknown;
+  readonly error?: unknown;
+}
+
+/**
+ * TUI の thread/started broadcast を voice が停止中も監視する。
+ *
+ * thread/loaded/list は unsubscribe 済み thread も grace period 中は返すため、
+ * /clear や /resume 後の current TUI thread を一覧だけから特定することはできない。
+ */
+export class CodexThreadTracker {
+  private readonly sessionId: string;
+  private connectionId: string | null = null;
+  private nextRequestId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private currentThreadId: string | null = null;
+  private epoch = 0;
+  private topLevelStartedGeneration = 0;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
+
+  getCurrentThreadId(): string | null {
+    return this.currentThreadId;
+  }
+
+  async start(): Promise<void> {
+    if (this.connectionId) return;
+    const epoch = ++this.epoch;
+    try {
+      const onMessage = new Channel<string>();
+      onMessage.onmessage = (message) => this.handleMessage(message, epoch);
+      const connectionId = await sessionRealtimeConnect({ sessionId: this.sessionId, onMessage });
+      if (epoch !== this.epoch) {
+        void sessionRealtimeDisconnect({ connectionId }).catch(() => {});
+        return;
+      }
+      this.connectionId = connectionId;
+
+      await this.request("initialize", {
+        clientInfo: {
+          name: "yorishiro-thread-tracker",
+          title: "Yorishiro Thread Tracker",
+          version: "0.6.1",
+        },
+        capabilities: { experimentalApi: true },
+      });
+      if (epoch !== this.epoch) return;
+      this.notify("initialized", {});
+      await this.discoverInitialThread(epoch);
+    } catch (error) {
+      if (epoch === this.epoch) this.stop();
+      throw error;
+    }
+  }
+
+  stop(): void {
+    this.epoch += 1;
+    const connectionId = this.connectionId;
+    this.connectionId = null;
+    this.currentThreadId = null;
+    const error = new Error("Codex thread tracker stopped");
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+    if (connectionId) void sessionRealtimeDisconnect({ connectionId }).catch(() => {});
+  }
+
+  private async discoverInitialThread(epoch: number): Promise<void> {
+    const generation = this.topLevelStartedGeneration;
+    const result = (await this.request("thread/loaded/list", {})) as {
+      readonly data?: ReadonlyArray<unknown>;
+    };
+    if (epoch !== this.epoch || generation !== this.topLevelStartedGeneration) return;
+    const ids = result.data;
+    if (!Array.isArray(ids)) return;
+
+    const topLevelIds: string[] = [];
+    for (const id of ids) {
+      if (typeof id !== "string" || id.length === 0) return;
+      let read: unknown;
+      try {
+        read = await this.request("thread/read", { threadId: id, includeTurns: false });
+      } catch {
+        return;
+      }
+      if (epoch !== this.epoch || generation !== this.topLevelStartedGeneration) return;
+      const thread = (read as { readonly thread?: unknown }).thread;
+      if (!isRecord(thread) || thread.id !== id || !("parentThreadId" in thread)) return;
+      if (thread.parentThreadId === null) topLevelIds.push(id);
+    }
+
+    // Startup 時に一意なら初期値にできる。複数時は過去の broadcast がないため推測しない。
+    const unique = [...new Set(topLevelIds)];
+    if (unique.length === 1 && generation === this.topLevelStartedGeneration) {
+      this.currentThreadId = unique[0] ?? null;
+    }
+  }
+
+  private request(method: string, params: Record<string, unknown>): Promise<unknown> {
+    const connectionId = this.connectionId;
+    if (!connectionId) return Promise.reject(new Error("Codex thread tracker is not connected"));
+    const id = this.nextRequestId++;
+    const promise = new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+    void sessionRealtimeSend({
+      connectionId,
+      message: JSON.stringify({ method, id, params }),
+    }).catch((error) => {
+      const pending = this.pending.get(id);
+      if (!pending) return;
+      this.pending.delete(id);
+      pending.reject(error instanceof Error ? error : new Error(String(error)));
+    });
+    return promise;
+  }
+
+  private notify(method: string, params: Record<string, unknown>): void {
+    if (!this.connectionId) return;
+    void sessionRealtimeSend({
+      connectionId: this.connectionId,
+      message: JSON.stringify({ method, params }),
+    }).catch(() => {});
+  }
+
+  private handleMessage(raw: string, epoch: number): void {
+    if (epoch !== this.epoch) return;
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(raw) as JsonRpcMessage;
+    } catch {
+      return;
+    }
+
+    if (typeof message.id === "number" && ("result" in message || "error" in message)) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      if ("error" in message) pending.reject(new Error(jsonRpcErrorMessage(message.error)));
+      else pending.resolve(message.result);
+      return;
+    }
+
+    if (message.method === "thread/started") {
+      const params = message.params;
+      const thread = isRecord(params) ? params.thread : undefined;
+      if (
+        isRecord(thread) &&
+        typeof thread.id === "string" &&
+        thread.id.length > 0 &&
+        thread.parentThreadId === null
+      ) {
+        this.topLevelStartedGeneration += 1;
+        this.currentThreadId = thread.id;
+      }
+      return;
+    }
+
+    if (message.method === "thread/closed" || message.method === "thread/deleted") {
+      const params = message.params;
+      if (isRecord(params) && params.threadId === this.currentThreadId) {
+        this.currentThreadId = null;
+      }
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function jsonRpcErrorMessage(value: unknown): string {
+  if (isRecord(value) && typeof value.message === "string") return value.message;
+  return "Codex app-server request failed";
+}

--- a/src/runtime/codex-realtime/codex-thread-tracker.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.ts
@@ -8,6 +8,7 @@ import {
 interface PendingRequest {
   readonly resolve: (value: unknown) => void;
   readonly reject: (reason: Error) => void;
+  readonly timeoutId: number;
 }
 
 interface JsonRpcMessage {
@@ -17,6 +18,11 @@ interface JsonRpcMessage {
   readonly result?: unknown;
   readonly error?: unknown;
 }
+
+const RPC_TIMEOUT_MS = 15_000;
+const RECONNECT_DELAY_MS = 250;
+
+class TrackerRequestTimeoutError extends Error {}
 
 /**
  * TUI の thread/started broadcast を voice が停止中も監視する。
@@ -32,6 +38,9 @@ export class CodexThreadTracker {
   private currentThreadId: string | null = null;
   private epoch = 0;
   private topLevelStartedGeneration = 0;
+  private running = false;
+  private connecting = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(sessionId: string) {
     this.sessionId = sessionId;
@@ -42,13 +51,40 @@ export class CodexThreadTracker {
   }
 
   async start(): Promise<void> {
-    if (this.connectionId) return;
+    if (this.running) return;
+    this.running = true;
     const epoch = ++this.epoch;
+    try {
+      await this.connect(epoch);
+    } catch (error) {
+      if (epoch === this.epoch && this.running) this.scheduleReconnect(epoch);
+      throw error;
+    }
+  }
+
+  stop(): void {
+    this.epoch += 1;
+    this.running = false;
+    this.connecting = false;
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    const connectionId = this.connectionId;
+    this.connectionId = null;
+    this.currentThreadId = null;
+    this.rejectPending(new Error("Codex thread tracker stopped"));
+    if (connectionId) void sessionRealtimeDisconnect({ connectionId }).catch(() => {});
+  }
+
+  private async connect(epoch: number): Promise<void> {
+    if (!this.running || this.connecting || this.connectionId) return;
+    this.connecting = true;
     try {
       const onMessage = new Channel<string>();
       onMessage.onmessage = (message) => this.handleMessage(message, epoch);
       const connectionId = await sessionRealtimeConnect({ sessionId: this.sessionId, onMessage });
-      if (epoch !== this.epoch) {
+      if (epoch !== this.epoch || !this.running) {
         void sessionRealtimeDisconnect({ connectionId }).catch(() => {});
         return;
       }
@@ -62,24 +98,34 @@ export class CodexThreadTracker {
         },
         capabilities: { experimentalApi: true },
       });
-      if (epoch !== this.epoch) return;
+      if (epoch !== this.epoch || !this.running) return;
       this.notify("initialized", {});
       await this.discoverInitialThread(epoch);
     } catch (error) {
-      if (epoch === this.epoch) this.stop();
+      const connectionId = this.connectionId;
+      this.connectionId = null;
+      this.rejectPending(error instanceof Error ? error : new Error(String(error)));
+      if (connectionId) void sessionRealtimeDisconnect({ connectionId }).catch(() => {});
       throw error;
+    } finally {
+      this.connecting = false;
     }
   }
 
-  stop(): void {
-    this.epoch += 1;
-    const connectionId = this.connectionId;
-    this.connectionId = null;
-    this.currentThreadId = null;
-    const error = new Error("Codex thread tracker stopped");
-    for (const pending of this.pending.values()) pending.reject(error);
+  private scheduleReconnect(epoch: number): void {
+    if (!this.running || epoch !== this.epoch || this.reconnectTimer !== null) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect(epoch).catch(() => this.scheduleReconnect(epoch));
+    }, RECONNECT_DELAY_MS);
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeoutId);
+      pending.reject(error);
+    }
     this.pending.clear();
-    if (connectionId) void sessionRealtimeDisconnect({ connectionId }).catch(() => {});
   }
 
   private async discoverInitialThread(epoch: number): Promise<void> {
@@ -97,7 +143,8 @@ export class CodexThreadTracker {
       let read: unknown;
       try {
         read = await this.request("thread/read", { threadId: id, includeTurns: false });
-      } catch {
+      } catch (error) {
+        if (error instanceof TrackerRequestTimeoutError) throw error;
         return;
       }
       if (epoch !== this.epoch || generation !== this.topLevelStartedGeneration) return;
@@ -118,7 +165,11 @@ export class CodexThreadTracker {
     if (!connectionId) return Promise.reject(new Error("Codex thread tracker is not connected"));
     const id = this.nextRequestId++;
     const promise = new Promise<unknown>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
+      const timeoutId = window.setTimeout(() => {
+        if (!this.pending.delete(id)) return;
+        reject(new TrackerRequestTimeoutError(`Codex thread tracker request timed out: ${method}`));
+      }, RPC_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timeoutId });
     });
     void sessionRealtimeSend({
       connectionId,
@@ -127,6 +178,7 @@ export class CodexThreadTracker {
       const pending = this.pending.get(id);
       if (!pending) return;
       this.pending.delete(id);
+      clearTimeout(pending.timeoutId);
       pending.reject(error instanceof Error ? error : new Error(String(error)));
     });
     return promise;
@@ -149,10 +201,21 @@ export class CodexThreadTracker {
       return;
     }
 
+    if (message.method === "yorishiro/realtime-bridge/closed") {
+      this.connectionId = null;
+      // この接続が見ていない間に /clear された可能性がある。grace period 中の
+      // 旧 thread を preferred として再利用せず、再接続後に一意なら再発見する。
+      this.currentThreadId = null;
+      this.rejectPending(new Error("Codex thread tracker connection closed"));
+      this.scheduleReconnect(epoch);
+      return;
+    }
+
     if (typeof message.id === "number" && ("result" in message || "error" in message)) {
       const pending = this.pending.get(message.id);
       if (!pending) return;
       this.pending.delete(message.id);
+      clearTimeout(pending.timeoutId);
       if ("error" in message) pending.reject(new Error(jsonRpcErrorMessage(message.error)));
       else pending.resolve(message.result);
       return;

--- a/src/runtime/codex-realtime/use-codex-realtime.test.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.test.ts
@@ -77,6 +77,11 @@ function setup(
         applyLipSyncSource,
         setFallbackPlaybackEnabled,
         createClient,
+        createThreadTracker: () => ({
+          getCurrentThreadId: () => null,
+          start: async () => {},
+          stop: () => {},
+        }),
       }),
     { initialProps: { sessionId: "main", available: true } },
   );

--- a/src/runtime/codex-realtime/use-codex-realtime.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.ts
@@ -6,6 +6,7 @@ import {
   type CodexRealtimeState,
   type CodexRealtimeStatus,
 } from "./codex-realtime-client";
+import { CodexThreadTracker } from "./codex-thread-tracker";
 
 export interface CodexRealtimeClientLike extends LipSyncSource {
   getStatus(): CodexRealtimeStatus;
@@ -17,7 +18,14 @@ export type CodexRealtimeClientFactory = (
   sessionId: string,
   onStateChange: (state: CodexRealtimeState) => void,
   stateExpressionCallbacks?: StateExpressionSchedulerCallbacks,
+  getPreferredThreadId?: () => string | null,
 ) => CodexRealtimeClientLike;
+
+export interface CodexThreadTrackerLike {
+  getCurrentThreadId(): string | null;
+  start(): Promise<void>;
+  stop(): void;
+}
 
 interface UseCodexRealtimeOptions {
   readonly sessionId: string;
@@ -27,6 +35,7 @@ interface UseCodexRealtimeOptions {
   readonly setFallbackPlaybackEnabled?: (enabled: boolean) => void | Promise<void>;
   readonly stateExpressionCallbacks?: StateExpressionSchedulerCallbacks;
   readonly createClient?: CodexRealtimeClientFactory;
+  readonly createThreadTracker?: (sessionId: string) => CodexThreadTrackerLike;
 }
 
 interface UseCodexRealtimeResult {
@@ -40,7 +49,15 @@ const defaultCreateClient: CodexRealtimeClientFactory = (
   sessionId,
   onStateChange,
   stateExpressionCallbacks,
-) => new CodexRealtimeClient(sessionId, onStateChange, { stateExpressionCallbacks });
+  getPreferredThreadId,
+) =>
+  new CodexRealtimeClient(sessionId, onStateChange, {
+    stateExpressionCallbacks,
+    getPreferredThreadId,
+  });
+
+const defaultCreateThreadTracker = (sessionId: string): CodexThreadTrackerLike =>
+  new CodexThreadTracker(sessionId);
 
 const FALLBACK_RESTORE_RETRY_DELAYS_MS = [50, 200] as const;
 
@@ -53,8 +70,10 @@ export function useCodexRealtime({
   setFallbackPlaybackEnabled = () => {},
   stateExpressionCallbacks,
   createClient = defaultCreateClient,
+  createThreadTracker = defaultCreateThreadTracker,
 }: UseCodexRealtimeOptions): UseCodexRealtimeResult {
   const clientRef = useRef<CodexRealtimeClientLike | null>(null);
+  const threadTrackerRef = useRef<CodexThreadTrackerLike | null>(null);
   const fallbackRef = useRef(fallbackLipSyncSource);
   const applyLipSyncSourceRef = useRef(applyLipSyncSource);
   const setFallbackPlaybackEnabledRef = useRef(setFallbackPlaybackEnabled);
@@ -162,6 +181,7 @@ export function useCodexRealtime({
         }
       },
       stateExpressionCallbacks,
+      () => threadTrackerRef.current?.getCurrentThreadId() ?? null,
     );
     clientRef.current = client;
 
@@ -196,6 +216,22 @@ export function useCodexRealtime({
     sessionIdRef.current = sessionId;
     if (!available || sessionChanged) stop();
   }, [available, sessionId, stop]);
+
+  useEffect(() => {
+    threadTrackerRef.current?.stop();
+    threadTrackerRef.current = null;
+    if (!available) return;
+    const tracker = createThreadTracker(sessionId);
+    threadTrackerRef.current = tracker;
+    void tracker.start().catch((error) => {
+      if (threadTrackerRef.current !== tracker) return;
+      console.warn("[codex-realtime] thread tracker unavailable", error);
+    });
+    return () => {
+      if (threadTrackerRef.current === tracker) threadTrackerRef.current = null;
+      tracker.stop();
+    };
+  }, [available, createThreadTracker, sessionId]);
 
   useEffect(() => {
     // Re-stamp the default owner after a WebView reload because the Rust MCP process can survive it.


### PR DESCRIPTION
## Summary
- keep a lightweight Codex thread tracker connected while voice is idle
- prefer the top-level thread announced after `/clear` instead of rejecting multiple grace-period threads
- validate the preferred thread before starting realtime voice
- recover the tracker after bridge closure and bound JSON-RPC waits with timeouts
- document the tracking lifecycle and failure behavior

## Root cause
Codex app-server keeps unsubscribed threads loaded for a grace period. After `/clear`, `thread/loaded/list` therefore contains both the old and new top-level threads, so the previous uniqueness check refused to start voice.

## Verification
- `npm run test:run` (167 files, 2102 tests)
- `npm run check`
- focused realtime tests (3 files, 41 tests)
- independent review agent: no remaining findings in the `/clear` scope

## Scope
This fixes `/clear` without deleting conversation history. Full automatic retargeting for `/resume` is intentionally not included because app-server does not broadcast the TUI-owned resumed thread.