### PR TITLE
Retarget realtime voice across Codex thread changes

### DIFF
--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -142,9 +142,10 @@ active threadを推測してはならない。TUI は host-owned loopback proxy 
 tracker はその ID を host IPC で読み、`thread/read` で loaded top-level と再検証してから採用する。proxy は
 transcript、turn payload、approval内容を保存しない。
 
-加えて、`/clear` は全 initialized connection へ broadcast される `thread/started` で追跡する。coldな
-`/resume` は新しくloadしたthreadの `thread/status/changed`、grace period中に既にload済みのresume先は
-次のactive statusでも補助的に追跡する。これらはproxy観測が一時的に利用不能な場合のfail-safeである。
+加えて、`/clear` は fork provenance を持たない `thread/started` broadcast で追跡する。`/resume` と
+`/fork` の ownership はproxyが相関した成功responseだけを正本とし、globalな `thread/status/changed` から
+推測しない。status通知はloaded / notLoadedのbookkeepingとcurrent threadの無効化にだけ使う。side
+conversationを含む別のtop-level threadも同じstatusを発するため、ownershipのfail-safeにはできない。
 
 接続中に tracker の current thread が変わった場合、現在の realtime 接続を停止し、新しい明示 ID へ
 自動再接続する。tracker bridge の切断や current thread の close で ID を特定できなくなった場合は、

--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -130,15 +130,25 @@ Main Agent が agent team を動かすと同じ app-server に複数 thread が 
 1. `thread/loaded/list` を取得する
 2. 各 ID を `thread/read({ includeTurns: false })` で読む
 3. `parentThreadId === null` の top-level thread だけを候補にする
-4. tracker が保持する latest top-level `thread/started` ID と照合する
+4. tracker が保持する latest top-level thread ID と照合する
 5. 一致する loaded top-level があれば、その ID で realtime を開始する
 6. tracker の初期 discovery 時だけ、top-level が一つならその ID を初期値にする
 7. subagent の終了と read が競合した場合は、最新の loaded snapshot からやり直す
 8. tracker に明示 ID がなく top-level が複数なら推測せず fail closed する
 
-Codex v2 Thread schema は `parentThreadId` を subagent の場合だけ設定する。recency、配列順、statusから
-active threadを推測してはならない。`thread/started` は全 initialized connection へ broadcast されるため、
-session 中継続する tracker が `/clear` と `/resume` の切替を明示 ID として記録する。
+Codex v2 Thread schema は `parentThreadId` を subagent の場合だけ設定する。recency、配列順、statusだけから
+active threadを推測してはならない。TUI は host-owned loopback proxy 経由で app-server へ接続し、proxy は
+`thread/start` / `thread/resume` / `thread/fork` の成功 response に含まれる thread ID だけを保持する。
+tracker はその ID を host IPC で読み、`thread/read` で loaded top-level と再検証してから採用する。proxy は
+transcript、turn payload、approval内容を保存しない。
+
+加えて、`/clear` は全 initialized connection へ broadcast される `thread/started` で追跡する。coldな
+`/resume` は新しくloadしたthreadの `thread/status/changed`、grace period中に既にload済みのresume先は
+次のactive statusでも補助的に追跡する。これらはproxy観測が一時的に利用不能な場合のfail-safeである。
+
+接続中に tracker の current thread が変わった場合、現在の realtime 接続を停止し、新しい明示 ID へ
+自動再接続する。tracker bridge の切断や current thread の close で ID を特定できなくなった場合は、
+誤った thread へつなぎ続けず realtime を停止する。この契約は `/clear` と `/resume` で共通とする。
 
 ### approval ownership
 
@@ -305,7 +315,8 @@ leaseをinvalidateしない。fallbackへのrestore IPCは一時失敗に備え�
 - approval request は同じ thread の subscriber 全員へ届く。bridge は自動応答せず、v1 の
   承認 UI は TUI だけを正本とする
 - `thread/loaded/list` の順序には active thread の意味がない。subagent は `parentThreadId` で除外し、
-  複数の top-level thread が loaded の場合は誤接続を避けて voice を開始しない
+  複数の top-level thread が loaded の場合は tracker の `/clear`・`/resume` 通知由来の明示 ID がなければ
+  誤接続を避けて voice を開始しない
 - v1 の接続実装は activeなCodex-backed Main Agent session だけを対象とする。shell tab や Claude / OpenCode には
   native voice adapterがなく、現在はbuttonも表示しない。将来の共通buttonは非対応を隠さず説明し、
   userが明示確認した場合だけ既存の安全なagent切替経路を使う

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1019,6 +1019,14 @@ async fn session_realtime_connect(
 }
 
 #[tauri::command]
