### PR TITLE
Expose GPT Live entry point for non-Codex agents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,9 +25,11 @@ import * as ReactDomClient from "react-dom/client";
 import * as THREE from "three";
 import {
   checkTutorialDone,
+  listSupportedAgents,
   markTutorialDone,
   prepareLocalizedPluginDir,
   ptyWrite,
+  resolveCommandPath,
   type SpawnSpec,
   sessionDestroy,
   sessionList,
@@ -91,6 +93,7 @@ import {
 } from "./components/session-tab-metadata-badges";
 import TabIndicator, { type TabIndicatorBadge } from "./components/TabIndicator";
 import TerminalWorkspace from "./components/TerminalWorkspace";
+import { VoiceEntryDialog, type VoiceEntryDialogMode } from "./components/VoiceEntryDialog";
 import type { Body, EyeState, LipSyncSource, SpeechStateExpressionHandle } from "./core/body";
 import { shouldTriggerStartleForToolFailure } from "./core/body/tool-failure-reflex";
 import { createSubsystemLog, DevLog, type DevLogEntry } from "./core/dev-log";
@@ -137,6 +140,12 @@ import { registerBundledMusicShelf } from "./runtime/bundled-music-shelf";
 import { registerBundledPomodoro } from "./runtime/bundled-pomodoro";
 import { registerBundledPomodoroUi } from "./runtime/bundled-pomodoro-ui";
 import { useCodexRealtime } from "./runtime/codex-realtime/use-codex-realtime";
+import {
+  consumePendingRealtimeStart,
+  isVoiceEntryAvailable,
+  markPendingRealtimeStart,
+  resolveVoiceEntryAction,
+} from "./runtime/codex-realtime/voice-entry";
 import { EventBus, type EventBusLogger } from "./runtime/event-bus";
 import { collectHealthReport } from "./runtime/health-check";
 import { buildRestoreRows } from "./runtime/history/describe-snapshot";
@@ -2416,7 +2425,23 @@ function App() {
   const { phase: reloadCurtainPhase, beginCurtainReload } = useReloadCurtain(
     isUserLayerReady && vrmReadyOnce,
   );
+  const switchMainAgent = useCallback(
+    async (agent: string, afterPersist?: () => void): Promise<void> => {
+      await beginCurtainReload(async () => {
+        await updateConfig({ terminalAgent: agent });
+        markMainSessionRespawnPending();
+        afterPersist?.();
+      });
+    },
+    [beginCurtainReload, updateConfig],
+  );
   const [terminalAgent, setTerminalAgent] = useState<TerminalAgent>("claude");
+  const [voiceEntryDialog, setVoiceEntryDialog] = useState<{
+    readonly mode: VoiceEntryDialogMode;
+    readonly targetAgentId: string | null;
+  } | null>(null);
+  const [pendingRealtimeStart] = useState(() => consumePendingRealtimeStart());
+  const pendingRealtimeStartRef = useRef(pendingRealtimeStart);
   const [defaultSpec, setDefaultSpec] = useState<SpawnSpec | null>(null);
   const [mainSessionResumeEnabled, setMainSessionResumeEnabled] = useState(true);
   // undefined = まだ未解決、null = 空（非注入）、string = 注入する内容。
@@ -3354,10 +3379,7 @@ function App() {
             await setActiveSceneFromUserSelection(id);
           },
           setTerminalAgent: async (agent) => {
-            await beginCurtainReload(async () => {
-              await updateConfig({ terminalAgent: agent });
-              markMainSessionRespawnPending();
-            });
+            await switchMainAgent(agent);
           },
           setAmbientAudioMuted: async (muted) => {
             await updateConfig({ ambientAudioMuted: muted });
@@ -3607,6 +3629,7 @@ function App() {
     updateYorishiroConfig,
     updateConfig,
     beginCurtainReload,
+    switchMainAgent,
     setActiveSceneFromUserSelection,
   ]);
 
@@ -3617,6 +3640,10 @@ function App() {
   const bodyRef = useRef<Body | null>(null);
   const codexVoiceAvailable =
     terminalAgent === "codex" && tabState.activeSessionId === tabState.mainSessionId;
+  const voiceEntryAvailable = isVoiceEntryAvailable(
+    tabState.activeSessionId,
+    tabState.mainSessionId,
+  );
   const greetedRef = useRef(false);
   const inTurnRef = useRef(false);
   const applyRealtimeLipSyncSource = useCallback((source: LipSyncSource) => {
@@ -3638,6 +3665,39 @@ function App() {
     setFallbackPlaybackEnabled: (enabled) => voicePlaybackLeaseSync.setEnabled(enabled),
     stateExpressionCallbacks: realtimeStateExpressionCallbacks,
   });
+
+  useEffect(() => {
+    if (
+      !pendingRealtimeStartRef.current ||
+      !codexVoiceAvailable ||
+      codexRealtimeState.status !== "idle"
+    ) {
+      return;
+    }
+    pendingRealtimeStartRef.current = false;
+    void toggleCodexRealtime();
+  }, [codexRealtimeState.status, codexVoiceAvailable, toggleCodexRealtime]);
+
+  const handleToggleVoice = useCallback(async () => {
+    if (codexVoiceAvailable) {
+      await toggleCodexRealtime();
+      return;
+    }
+
+    const action = await resolveVoiceEntryAction({
+      activeAgent: terminalAgent,
+      agents: await listSupportedAgents().catch(() => []),
+      resolveCommandPath: (command) => resolveCommandPath({ command }),
+    });
+    if (action.kind === "start") {
+      await toggleCodexRealtime();
+      return;
+    }
+    setVoiceEntryDialog({
+      mode: action.kind === "confirm-switch" ? "switch" : "setup",
+      targetAgentId: action.agent?.id ?? null,
+    });
+  }, [codexVoiceAvailable, terminalAgent, toggleCodexRealtime]);
 
   const handleBodyReady = useCallback(
     (body: Body | null) => {
@@ -3925,6 +3985,24 @@ function App() {
     uiState.set(SETTINGS_PACK_ID, PREVIOUS_ACTIVE_UI_KEY, current);
     uiPackRegistry.setActiveUi(SETTINGS_PACK_ID);
   }, []);
+
+  const handleVoiceEntryCancel = useCallback(() => {
+    setVoiceEntryDialog(null);
+  }, []);
+
+  const handleVoiceEntryConfirmSwitch = useCallback(() => {
+    if (voiceEntryDialog?.mode !== "switch" || voiceEntryDialog.targetAgentId === null) return;
+    const targetAgentId = voiceEntryDialog.targetAgentId;
+    setVoiceEntryDialog(null);
+    void switchMainAgent(targetAgentId, markPendingRealtimeStart);
+  }, [switchMainAgent, voiceEntryDialog]);
+
+  const handleVoiceEntryOpenSettings = useCallback(() => {
+    setVoiceEntryDialog(null);
+    if (getUiRegistry().getActiveUi()?.id !== SETTINGS_PACK_ID) {
+      handleOpenSettings();
+    }
+  }, [handleOpenSettings]);
 
   const [vrmUrl, setVrmUrl] = useState<string | null>(null);
 
@@ -4399,7 +4477,7 @@ function App() {
         settingsLabel={strings.settings}
         onToggleSidebar={handleToggleSidebar}
         onOpenSettings={handleOpenSettings}
-        voiceAvailable={codexVoiceAvailable}
+        voiceAvailable={voiceEntryAvailable}
         voiceActive={codexRealtimeState.status === "active"}
         voiceBusy={codexRealtimeState.status === "connecting"}
         voiceLabel={
@@ -4418,7 +4496,7 @@ function App() {
             : undefined
         }
         voiceError={codexRealtimeState.error}
-        onToggleVoice={() => void toggleCodexRealtime()}
+        onToggleVoice={() => void handleToggleVoice()}
         tabs={
           <TabIndicator
             state={tabState}
@@ -4502,6 +4580,22 @@ function App() {
           strings={restoreConfirmStrings(strings)}
           onClose={handleRestoreDialogClose}
           onConfirm={handleRestoreDialogConfirm}
+        />
+      ) : null}
+      {voiceEntryDialog ? (
+        <VoiceEntryDialog
+          mode={voiceEntryDialog.mode}
+          strings={{
+            title: strings.gptLiveRequiresCodex,
+            switchBody: strings.gptLiveSwitchBody,
+            setupBody: strings.gptLiveSetupBody,
+            cancel: strings.gptLiveCancel,
+            confirmSwitch: strings.gptLiveConfirmSwitch,
+            openSettings: strings.gptLiveOpenSettings,
+          }}
+          onCancel={handleVoiceEntryCancel}
+          onConfirmSwitch={handleVoiceEntryConfirmSwitch}
+          onOpenSettings={handleVoiceEntryOpenSettings}
         />
       ) : null}
       {reloadCurtainPhase !== "hidden" ? (

--- a/src/components/VoiceEntryDialog.test.tsx
+++ b/src/components/VoiceEntryDialog.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { VoiceEntryDialog, type VoiceEntryDialogStrings } from "./VoiceEntryDialog";
+
+const strings: VoiceEntryDialogStrings = {
+  title: "GPT Live requires Codex",
+  switchBody: "Switch to Codex and start GPT Live?",
+  setupBody: "Install Codex and sign in, then select it in Settings.",
+  cancel: "Cancel",
+  confirmSwitch: "Switch and start",
+  openSettings: "Open Settings",
+};
+
+afterEach(cleanup);
+
+describe("VoiceEntryDialog", () => {
+  it("only switches after explicit confirmation", () => {
+    const onConfirmSwitch = vi.fn();
+    render(
+      <VoiceEntryDialog
+        mode="switch"
+        strings={strings}
+        onCancel={vi.fn()}
+        onConfirmSwitch={onConfirmSwitch}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(strings.switchBody)).toBeTruthy();
+    expect(onConfirmSwitch).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: strings.confirmSwitch }));
+    expect(onConfirmSwitch).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels without switching", () => {
+    const onCancel = vi.fn();
+    const onConfirmSwitch = vi.fn();
+    render(
+      <VoiceEntryDialog
+        mode="switch"
+        strings={strings}
+        onCancel={onCancel}
+        onConfirmSwitch={onConfirmSwitch}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: strings.cancel }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirmSwitch).not.toHaveBeenCalled();
+  });
+
+  it("guides an unconfigured user to Settings without switching", () => {
+    const onOpenSettings = vi.fn();
+    const onConfirmSwitch = vi.fn();
+    render(
+      <VoiceEntryDialog
+        mode="setup"
+        strings={strings}
+        onCancel={vi.fn()}
+        onConfirmSwitch={onConfirmSwitch}
+        onOpenSettings={onOpenSettings}
+      />,
+    );
+
+    expect(screen.getByText(strings.setupBody)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: strings.openSettings }));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(onConfirmSwitch).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/VoiceEntryDialog.tsx
+++ b/src/components/VoiceEntryDialog.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useId, useRef } from "react";
+import { createPortal } from "react-dom";
+
+export type VoiceEntryDialogMode = "switch" | "setup";
+
+export interface VoiceEntryDialogStrings {
+  readonly title: string;
+  readonly switchBody: string;
+  readonly setupBody: string;
+  readonly cancel: string;
+  readonly confirmSwitch: string;
+  readonly openSettings: string;
+}
+
+export interface VoiceEntryDialogProps {
+  readonly mode: VoiceEntryDialogMode;
+  readonly strings: VoiceEntryDialogStrings;
+  readonly onCancel: () => void;
+  readonly onConfirmSwitch: () => void;
+  readonly onOpenSettings: () => void;
+}
+
+export function VoiceEntryDialog({
+  mode,
+  strings,
+  onCancel,
+  onConfirmSwitch,
+  onOpenSettings,
+}: VoiceEntryDialogProps): React.ReactPortal | null {
+  const titleId = useId();
+  const bodyId = useId();
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    cancelRef.current?.focus();
+  }, []);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div className="restore-confirm-overlay" data-surface="themed">
+      <button
+        aria-hidden="true"
+        aria-label={strings.cancel}
+        className="restore-confirm-backdrop"
+        onMouseDown={(event) => {
+          event.preventDefault();
+          onCancel();
+        }}
+        tabIndex={-1}
+        type="button"
+      />
+      <div
+        aria-describedby={bodyId}
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className="restore-confirm-panel"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onCancel();
+          }
+        }}
+        role="dialog"
+      >
+        <h2 className="restore-confirm-title" id={titleId}>
+          {strings.title}
+        </h2>
+        <p className="restore-confirm-body" id={bodyId}>
+          {mode === "switch" ? strings.switchBody : strings.setupBody}
+        </p>
+        <div className="restore-confirm-footer">
+          <button
+            className="restore-confirm-button restore-confirm-button-secondary"
+            onClick={onCancel}
+            ref={cancelRef}
+            type="button"
+          >
+            {strings.cancel}
+          </button>
+          <button
+            className="restore-confirm-button restore-confirm-button-primary"
+            onClick={mode === "switch" ? onConfirmSwitch : onOpenSettings}
+            type="button"
+          >
+            {mode === "switch" ? strings.confirmSwitch : strings.openSettings}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -168,9 +168,9 @@ const EN: UiStrings = {
   codexVoiceConnecting: "Connecting Codex voice…",
   codexVoiceRetry: "Retry Codex voice",
   codexVoiceApiBilling: "API billing",
-  gptLiveRequiresCodex: "GPT Live currently requires Codex",
+  gptLiveRequiresCodex: "Voice conversation (GPT Live) currently requires Codex",
   gptLiveSwitchBody:
-    "Your current Main Agent does not support GPT Live. Switch to Codex and start GPT Live? Your current conversation and work state are preserved, and switching back resumes it.",
+    "Your current Main Agent does not support voice conversation. Switch to Codex and start a voice conversation? Your current conversation and work state are preserved, and switching back to the original agent resumes where you left off.",
   gptLiveSetupBody:
     "Install the Codex CLI and sign in with ChatGPT (or configure an API key), then open Settings to select Codex as the Main Agent.",
   gptLiveCancel: "Cancel",
@@ -295,9 +295,9 @@ const JA: UiStrings = {
   codexVoiceConnecting: "Codex 音声会話に接続中…",
   codexVoiceRetry: "Codex 音声会話を再試行",
   codexVoiceApiBilling: "API従量課金",
-  gptLiveRequiresCodex: "GPT Liveには現在Codexが必要です",
+  gptLiveRequiresCodex: "音声対話（GPT Live）の利用には、現在Codexが必要です",
   gptLiveSwitchBody:
-    "現在のMain AgentはGPT Liveに対応していません。Codexへ切り替えてGPT Liveを始めますか？現在の会話と作業状態は保持され、元のAgentへ戻すと続きから再開できます。",
+    "現在のメインエージェントは音声対話に対応していません。Codexへ切り替えて、音声対話を始めますか？現在の会話と作業状態は保持され、元のエージェントへ戻すと続きから再開できます。",
   gptLiveSetupBody:
     "Codex CLIをインストールし、ChatGPTでサインイン（またはAPIキーを設定）してから、SettingsでMain AgentにCodexを選んでください。",
   gptLiveCancel: "キャンセル",

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -39,6 +39,12 @@ export interface UiStrings {
   readonly codexVoiceConnecting: string;
   readonly codexVoiceRetry: string;
   readonly codexVoiceApiBilling: string;
+  readonly gptLiveRequiresCodex: string;
+  readonly gptLiveSwitchBody: string;
+  readonly gptLiveSetupBody: string;
+  readonly gptLiveCancel: string;
+  readonly gptLiveConfirmSwitch: string;
+  readonly gptLiveOpenSettings: string;
   /**
    * セッション再起動を伴う設定変更の確認ダイアログ。「セッション」というシステム語
    * ではなく会話の行き先を伝える：persona は新しく始まる（引き継がない）、agent は
@@ -162,6 +168,14 @@ const EN: UiStrings = {
   codexVoiceConnecting: "Connecting Codex voice…",
   codexVoiceRetry: "Retry Codex voice",
   codexVoiceApiBilling: "API billing",
+  gptLiveRequiresCodex: "GPT Live currently requires Codex",
+  gptLiveSwitchBody:
+    "Your current Main Agent does not support GPT Live. Switch to Codex and start GPT Live? Your current conversation and work state are preserved, and switching back resumes it.",
+  gptLiveSetupBody:
+    "Install the Codex CLI and sign in with ChatGPT (or configure an API key), then open Settings to select Codex as the Main Agent.",
+  gptLiveCancel: "Cancel",
+  gptLiveConfirmSwitch: "Switch and start",
+  gptLiveOpenSettings: "Open Settings",
   personaSwitchConfirm: "Switch to {next}. The conversation starts fresh.",
   personaSwitchConfirmButton: "Switch",
   agentSwitchConfirm:
@@ -281,6 +295,14 @@ const JA: UiStrings = {
   codexVoiceConnecting: "Codex 音声会話に接続中…",
   codexVoiceRetry: "Codex 音声会話を再試行",
   codexVoiceApiBilling: "API従量課金",
+  gptLiveRequiresCodex: "GPT Liveには現在Codexが必要です",
+  gptLiveSwitchBody:
+    "現在のMain AgentはGPT Liveに対応していません。Codexへ切り替えてGPT Liveを始めますか？現在の会話と作業状態は保持され、元のAgentへ戻すと続きから再開できます。",
+  gptLiveSetupBody:
+    "Codex CLIをインストールし、ChatGPTでサインイン（またはAPIキーを設定）してから、SettingsでMain AgentにCodexを選んでください。",
+  gptLiveCancel: "キャンセル",
+  gptLiveConfirmSwitch: "切り替えて開始",
+  gptLiveOpenSettings: "Settingsを開く",
   personaSwitchConfirm: "{next} に切り替えます。会話は新しく始まります。",
   personaSwitchConfirmButton: "切り替える",
   agentSwitchConfirm:

--- a/src/runtime/codex-realtime/voice-entry.test.ts
+++ b/src/runtime/codex-realtime/voice-entry.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import type { AgentDescriptor } from "../../bindings/tauri-commands";
+import {
+  consumePendingRealtimeStart,
+  isVoiceEntryAvailable,
+  markPendingRealtimeStart,
+  PENDING_REALTIME_START_KEY,
+  resolveVoiceEntryAction,
+} from "./voice-entry";
+
+const capabilities = (realtimeConversation: boolean) => ({
+  personaOverlay: true,
+  mcpInjection: true,
+  plugins: true,
+  lifecycleHooks: true,
+  sessionResume: true,
+  realtimeConversation,
+});
+
+const agent = (id: string, realtimeConversation: boolean, binaryName = id): AgentDescriptor => ({
+  id,
+  displayName: id === "codex" ? "Codex" : "Claude Code",
+  binaryName,
+  capabilities: capabilities(realtimeConversation),
+  commandSyntax: { prefix: "/", separator: ":" },
+});
+
+describe("resolveVoiceEntryAction", () => {
+  const agents = [agent("claude", false, "claude"), agent("codex", true, "codex")];
+
+  it("preserves the existing realtime path for the active Codex agent", async () => {
+    const resolveCommandPath = vi.fn();
+    await expect(
+      resolveVoiceEntryAction({ activeAgent: "codex", agents, resolveCommandPath }),
+    ).resolves.toEqual({ kind: "start" });
+    expect(resolveCommandPath).not.toHaveBeenCalled();
+  });
+
+  it("offers an explicit switch when the realtime agent is configured", async () => {
+    await expect(
+      resolveVoiceEntryAction({
+        activeAgent: "claude",
+        agents,
+        resolveCommandPath: vi.fn().mockResolvedValue("/usr/local/bin/codex"),
+      }),
+    ).resolves.toMatchObject({ kind: "confirm-switch", agent: { id: "codex" } });
+  });
+
+  it("offers setup when the realtime agent binary is missing", async () => {
+    await expect(
+      resolveVoiceEntryAction({
+        activeAgent: "claude",
+        agents,
+        resolveCommandPath: vi.fn().mockResolvedValue(null),
+      }),
+    ).resolves.toMatchObject({ kind: "setup", agent: { id: "codex" } });
+  });
+
+  it("offers setup when no registered adapter supports realtime", async () => {
+    await expect(
+      resolveVoiceEntryAction({
+        activeAgent: "claude",
+        agents: [agent("claude", false)],
+        resolveCommandPath: vi.fn(),
+      }),
+    ).resolves.toEqual({ kind: "setup", agent: null });
+  });
+});
+
+describe("isVoiceEntryAvailable", () => {
+  it("keeps the entry visible for the Main Agent session regardless of harness", () => {
+    expect(isVoiceEntryAvailable("main", "main")).toBe(true);
+    expect(isVoiceEntryAvailable("shell-2", "main")).toBe(false);
+  });
+});
+
+describe("pending realtime start", () => {
+  it("is a one-shot marker across the agent-switch reload", () => {
+    const storage = window.sessionStorage;
+    storage.removeItem(PENDING_REALTIME_START_KEY);
+    markPendingRealtimeStart(storage);
+    expect(consumePendingRealtimeStart(storage)).toBe(true);
+    expect(consumePendingRealtimeStart(storage)).toBe(false);
+  });
+});

--- a/src/runtime/codex-realtime/voice-entry.ts
+++ b/src/runtime/codex-realtime/voice-entry.ts
@@ -1,0 +1,62 @@
+import type { AgentDescriptor } from "../../bindings/tauri-commands";
+
+export const PENDING_REALTIME_START_KEY = "yorishiro:pending-realtime-start";
+
+export type VoiceEntryAction =
+  | { readonly kind: "start" }
+  | { readonly kind: "confirm-switch"; readonly agent: AgentDescriptor }
+  | { readonly kind: "setup"; readonly agent: AgentDescriptor | null };
+
+export interface ResolveVoiceEntryActionOptions {
+  readonly activeAgent: string;
+  readonly agents: readonly AgentDescriptor[];
+  readonly resolveCommandPath: (command: string) => Promise<string | null>;
+}
+
+/** GPT Live discovery is shown for the Main Agent session, independent of its harness. */
+export function isVoiceEntryAvailable(activeSessionId: string, mainSessionId: string): boolean {
+  return activeSessionId === mainSessionId;
+}
+
+/**
+ * Voice entry discovery is capability based so another harness can become a realtime target
+ * without changing the title-bar flow. Today Codex is the only registered realtime adapter.
+ */
+export async function resolveVoiceEntryAction({
+  activeAgent,
+  agents,
+  resolveCommandPath,
+}: ResolveVoiceEntryActionOptions): Promise<VoiceEntryAction> {
+  const active = agents.find((agent) => agent.id === activeAgent);
+  if (active?.capabilities.realtimeConversation === true) {
+    return { kind: "start" };
+  }
+
+  const target = agents.find((agent) => agent.capabilities.realtimeConversation);
+  if (target === undefined) {
+    return { kind: "setup", agent: null };
+  }
+
+  const commandPath = await resolveCommandPath(target.binaryName).catch(() => null);
+  return commandPath === null
+    ? { kind: "setup", agent: target }
+    : { kind: "confirm-switch", agent: target };
+}
+
+export function markPendingRealtimeStart(storage: Storage = sessionStorage): void {
+  try {
+    storage.setItem(PENDING_REALTIME_START_KEY, "1");
+  } catch {
+    // Storage is best-effort; agent switching must still be allowed in restricted WebViews.
+  }
+}
+
+export function consumePendingRealtimeStart(storage: Storage = sessionStorage): boolean {
+  try {
+    const pending = storage.getItem(PENDING_REALTIME_START_KEY) === "1";
+    storage.removeItem(PENDING_REALTIME_START_KEY);
+    return pending;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- keep the GPT Live voice entry visible for non-Codex agent sessions
- explain the current Codex requirement in a confirmation dialog
- route confirmed switches through the existing safe agent-switch path
- preserve cancel behavior and distinguish configured/unconfigured Codex guidance
- keep the existing Codex voice path unchanged

## Verification
- focused VoiceEntryDialog and voice-entry tests: 9 passed
- `npm run check`
- pre-push TypeScript, Biome, Rust fmt/clippy, and TypeDoc gates
- manually verified Claude → confirmation dialog → Codex → voice start
- manually verified cancel leaves the active agent unchanged

## Local macOS production-build note
A locally generated `.app` may only have a linker/ad-hoc signature, so macOS can reject microphone access with `The request is not allowed by the user agent or the platform in the current context`. For local verification, give the test bundle a distinct bundle identifier and ad-hoc sign the complete app bundle before launching it. This is a local test-artifact issue; the signing workaround is intentionally not part of this PR. Official release builds use the release signing/notarization path.

Closes #82