+async fn session_realtime_selected_thread(
+    pty_state: State<'_, PtyState>,
+    session_id: String,
+) -> Result<Option<String>, String> {
+    Ok(pty_state.realtime_selected_thread_id(&session_id))
+}
+
+#[tauri::command]
 async fn session_realtime_send(
     bridge_state: State<'_, RealtimeBridgeState>,
     connection_id: String,
@@ -2395,6 +2403,7 @@ pub fn run() {
             session_attach,
             session_detach,
             session_realtime_connect,
+            session_realtime_selected_thread,
             session_realtime_send,
             session_realtime_disconnect,
             session_list,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -496,6 +496,11 @@ impl PtyState {
             .and_then(|session| session.realtime_endpoint())
     }
 
+    pub fn realtime_selected_thread_id(&self, session_id: &str) -> Option<String> {
+        self.session_or_default(session_id)
+            .and_then(|session| session.realtime_selected_thread_id())
+    }
+
     pub fn write_data(&self, session_id: &str, data: &str) -> Result<(), String> {
         let Some(session) = self.session_or_default(session_id) else {
             return Ok(());

--- a/src-tauri/src/sessions/codex_tui_proxy.rs
+++ b/src-tauri/src/sessions/codex_tui_proxy.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use tokio::sync::oneshot;
 use tokio_tungstenite::tungstenite::{
-    handshake::server::{Request, Response},
+    handshake::server::{ErrorResponse, Request, Response},
     http::StatusCode,
     Message,
 };
@@ -106,25 +106,27 @@ impl Drop for CodexTuiProxy {
     }
 }
 
+// tungstenite fixes the callback error type to an HTTP response. Boxing that response would
+// avoid this lint, but would no longer satisfy the library's callback contract.
+#[allow(clippy::result_large_err)]
+fn reject_browser_origin(request: &Request, response: Response) -> Result<Response, ErrorResponse> {
+    if request.headers().contains_key("origin") {
+        return Err(Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .body(Some("Origin header is not allowed".to_string()))
+            .expect("static WebSocket rejection response should be valid"));
+    }
+    Ok(response)
+}
+
 async fn proxy_connection(
     client_stream: tokio::net::TcpStream,
     upstream_endpoint: String,
     selected_thread_id: Arc<Mutex<Option<String>>>,
 ) -> Result<(), String> {
-    let client = tokio_tungstenite::accept_hdr_async(
-        client_stream,
-        |request: &Request, response: Response| {
-            if request.headers().contains_key("origin") {
-                return Err(Response::builder()
-                    .status(StatusCode::FORBIDDEN)
-                    .body(Some("Origin header is not allowed".to_string()))
-                    .expect("static WebSocket rejection response should be valid"));
-            }
-            Ok(response)
-        },
-    )
-    .await
-    .map_err(|error| format!("TUI handshake failed: {error}"))?;
+    let client = tokio_tungstenite::accept_hdr_async(client_stream, reject_browser_origin)
+        .await
+        .map_err(|error| format!("TUI handshake failed: {error}"))?;
     let (upstream, _) = tokio_tungstenite::connect_async(&upstream_endpoint)
         .await
         .map_err(|error| format!("upstream connection failed: {error}"))?;

--- a/src-tauri/src/sessions/codex_tui_proxy.rs
+++ b/src-tauri/src/sessions/codex_tui_proxy.rs
@@ -5,7 +5,11 @@ use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use tokio::sync::oneshot;
-use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::{
+    handshake::server::{Request, Response},
+    http::StatusCode,
+    Message,
+};
 
 /// Codex TUI の app-server transport を透過中継し、thread 選択 response の ID だけを保持する。
 /// transcript や turn payload は保存しない。
@@ -107,9 +111,20 @@ async fn proxy_connection(
     upstream_endpoint: String,
     selected_thread_id: Arc<Mutex<Option<String>>>,
 ) -> Result<(), String> {
-    let client = tokio_tungstenite::accept_async(client_stream)
-        .await
-        .map_err(|error| format!("TUI handshake failed: {error}"))?;
+    let client = tokio_tungstenite::accept_hdr_async(
+        client_stream,
+        |request: &Request, response: Response| {
+            if request.headers().contains_key("origin") {
+                return Err(Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .body(Some("Origin header is not allowed".to_string()))
+                    .expect("static WebSocket rejection response should be valid"));
+            }
+            Ok(response)
+        },
+    )
+    .await
+    .map_err(|error| format!("TUI handshake failed: {error}"))?;
     let (upstream, _) = tokio_tungstenite::connect_async(&upstream_endpoint)
         .await
         .map_err(|error| format!("upstream connection failed: {error}"))?;
@@ -179,6 +194,15 @@ fn track_thread_selection_request(raw: &str, pending: &mut HashSet<String>) {
 
 fn take_selected_thread_response(raw: &str, pending: &mut HashSet<String>) -> Option<String> {
     let message = serde_json::from_str::<Value>(raw).ok()?;
+    let object = message.as_object()?;
+    if object.contains_key("method") {
+        return None;
+    }
+    let has_result = object.contains_key("result");
+    let has_error = object.contains_key("error");
+    if has_result == has_error {
+        return None;
+    }
     let key = message.get("id").and_then(request_id_key)?;
     if !pending.remove(&key) {
         return None;
@@ -195,6 +219,10 @@ fn take_selected_thread_response(raw: &str, pending: &mut HashSet<String>) -> Op
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio_tungstenite::tungstenite::{
+        client::IntoClientRequest,
+        http::{header::ORIGIN, HeaderValue},
+    };
 
     #[tokio::test]
     async fn forwards_websocket_messages_and_records_the_selected_thread() {
@@ -249,6 +277,28 @@ mod tests {
         upstream_task.await.expect("upstream task");
     }
 
+    #[tokio::test]
+    async fn rejects_websocket_handshakes_with_an_origin_header() {
+        let proxy =
+            CodexTuiProxy::spawn("ws://127.0.0.1:9".to_string()).expect("proxy should start");
+        let mut request = proxy
+            .endpoint()
+            .into_client_request()
+            .expect("valid proxy request");
+        request
+            .headers_mut()
+            .insert(ORIGIN, HeaderValue::from_static("http://tauri.localhost"));
+
+        let error = match tokio_tungstenite::connect_async(request).await {
+            Ok(_) => panic!("Origin-bearing handshake must be rejected"),
+            Err(error) => error,
+        };
+        let tokio_tungstenite::tungstenite::Error::Http(response) = error else {
+            panic!("expected HTTP handshake rejection, got {error}");
+        };
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
     #[test]
     fn observes_only_successful_thread_selection_responses() {
         let mut pending = HashSet::new();
@@ -296,5 +346,49 @@ mod tests {
             None
         );
         assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn server_request_id_collision_does_not_consume_pending_selection() {
+        let mut pending = HashSet::new();
+        track_thread_selection_request(
+            r#"{"method":"thread/resume","id":7,"params":{"threadId":"old"}}"#,
+            &mut pending,
+        );
+
+        assert_eq!(
+            take_selected_thread_response(
+                r#"{"method":"item/commandExecution/requestApproval","id":7,"params":{}}"#,
+                &mut pending,
+            ),
+            None
+        );
+        assert!(pending.contains("7"));
+        assert_eq!(
+            take_selected_thread_response(
+                r#"{"id":7,"result":{"thread":{"id":"resumed"}}}"#,
+                &mut pending,
+            ),
+            Some("resumed".to_string())
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn malformed_response_does_not_consume_pending_selection() {
+        let mut pending = HashSet::new();
+        track_thread_selection_request(
+            r#"{"method":"thread/start","id":9,"params":{}}"#,
+            &mut pending,
+        );
+
+        assert_eq!(
+            take_selected_thread_response(
+                r#"{"id":9,"result":{"thread":{"id":"wrong"}},"error":{"message":"also wrong"}}"#,
+                &mut pending,
+            ),
+            None
+        );
+        assert!(pending.contains("9"));
     }
 }

--- a/src-tauri/src/sessions/codex_tui_proxy.rs
+++ b/src-tauri/src/sessions/codex_tui_proxy.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use tokio::sync::oneshot;
 use tokio_tungstenite::tungstenite::{
-    handshake::server::{ErrorResponse, Request, Response},
+    handshake::server::{Callback, ErrorResponse, Request, Response},
     http::StatusCode,
     Message,
 };
@@ -106,17 +106,18 @@ impl Drop for CodexTuiProxy {
     }
 }
 
-// tungstenite fixes the callback error type to an HTTP response. Boxing that response would
-// avoid this lint, but would no longer satisfy the library's callback contract.
-#[allow(clippy::result_large_err)]
-fn reject_browser_origin(request: &Request, response: Response) -> Result<Response, ErrorResponse> {
-    if request.headers().contains_key("origin") {
-        return Err(Response::builder()
-            .status(StatusCode::FORBIDDEN)
-            .body(Some("Origin header is not allowed".to_string()))
-            .expect("static WebSocket rejection response should be valid"));
+struct RejectBrowserOrigin;
+
+impl Callback for RejectBrowserOrigin {
+    fn on_request(self, request: &Request, response: Response) -> Result<Response, ErrorResponse> {
+        if request.headers().contains_key("origin") {
+            return Err(Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .body(Some("Origin header is not allowed".to_string()))
+                .expect("static WebSocket rejection response should be valid"));
+        }
+        Ok(response)
     }
-    Ok(response)
 }
 
 async fn proxy_connection(
@@ -124,7 +125,7 @@ async fn proxy_connection(
     upstream_endpoint: String,
     selected_thread_id: Arc<Mutex<Option<String>>>,
 ) -> Result<(), String> {
-    let client = tokio_tungstenite::accept_hdr_async(client_stream, reject_browser_origin)
+    let client = tokio_tungstenite::accept_hdr_async(client_stream, RejectBrowserOrigin)
         .await
         .map_err(|error| format!("TUI handshake failed: {error}"))?;
     let (upstream, _) = tokio_tungstenite::connect_async(&upstream_endpoint)

--- a/src-tauri/src/sessions/codex_tui_proxy.rs
+++ b/src-tauri/src/sessions/codex_tui_proxy.rs
@@ -1,0 +1,300 @@
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use std::collections::HashSet;
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use tokio::sync::oneshot;
+use tokio_tungstenite::tungstenite::Message;
+
+/// Codex TUI の app-server transport を透過中継し、thread 選択 response の ID だけを保持する。
+/// transcript や turn payload は保存しない。
+pub(super) struct CodexTuiProxy {
+    endpoint: String,
+    selected_thread_id: Arc<Mutex<Option<String>>>,
+    shutdown: Option<oneshot::Sender<()>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl CodexTuiProxy {
+    pub(super) fn spawn(upstream_endpoint: String) -> Result<Self, String> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .map_err(|error| format!("Codex TUI proxy port allocation failed: {error}"))?;
+        let address = listener
+            .local_addr()
+            .map_err(|error| format!("Codex TUI proxy address lookup failed: {error}"))?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|error| format!("Codex TUI proxy nonblocking setup failed: {error}"))?;
+        let endpoint = format!("ws://{address}");
+        let selected_thread_id = Arc::new(Mutex::new(None));
+        let task_selected_thread_id = Arc::clone(&selected_thread_id);
+        let (shutdown, mut shutdown_rx) = oneshot::channel();
+
+        let thread = std::thread::Builder::new()
+            .name("codex-tui-proxy".to_string())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        eprintln!("[codex-tui-proxy] runtime creation failed: {error}");
+                        return;
+                    }
+                };
+                runtime.block_on(async move {
+                    let listener = match tokio::net::TcpListener::from_std(listener) {
+                        Ok(listener) => listener,
+                        Err(error) => {
+                            eprintln!("[codex-tui-proxy] listener setup failed: {error}");
+                            return;
+                        }
+                    };
+                    loop {
+                        tokio::select! {
+                            _ = &mut shutdown_rx => break,
+                            accepted = listener.accept() => {
+                                let Ok((stream, _)) = accepted else { continue };
+                                let upstream = upstream_endpoint.clone();
+                                let selected = Arc::clone(&task_selected_thread_id);
+                                tokio::spawn(async move {
+                                    if let Err(error) = proxy_connection(stream, upstream, selected).await {
+                                        eprintln!("[codex-tui-proxy] connection ended: {error}");
+                                    }
+                                });
+                            }
+                        }
+                    }
+                });
+            })
+            .map_err(|error| format!("Codex TUI proxy thread spawn failed: {error}"))?;
+
+        Ok(Self {
+            endpoint,
+            selected_thread_id,
+            shutdown: Some(shutdown),
+            thread: Some(thread),
+        })
+    }
+
+    pub(super) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub(super) fn selected_thread_id(&self) -> Option<String> {
+        self.selected_thread_id
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+impl Drop for CodexTuiProxy {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+async fn proxy_connection(
+    client_stream: tokio::net::TcpStream,
+    upstream_endpoint: String,
+    selected_thread_id: Arc<Mutex<Option<String>>>,
+) -> Result<(), String> {
+    let client = tokio_tungstenite::accept_async(client_stream)
+        .await
+        .map_err(|error| format!("TUI handshake failed: {error}"))?;
+    let (upstream, _) = tokio_tungstenite::connect_async(&upstream_endpoint)
+        .await
+        .map_err(|error| format!("upstream connection failed: {error}"))?;
+    let (mut client_sink, mut client_stream) = client.split();
+    let (mut upstream_sink, mut upstream_stream) = upstream.split();
+    let mut thread_selection_requests = HashSet::new();
+
+    loop {
+        tokio::select! {
+            message = client_stream.next() => {
+                let Some(message) = message else { break };
+                let message = message.map_err(|error| format!("TUI receive failed: {error}"))?;
+                if let Message::Text(text) = &message {
+                    track_thread_selection_request(text.as_ref(), &mut thread_selection_requests);
+                }
+                upstream_sink.send(message).await
+                    .map_err(|error| format!("upstream send failed: {error}"))?;
+            }
+            message = upstream_stream.next() => {
+                let Some(message) = message else { break };
+                let message = message.map_err(|error| format!("upstream receive failed: {error}"))?;
+                if let Message::Text(text) = &message {
+                    if let Some(thread_id) = take_selected_thread_response(
+                        text.as_ref(),
+                        &mut thread_selection_requests,
+                    ) {
+                        *selected_thread_id
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(thread_id);
+                    }
+                }
+                client_sink.send(message).await
+                    .map_err(|error| format!("TUI send failed: {error}"))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn request_id_key(value: &Value) -> Option<String> {
+    serde_json::to_string(value).ok()
+}
+
+fn track_thread_selection_request(raw: &str, pending: &mut HashSet<String>) {
+    let Ok(message) = serde_json::from_str::<Value>(raw) else {
+        return;
+    };
+    let method = message.get("method").and_then(Value::as_str);
+    let selects_main_thread = match method {
+        Some("thread/start" | "thread/resume") => true,
+        Some("thread/fork") => {
+            message
+                .get("params")
+                .and_then(|params| params.get("excludeTurns"))
+                .and_then(Value::as_bool)
+                != Some(true)
+        }
+        _ => false,
+    };
+    if !selects_main_thread {
+        return;
+    }
+    if let Some(key) = message.get("id").and_then(request_id_key) {
+        pending.insert(key);
+    }
+}
+
+fn take_selected_thread_response(raw: &str, pending: &mut HashSet<String>) -> Option<String> {
+    let message = serde_json::from_str::<Value>(raw).ok()?;
+    let key = message.get("id").and_then(request_id_key)?;
+    if !pending.remove(&key) {
+        return None;
+    }
+    message
+        .get("result")?
+        .get("thread")?
+        .get("id")?
+        .as_str()
+        .filter(|thread_id| !thread_id.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn forwards_websocket_messages_and_records_the_selected_thread() {
+        let upstream_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("upstream listener");
+        let upstream_address = upstream_listener.local_addr().expect("upstream address");
+        let upstream_task = tokio::spawn(async move {
+            let (stream, _) = upstream_listener.accept().await.expect("upstream accept");
+            let mut socket = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("upstream handshake");
+            let request = socket
+                .next()
+                .await
+                .expect("request")
+                .expect("valid request");
+            assert!(matches!(request, Message::Text(_)));
+            socket
+                .send(Message::Text(
+                    r#"{"id":7,"result":{"thread":{"id":"resumed"}}}"#.into(),
+                ))
+                .await
+                .expect("upstream response");
+        });
+
+        let proxy =
+            CodexTuiProxy::spawn(format!("ws://{upstream_address}")).expect("proxy should start");
+        let (mut client, _) = tokio_tungstenite::connect_async(proxy.endpoint())
+            .await
+            .expect("proxy handshake");
+        client
+            .send(Message::Text(
+                r#"{"method":"thread/resume","id":7,"params":{"threadId":"old"}}"#.into(),
+            ))
+            .await
+            .expect("proxy request");
+        let response = client
+            .next()
+            .await
+            .expect("response")
+            .expect("valid response");
+        assert!(matches!(response, Message::Text(_)));
+
+        for _ in 0..20 {
+            if proxy.selected_thread_id().as_deref() == Some("resumed") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(proxy.selected_thread_id().as_deref(), Some("resumed"));
+        upstream_task.await.expect("upstream task");
+    }
+
+    #[test]
+    fn observes_only_successful_thread_selection_responses() {
+        let mut pending = HashSet::new();
+        track_thread_selection_request(
+            r#"{"method":"thread/resume","id":7,"params":{"threadId":"old"}}"#,
+            &mut pending,
+        );
+        assert_eq!(
+            take_selected_thread_response(
+                r#"{"id":7,"result":{"thread":{"id":"resumed"}}}"#,
+                &mut pending,
+            ),
+            Some("resumed".to_string())
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn ignores_unrelated_and_failed_responses() {
+        let mut pending = HashSet::new();
+        track_thread_selection_request(
+            r#"{"method":"thread/read","id":1,"params":{}}"#,
+            &mut pending,
+        );
+        assert!(pending.is_empty());
+
+        track_thread_selection_request(
+            r#"{"method":"thread/fork","id":2,"params":{"excludeTurns":true}}"#,
+            &mut pending,
+        );
+        assert!(
+            pending.is_empty(),
+            "side conversations do not replace the main TUI thread"
+        );
+
+        track_thread_selection_request(
+            r#"{"method":"thread/start","id":"start-1","params":{}}"#,
+            &mut pending,
+        );
+        assert_eq!(
+            take_selected_thread_response(
+                r#"{"id":"start-1","error":{"message":"failed"}}"#,
+                &mut pending,
+            ),
+            None
+        );
+        assert!(pending.is_empty());
+    }
+}

--- a/src-tauri/src/sessions/mod.rs
+++ b/src-tauri/src/sessions/mod.rs
@@ -6,6 +6,7 @@
 //! Internal design-record: 2026-05-05-multi-pane-terminal.md.
 
 pub mod agent_adapter;
+mod codex_tui_proxy;
 pub mod osc133;
 pub mod pty_session;
 pub mod registry;

--- a/src-tauri/src/sessions/pty_session.rs
+++ b/src-tauri/src/sessions/pty_session.rs
@@ -18,6 +18,7 @@ use tauri::{AppHandle, Emitter};
 
 use crate::pty::PtyExit;
 
+use super::codex_tui_proxy::CodexTuiProxy;
 use super::osc133::{Osc133Parser, OscEvent};
 use super::registry::SessionRegistry;
 use super::types::{SessionActivity, SessionId};
@@ -242,6 +243,7 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 struct CodexAppServerProcess {
     child: Child,
     endpoint: String,
+    tui_proxy: Option<CodexTuiProxy>,
 }
 
 impl CodexAppServerProcess {
@@ -271,9 +273,24 @@ impl CodexAppServerProcess {
                 "Failed to spawn Codex app-server ({binary}). Codex 0.145.0 or newer is required: {e}"
             )
         })?;
-        let mut process = Self { child, endpoint };
+        let mut process = Self {
+            child,
+            endpoint,
+            tui_proxy: None,
+        };
         process.wait_until_ready(address)?;
+        process.tui_proxy = Some(CodexTuiProxy::spawn(process.endpoint.clone())?);
         Ok(process)
+    }
+
+    fn tui_endpoint(&self) -> Option<&str> {
+        self.tui_proxy.as_ref().map(CodexTuiProxy::endpoint)
+    }
+
+    fn selected_thread_id(&self) -> Option<String> {
+        self.tui_proxy
+            .as_ref()
+            .and_then(CodexTuiProxy::selected_thread_id)
     }
 
     fn wait_until_ready(&mut self, address: SocketAddr) -> Result<(), String> {
@@ -299,6 +316,7 @@ impl CodexAppServerProcess {
 
 impl Drop for CodexAppServerProcess {
     fn drop(&mut self) {
+        self.tui_proxy.take();
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
@@ -430,7 +448,7 @@ impl PtySession {
                     resume: *resume,
                     realtime_endpoint: pending_app_server
                         .as_ref()
-                        .map(|server| server.endpoint.as_str()),
+                        .and_then(CodexAppServerProcess::tui_endpoint),
                 };
                 let launch = adapter.build_launch_args(&ctx)?;
                 for (k, v) in &launch.env {
@@ -621,6 +639,12 @@ impl PtySession {
         lock_or_recover(&self.codex_app_server)
             .as_ref()
             .map(|server| server.endpoint.clone())
+    }
+
+    pub fn realtime_selected_thread_id(&self) -> Option<String> {
+        lock_or_recover(&self.codex_app_server)
+            .as_ref()
+            .and_then(CodexAppServerProcess::selected_thread_id)
     }
 
     pub fn write_data(&self, data: &str) -> Result<(), String> {

--- a/src/bindings/tauri-commands.ts
+++ b/src/bindings/tauri-commands.ts
@@ -150,6 +150,11 @@ export const sessionRealtimeConnect = (args: {
   readonly onMessage: Channel<string>;
 }): Promise<string> => call("session_realtime_connect", args);
 
+/** Codex TUI proxy が最後に確認した top-level thread selection。 */
+export const sessionRealtimeSelectedThread = (args: {
+  readonly sessionId: string;
+}): Promise<string | null> => call("session_realtime_selected_thread", args);
+
 /** Rust host が所有する realtime connection へ JSON-RPC text を送る。 */
 export const sessionRealtimeSend = (args: {
   readonly connectionId: string;

--- a/src/runtime/codex-realtime/codex-thread-tracker.test.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.test.ts
@@ -19,6 +19,7 @@ const bridge = vi.hoisted(() => ({
   loadedThreads: ["thread-1"] as string[],
   parents: {} as Record<string, string | null>,
   pendingReads: false,
+  selectedThread: null as string | null,
   readResponders: [] as Array<() => void>,
   disconnect: vi.fn(async () => {}),
   connect: vi.fn(async ({ onMessage }: { onMessage: FakeChannel<string> }): Promise<string> => {
@@ -36,6 +37,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 vi.mock("../../bindings/tauri-commands", () => ({
   sessionRealtimeConnect: bridge.connect,
   sessionRealtimeDisconnect: bridge.disconnect,
+  sessionRealtimeSelectedThread: vi.fn(async () => bridge.selectedThread),
   sessionRealtimeSend: vi.fn(async ({ message }: { message: string }): Promise<void> => {
     const request = JSON.parse(message) as SentMessage;
     bridge.sent.push(request);
@@ -69,6 +71,7 @@ describe("CodexThreadTracker", () => {
     bridge.loadedThreads = ["thread-1"];
     bridge.parents = {};
     bridge.pendingReads = false;
+    bridge.selectedThread = null;
     bridge.readResponders = [];
     bridge.disconnect.mockClear();
     bridge.connect.mockClear();
@@ -102,6 +105,99 @@ describe("CodexThreadTracker", () => {
       }),
     );
     expect(tracker.getCurrentThreadId()).toBe("thread-after-clear");
+    tracker.stop();
+  });
+
+  it("tracks the top-level thread loaded by /resume from its status notification", async () => {
+    const changes: Array<string | null> = [];
+    const tracker = new CodexThreadTracker("main-session", (threadId) => changes.push(threadId));
+    await tracker.start();
+
+    bridge.loadedThreads = ["thread-1", "thread-after-resume"];
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/status/changed",
+        params: { threadId: "thread-after-resume", status: { type: "idle" } },
+      }),
+    );
+    await vi.waitFor(() => expect(tracker.getCurrentThreadId()).toBe("thread-after-resume"));
+
+    expect(changes).toEqual(["thread-1", "thread-after-resume"]);
+    tracker.stop();
+  });
+
+  it("tracks a grace-period loaded /resume target when its next turn becomes active", async () => {
+    bridge.loadedThreads = ["thread-1", "thread-2"];
+    const tracker = new CodexThreadTracker("main-session");
+    await tracker.start();
+    expect(tracker.getCurrentThreadId()).toBeNull();
+
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/status/changed",
+        params: { threadId: "thread-2", status: { type: "idle" } },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(tracker.getCurrentThreadId()).toBeNull();
+
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/status/changed",
+        params: { threadId: "thread-2", status: { type: "active", activeFlags: [] } },
+      }),
+    );
+    await vi.waitFor(() => expect(tracker.getCurrentThreadId()).toBe("thread-2"));
+    tracker.stop();
+  });
+
+  it("tracks an already-loaded /resume target observed by the TUI proxy", async () => {
+    bridge.loadedThreads = ["thread-1", "thread-2"];
+    const tracker = new CodexThreadTracker("main-session");
+    await tracker.start();
+    expect(tracker.getCurrentThreadId()).toBeNull();
+
+    bridge.selectedThread = "thread-2";
+    await vi.waitFor(() => expect(tracker.getCurrentThreadId()).toBe("thread-2"));
+    tracker.stop();
+  });
+
+  it("does not switch back when the previous top-level thread later becomes idle", async () => {
+    const tracker = new CodexThreadTracker("main-session");
+    await tracker.start();
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/started",
+        params: { thread: { id: "thread-2", parentThreadId: null } },
+      }),
+    );
+
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/status/changed",
+        params: { threadId: "thread-1", status: { type: "idle" } },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(tracker.getCurrentThreadId()).toBe("thread-2");
+    tracker.stop();
+  });
+
+  it("ignores a subagent status notification while resolving /resume", async () => {
+    bridge.parents.subagent = "thread-1";
+    const tracker = new CodexThreadTracker("main-session");
+    await tracker.start();
+
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/status/changed",
+        params: { threadId: "subagent", status: { type: "idle" } },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(tracker.getCurrentThreadId()).toBe("thread-1");
     tracker.stop();
   });
 

--- a/src/runtime/codex-realtime/codex-thread-tracker.test.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.test.ts
@@ -20,9 +20,14 @@ const bridge = vi.hoisted(() => ({
   parents: {} as Record<string, string | null>,
   pendingReads: false,
   selectedThread: null as string | null,
+  connectFailuresRemaining: 0,
   readResponders: [] as Array<() => void>,
   disconnect: vi.fn(async () => {}),
   connect: vi.fn(async ({ onMessage }: { onMessage: FakeChannel<string> }): Promise<string> => {
+    if (bridge.connectFailuresRemaining > 0) {
+      bridge.connectFailuresRemaining -= 1;
+      throw new Error("connect failed");
+    }
     bridge.channel = onMessage;
     return `tracker-connection-${bridge.connect.mock.calls.length}`;
   }),
@@ -72,6 +77,7 @@ describe("CodexThreadTracker", () => {
     bridge.parents = {};
     bridge.pendingReads = false;
     bridge.selectedThread = null;
+    bridge.connectFailuresRemaining = 0;
     bridge.readResponders = [];
     bridge.disconnect.mockClear();
     bridge.connect.mockClear();
@@ -108,7 +114,7 @@ describe("CodexThreadTracker", () => {
     tracker.stop();
   });
 
-  it("tracks the top-level thread loaded by /resume from its status notification", async () => {
+  it("does not infer TUI ownership from a generic top-level status notification", async () => {
     const changes: Array<string | null> = [];
     const tracker = new CodexThreadTracker("main-session", (threadId) => changes.push(threadId));
     await tracker.start();
@@ -120,13 +126,14 @@ describe("CodexThreadTracker", () => {
         params: { threadId: "thread-after-resume", status: { type: "idle" } },
       }),
     );
-    await vi.waitFor(() => expect(tracker.getCurrentThreadId()).toBe("thread-after-resume"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(changes).toEqual(["thread-1", "thread-after-resume"]);
+    expect(tracker.getCurrentThreadId()).toBe("thread-1");
+    expect(changes).toEqual(["thread-1"]);
     tracker.stop();
   });
 
-  it("tracks a grace-period loaded /resume target when its next turn becomes active", async () => {
+  it("does not infer TUI ownership when another loaded top-level thread becomes active", async () => {
     bridge.loadedThreads = ["thread-1", "thread-2"];
     const tracker = new CodexThreadTracker("main-session");
     await tracker.start();
@@ -147,7 +154,48 @@ describe("CodexThreadTracker", () => {
         params: { threadId: "thread-2", status: { type: "active", activeFlags: [] } },
       }),
     );
-    await vi.waitFor(() => expect(tracker.getCurrentThreadId()).toBe("thread-2"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(tracker.getCurrentThreadId()).toBeNull();
+    tracker.stop();
+  });
+
+  it("ignores side-fork started and status signals without retargeting active voice", async () => {
+    const changes: Array<string | null> = [];
+    const tracker = new CodexThreadTracker("main-session", (threadId) => changes.push(threadId));
+    await tracker.start();
+
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/started",
+        params: {
+          thread: { id: "side-fork", parentThreadId: null, forkedFromId: "thread-1" },
+        },
+      }),
+    );
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/status/changed",
+        params: { threadId: "side-fork", status: { type: "active", activeFlags: [] } },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(tracker.getCurrentThreadId()).toBe("thread-1");
+    expect(changes).toEqual(["thread-1"]);
+    tracker.stop();
+  });
+
+  it("tracks a normal fork only when the TUI proxy selects it", async () => {
+    bridge.loadedThreads = ["thread-1", "forked-thread"];
+    const changes: Array<string | null> = [];
+    const tracker = new CodexThreadTracker("main-session", (threadId) => changes.push(threadId));
+    await tracker.start();
+    expect(tracker.getCurrentThreadId()).toBeNull();
+
+    bridge.selectedThread = "forked-thread";
+    await vi.waitFor(() => expect(tracker.getCurrentThreadId()).toBe("forked-thread"));
+
+    expect(changes).toEqual(["forked-thread"]);
     tracker.stop();
   });
 
@@ -248,6 +296,23 @@ describe("CodexThreadTracker", () => {
 
     expect(bridge.connect).toHaveBeenCalledTimes(2);
     expect(tracker.getCurrentThreadId()).toBeNull();
+    tracker.stop();
+    vi.useRealTimers();
+  });
+
+  it("starts proxy selection polling after an initial connect failure reconnects", async () => {
+    vi.useFakeTimers();
+    bridge.connectFailuresRemaining = 1;
+    bridge.loadedThreads = ["thread-1", "thread-2"];
+    bridge.selectedThread = "thread-2";
+    const tracker = new CodexThreadTracker("main-session");
+
+    await expect(tracker.start()).rejects.toThrow("connect failed");
+    expect(bridge.connect).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(tracker.getCurrentThreadId()).toBe("thread-2"));
+
+    expect(bridge.connect).toHaveBeenCalledTimes(2);
     tracker.stop();
     vi.useRealTimers();
   });

--- a/src/runtime/codex-realtime/codex-thread-tracker.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.ts
@@ -2,6 +2,7 @@ import { Channel } from "@tauri-apps/api/core";
 import {
   sessionRealtimeConnect,
   sessionRealtimeDisconnect,
+  sessionRealtimeSelectedThread,
   sessionRealtimeSend,
 } from "../../bindings/tauri-commands";
 
@@ -21,6 +22,7 @@ interface JsonRpcMessage {
 
 const RPC_TIMEOUT_MS = 15_000;
 const RECONNECT_DELAY_MS = 250;
+const TUI_SELECTION_POLL_MS = 100;
 
 class TrackerRequestTimeoutError extends Error {}
 
@@ -32,18 +34,27 @@ class TrackerRequestTimeoutError extends Error {}
  */
 export class CodexThreadTracker {
   private readonly sessionId: string;
+  private readonly onCurrentThreadChange: (threadId: string | null) => void;
   private connectionId: string | null = null;
   private nextRequestId = 1;
   private pending = new Map<number, PendingRequest>();
   private currentThreadId: string | null = null;
+  private knownLoadedThreadIds = new Set<string>();
   private epoch = 0;
   private topLevelStartedGeneration = 0;
+  private threadSelectionGeneration = 0;
+  private validatingThreadId: string | null = null;
   private running = false;
   private connecting = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private selectionPollTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(sessionId: string) {
+  constructor(
+    sessionId: string,
+    onCurrentThreadChange: (threadId: string | null) => void = () => {},
+  ) {
     this.sessionId = sessionId;
+    this.onCurrentThreadChange = onCurrentThreadChange;
   }
 
   getCurrentThreadId(): string | null {
@@ -56,6 +67,7 @@ export class CodexThreadTracker {
     const epoch = ++this.epoch;
     try {
       await this.connect(epoch);
+      this.startSelectionPolling(epoch);
     } catch (error) {
       if (epoch === this.epoch && this.running) this.scheduleReconnect(epoch);
       throw error;
@@ -70,9 +82,14 @@ export class CodexThreadTracker {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+    if (this.selectionPollTimer !== null) {
+      clearInterval(this.selectionPollTimer);
+      this.selectionPollTimer = null;
+    }
     const connectionId = this.connectionId;
     this.connectionId = null;
-    this.currentThreadId = null;
+    this.setCurrentThreadId(null);
+    this.knownLoadedThreadIds.clear();
     this.rejectPending(new Error("Codex thread tracker stopped"));
     if (connectionId) void sessionRealtimeDisconnect({ connectionId }).catch(() => {});
   }
@@ -136,6 +153,9 @@ export class CodexThreadTracker {
     if (epoch !== this.epoch || generation !== this.topLevelStartedGeneration) return;
     const ids = result.data;
     if (!Array.isArray(ids)) return;
+    this.knownLoadedThreadIds = new Set(
+      ids.filter((id): id is string => typeof id === "string" && id.length > 0),
+    );
 
     const topLevelIds: string[] = [];
     for (const id of ids) {
@@ -156,8 +176,65 @@ export class CodexThreadTracker {
     // Startup 時に一意なら初期値にできる。複数時は過去の broadcast がないため推測しない。
     const unique = [...new Set(topLevelIds)];
     if (unique.length === 1 && generation === this.topLevelStartedGeneration) {
-      this.currentThreadId = unique[0] ?? null;
+      this.setCurrentThreadId(unique[0] ?? null);
     }
+  }
+
+  private setCurrentThreadId(threadId: string | null): void {
+    if (this.currentThreadId === threadId) return;
+    this.currentThreadId = threadId;
+    this.onCurrentThreadChange(threadId);
+  }
+
+  private startSelectionPolling(epoch: number): void {
+    if (this.selectionPollTimer !== null) return;
+    const poll = (): void => {
+      void sessionRealtimeSelectedThread({ sessionId: this.sessionId })
+        .then((threadId) => {
+          if (epoch !== this.epoch || !this.running || !threadId) return;
+          this.considerStatusThread(threadId, epoch);
+        })
+        .catch(() => {});
+    };
+    poll();
+    this.selectionPollTimer = setInterval(poll, TUI_SELECTION_POLL_MS);
+  }
+
+  /**
+   * TUI proxy selection and lifecycle notifications are both untrusted candidates until
+   * `thread/read` confirms they are loaded top-level threads.
+   */
+  private considerStatusThread(threadId: string, epoch: number): void {
+    if (threadId === this.currentThreadId || threadId === this.validatingThreadId) return;
+    this.validatingThreadId = threadId;
+    const generation = ++this.threadSelectionGeneration;
+    void this.request("thread/read", { threadId, includeTurns: false })
+      .then((read) => {
+        if (
+          epoch !== this.epoch ||
+          !this.running ||
+          generation !== this.threadSelectionGeneration
+        ) {
+          return;
+        }
+        const thread = (read as { readonly thread?: unknown }).thread;
+        if (
+          isRecord(thread) &&
+          thread.id === threadId &&
+          "parentThreadId" in thread &&
+          thread.parentThreadId === null
+        ) {
+          this.setCurrentThreadId(threadId);
+        }
+      })
+      .catch((error) => {
+        if (error instanceof TrackerRequestTimeoutError) {
+          console.warn("[codex-realtime] timed out validating resumed thread", error);
+        }
+      })
+      .finally(() => {
+        if (this.validatingThreadId === threadId) this.validatingThreadId = null;
+      });
   }
 
   private request(method: string, params: Record<string, unknown>): Promise<unknown> {
@@ -205,7 +282,8 @@ export class CodexThreadTracker {
       this.connectionId = null;
       // この接続が見ていない間に /clear された可能性がある。grace period 中の
       // 旧 thread を preferred として再利用せず、再接続後に一意なら再発見する。
-      this.currentThreadId = null;
+      this.setCurrentThreadId(null);
+      this.knownLoadedThreadIds.clear();
       this.rejectPending(new Error("Codex thread tracker connection closed"));
       this.scheduleReconnect(epoch);
       return;
@@ -231,15 +309,45 @@ export class CodexThreadTracker {
         thread.parentThreadId === null
       ) {
         this.topLevelStartedGeneration += 1;
-        this.currentThreadId = thread.id;
+        this.threadSelectionGeneration += 1;
+        this.knownLoadedThreadIds.add(thread.id);
+        this.setCurrentThreadId(thread.id);
       }
+      return;
+    }
+
+    if (message.method === "thread/status/changed") {
+      const params = message.params;
+      if (
+        !isRecord(params) ||
+        typeof params.threadId !== "string" ||
+        params.threadId.length === 0
+      ) {
+        return;
+      }
+      const status = params.status;
+      if (!isRecord(status) || typeof status.type !== "string") return;
+      if (status.type === "notLoaded") {
+        this.knownLoadedThreadIds.delete(params.threadId);
+        if (params.threadId === this.currentThreadId) this.setCurrentThreadId(null);
+        return;
+      }
+      const wasAlreadyLoaded = this.knownLoadedThreadIds.has(params.threadId);
+      this.knownLoadedThreadIds.add(params.threadId);
+      // A cold /resume announces the newly loaded idle thread. If it was already kept loaded
+      // by the grace period, the first reliable ownership signal is its next active turn.
+      if (status.type !== "active" && wasAlreadyLoaded) return;
+      this.considerStatusThread(params.threadId, epoch);
       return;
     }
 
     if (message.method === "thread/closed" || message.method === "thread/deleted") {
       const params = message.params;
+      if (isRecord(params) && typeof params.threadId === "string") {
+        this.knownLoadedThreadIds.delete(params.threadId);
+      }
       if (isRecord(params) && params.threadId === this.currentThreadId) {
-        this.currentThreadId = null;
+        this.setCurrentThreadId(null);
       }
     }
   }

--- a/src/runtime/codex-realtime/codex-thread-tracker.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.ts
@@ -67,7 +67,6 @@ export class CodexThreadTracker {
     const epoch = ++this.epoch;
     try {
       await this.connect(epoch);
-      this.startSelectionPolling(epoch);
     } catch (error) {
       if (epoch === this.epoch && this.running) this.scheduleReconnect(epoch);
       throw error;
@@ -118,6 +117,10 @@ export class CodexThreadTracker {
       if (epoch !== this.epoch || !this.running) return;
       this.notify("initialized", {});
       await this.discoverInitialThread(epoch);
+      if (epoch !== this.epoch || !this.running) return;
+      // Initial connect and every later reconnect share this path. Keep proxy polling alive even
+      // when the first connection attempt failed before start() could install it.
+      this.startSelectionPolling(epoch);
     } catch (error) {
       const connectionId = this.connectionId;
       this.connectionId = null;
@@ -192,7 +195,7 @@ export class CodexThreadTracker {
       void sessionRealtimeSelectedThread({ sessionId: this.sessionId })
         .then((threadId) => {
           if (epoch !== this.epoch || !this.running || !threadId) return;
-          this.considerStatusThread(threadId, epoch);
+          this.considerProxyThread(threadId, epoch);
         })
         .catch(() => {});
     };
@@ -201,10 +204,10 @@ export class CodexThreadTracker {
   }
 
   /**
-   * TUI proxy selection and lifecycle notifications are both untrusted candidates until
-   * `thread/read` confirms they are loaded top-level threads.
+   * TUI proxy selection is authoritative for ownership, but its ID is still validated with
+   * `thread/read` before voice uses it.
    */
-  private considerStatusThread(threadId: string, epoch: number): void {
+  private considerProxyThread(threadId: string, epoch: number): void {
     if (threadId === this.currentThreadId || threadId === this.validatingThreadId) return;
     this.validatingThreadId = threadId;
     const generation = ++this.threadSelectionGeneration;
@@ -306,7 +309,8 @@ export class CodexThreadTracker {
         isRecord(thread) &&
         typeof thread.id === "string" &&
         thread.id.length > 0 &&
-        thread.parentThreadId === null
+        thread.parentThreadId === null &&
+        (!("forkedFromId" in thread) || thread.forkedFromId === null)
       ) {
         this.topLevelStartedGeneration += 1;
         this.threadSelectionGeneration += 1;
@@ -332,12 +336,9 @@ export class CodexThreadTracker {
         if (params.threadId === this.currentThreadId) this.setCurrentThreadId(null);
         return;
       }
-      const wasAlreadyLoaded = this.knownLoadedThreadIds.has(params.threadId);
       this.knownLoadedThreadIds.add(params.threadId);
-      // A cold /resume announces the newly loaded idle thread. If it was already kept loaded
-      // by the grace period, the first reliable ownership signal is its next active turn.
-      if (status.type !== "active" && wasAlreadyLoaded) return;
-      this.considerStatusThread(params.threadId, epoch);
+      // Status is global thread activity, not evidence that the TUI selected this thread. In
+      // particular side forks and other top-level work can become active independently.
       return;
     }
 

--- a/src/runtime/codex-realtime/use-codex-realtime.test.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.test.ts
@@ -60,6 +60,8 @@ function setup(
   setFallbackPlaybackEnabled: (enabled: boolean) => void | Promise<void> = vi.fn(),
 ) {
   const clients: FakeClient[] = [];
+  let trackedThreadId: string | null = "thread-1";
+  let notifyThreadChange: (threadId: string | null) => void = () => {};
   const createClient: CodexRealtimeClientFactory = (_sessionId, onStateChange) => {
     const startResult = starts[clients.length] ?? Promise.resolve();
     const client = new FakeClient(onStateChange, startResult);
@@ -77,15 +79,28 @@ function setup(
         applyLipSyncSource,
         setFallbackPlaybackEnabled,
         createClient,
-        createThreadTracker: () => ({
-          getCurrentThreadId: () => null,
-          start: async () => {},
-          stop: () => {},
-        }),
+        createThreadTracker: (_sessionId, onCurrentThreadChange) => {
+          notifyThreadChange = onCurrentThreadChange;
+          return {
+            getCurrentThreadId: () => trackedThreadId,
+            start: async () => {},
+            stop: () => {},
+          };
+        },
       }),
     { initialProps: { sessionId: "main", available: true } },
   );
-  return { ...hook, clients, fallback, applyLipSyncSource, setFallbackPlaybackEnabled };
+  return {
+    ...hook,
+    clients,
+    fallback,
+    applyLipSyncSource,
+    setFallbackPlaybackEnabled,
+    changeThread: (threadId: string | null) => {
+      trackedThreadId = threadId;
+      notifyThreadChange(threadId);
+    },
+  };
 }
 
 describe("useCodexRealtime", () => {
@@ -239,6 +254,37 @@ describe("useCodexRealtime", () => {
       await firstStart.promise.catch(() => {});
     });
     expect(result.current.state.status).toBe("active");
+  });
+
+  it("/clear または /resume で current thread が変わると active voice を再接続する", async () => {
+    const { result, clients, changeThread } = setup([Promise.resolve(), Promise.resolve()]);
+
+    await act(async () => {
+      await result.current.toggle();
+    });
+    act(() => clients[0].emit({ status: "active", billing: "subscription" }));
+
+    await act(async () => {
+      changeThread("thread-2");
+      await vi.waitFor(() => expect(clients).toHaveLength(2));
+    });
+
+    expect(clients[0].stop).toHaveBeenCalledTimes(1);
+    expect(clients[1].start).toHaveBeenCalledTimes(1);
+  });
+
+  it("current thread を特定できなくなった場合は active voice を切断する", async () => {
+    const { result, clients, changeThread } = setup([Promise.resolve()]);
+
+    await act(async () => {
+      await result.current.toggle();
+    });
+    act(() => clients[0].emit({ status: "active", billing: "subscription" }));
+    act(() => changeThread(null));
+
+    expect(clients[0].stop).toHaveBeenCalledTimes(1);
+    expect(clients).toHaveLength(1);
+    expect(result.current.state).toEqual({ status: "idle" });
   });
 
   it("明示stopを先に所有権解除し、後着のclosed/error通知をidleへ戻さない", async () => {

--- a/src/runtime/codex-realtime/use-codex-realtime.test.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.test.ts
@@ -34,13 +34,17 @@ class FakeClient implements CodexRealtimeClientLike {
   constructor(
     private readonly onStateChange: (state: CodexRealtimeState) => void,
     private readonly startResult: Promise<void>,
+    private readonly getPreferredThreadId: () => string | null,
   ) {}
+
+  preferredThreadIdAtStart: string | null = null;
 
   getStatus(): CodexRealtimeState["status"] {
     return this.status;
   }
 
   readonly start = vi.fn((): Promise<void> => {
+    this.preferredThreadIdAtStart = this.getPreferredThreadId();
     this.emit({ status: "connecting" });
     return this.startResult;
   });
@@ -62,9 +66,14 @@ function setup(
   const clients: FakeClient[] = [];
   let trackedThreadId: string | null = "thread-1";
   let notifyThreadChange: (threadId: string | null) => void = () => {};
-  const createClient: CodexRealtimeClientFactory = (_sessionId, onStateChange) => {
+  const createClient: CodexRealtimeClientFactory = (
+    _sessionId,
+    onStateChange,
+    _stateExpressionCallbacks,
+    getPreferredThreadId = () => null,
+  ) => {
     const startResult = starts[clients.length] ?? Promise.resolve();
-    const client = new FakeClient(onStateChange, startResult);
+    const client = new FakeClient(onStateChange, startResult, getPreferredThreadId);
     clients.push(client);
     return client;
   };
@@ -271,6 +280,7 @@ describe("useCodexRealtime", () => {
 
     expect(clients[0].stop).toHaveBeenCalledTimes(1);
     expect(clients[1].start).toHaveBeenCalledTimes(1);
+    expect(clients[1].preferredThreadIdAtStart).toBe("thread-2");
   });
 
   it("current thread を特定できなくなった場合は active voice を切断する", async () => {

--- a/src/runtime/codex-realtime/use-codex-realtime.ts
+++ b/src/runtime/codex-realtime/use-codex-realtime.ts
@@ -35,7 +35,10 @@ interface UseCodexRealtimeOptions {
   readonly setFallbackPlaybackEnabled?: (enabled: boolean) => void | Promise<void>;
   readonly stateExpressionCallbacks?: StateExpressionSchedulerCallbacks;
   readonly createClient?: CodexRealtimeClientFactory;
-  readonly createThreadTracker?: (sessionId: string) => CodexThreadTrackerLike;
+  readonly createThreadTracker?: (
+    sessionId: string,
+    onCurrentThreadChange: (threadId: string | null) => void,
+  ) => CodexThreadTrackerLike;
 }
 
 interface UseCodexRealtimeResult {
@@ -56,8 +59,10 @@ const defaultCreateClient: CodexRealtimeClientFactory = (
     getPreferredThreadId,
   });
 
-const defaultCreateThreadTracker = (sessionId: string): CodexThreadTrackerLike =>
-  new CodexThreadTracker(sessionId);
+const defaultCreateThreadTracker = (
+  sessionId: string,
+  onCurrentThreadChange: (threadId: string | null) => void,
+): CodexThreadTrackerLike => new CodexThreadTracker(sessionId, onCurrentThreadChange);
 
 const FALLBACK_RESTORE_RETRY_DELAYS_MS = [50, 200] as const;
 
@@ -144,12 +149,8 @@ export function useCodexRealtime({
     restoreFallback();
   }, [restoreFallback, restoreFallbackPlayback]);
 
-  const toggle = useCallback(async () => {
-    if (clientRef.current) {
-      stop();
-      return;
-    }
-
+  const start = useCallback(async () => {
+    if (clientRef.current) return;
     let client: CodexRealtimeClientLike;
     client = createClientRef.current(
       sessionId,
@@ -208,8 +209,15 @@ export function useCodexRealtime({
     restoreFallbackPlayback,
     sessionId,
     stateExpressionCallbacks,
-    stop,
   ]);
+
+  const toggle = useCallback(async () => {
+    if (clientRef.current) {
+      stop();
+      return;
+    }
+    await start();
+  }, [start, stop]);
 
   useEffect(() => {
     const sessionChanged = sessionIdRef.current !== sessionId;
@@ -221,7 +229,12 @@ export function useCodexRealtime({
     threadTrackerRef.current?.stop();
     threadTrackerRef.current = null;
     if (!available) return;
-    const tracker = createThreadTracker(sessionId);
+    let tracker: CodexThreadTrackerLike;
+    tracker = createThreadTracker(sessionId, (threadId) => {
+      if (threadTrackerRef.current !== tracker || !clientRef.current) return;
+      stop();
+      if (threadId) void start();
+    });
     threadTrackerRef.current = tracker;
     void tracker.start().catch((error) => {
       if (threadTrackerRef.current !== tracker) return;
@@ -231,7 +244,7 @@ export function useCodexRealtime({
       if (threadTrackerRef.current === tracker) threadTrackerRef.current = null;
       tracker.stop();
     };
-  }, [available, createThreadTracker, sessionId]);
+  }, [available, createThreadTracker, sessionId, start, stop]);
 
   useEffect(() => {
     // Re-stamp the default owner after a WebView reload because the Rust MCP process can survive it.


### PR DESCRIPTION
## Summary
- observe successful TUI `thread/start`, `thread/resume`, and main `thread/fork` responses through a host-owned transparent WebSocket proxy
- publish the authoritative TUI-owned thread ID without storing conversation content
- retarget an active realtime voice connection when the selected thread changes
- preserve `/clear` fallback tracking while excluding side-conversation forks
- recover polling after connection failure and fail closed when ownership is unknown

## Security and correctness
- reject Origin-bearing browser WebSocket handshakes at the loopback proxy
- preserve bidirectional JSON-RPC request correlation on ID collisions
- leave approval messages unchanged and retain TUI approval ownership
- use status notifications only for loaded-state bookkeeping, never ownership inference

## Verification
- Rust proxy tests: 6 passed
- focused realtime frontend tests: 29 passed
- TypeScript and Biome passed
- Rust fmt and clippy passed
- pre-push TypeScript, Biome, Rust fmt/clippy, and TypeDoc gates passed
- independent review: all HIGH/MEDIUM findings resolved; documentation aligned

No existing GitHub issue is closed by this PR.