### PR TITLE
feat(ui): clarify GPT Live voice states

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -140,14 +140,12 @@ body,
 }
 
 /*
- * GPT Live 音声会話ボタンの状態語彙。色相だけに頼らず、active は塗り+枠の
- * 明度差、connecting はアイコン形状（スピナー）、error は失敗の赤系
- * （tab-indicator の失敗と同系）でも区別できるようにする。
+ * GPT Live 音声会話ボタンの状態語彙。active は theme accent のアイコン色、
+ * connecting はアイコン形状（スピナー）、error は失敗の赤系
+ * （tab-indicator の失敗と同系）と隣接テキストで区別する。
  */
 .title-bar-voice-button[data-voice-state="active"] {
   color: var(--yorishiro-accent);
-  border-color: var(--yorishiro-accent-border);
-  background: var(--yorishiro-accent-soft);
 }
 
 .title-bar-voice-button[data-voice-state="active"] svg,

--- a/src/App.css
+++ b/src/App.css
@@ -145,10 +145,27 @@ body,
  * （tab-indicator の失敗と同系）と隣接テキストで区別する。
  */
 .title-bar-voice-button[data-voice-state="active"] {
-  color: color-mix(in srgb, var(--yorishiro-accent) 78%, white);
+  position: relative;
+  color: color-mix(in srgb, var(--yorishiro-accent) 60%, white);
 }
 
-.title-bar-voice-button[data-voice-state="active"] svg,
+.title-bar-voice-button[data-voice-state="active"] svg {
+  opacity: 1;
+  filter: drop-shadow(0 0 3px color-mix(in srgb, var(--yorishiro-accent) 55%, transparent));
+}
+
+.title-bar-voice-status-dot {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 4px color-mix(in srgb, var(--yorishiro-accent) 70%, transparent);
+  pointer-events: none;
+}
+
 .title-bar-voice-button[data-voice-state="error"] svg {
   opacity: 1;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -145,7 +145,7 @@ body,
  * （tab-indicator の失敗と同系）と隣接テキストで区別する。
  */
 .title-bar-voice-button[data-voice-state="active"] {
-  color: var(--yorishiro-accent);
+  color: color-mix(in srgb, var(--yorishiro-accent) 78%, white);
 }
 
 .title-bar-voice-button[data-voice-state="active"] svg,

--- a/src/App.css
+++ b/src/App.css
@@ -140,18 +140,17 @@ body,
 }
 
 /*
- * GPT Live 音声会話ボタンの状態語彙。active は theme accent のアイコン色、
+ * GPT Live 音声会話ボタンの状態語彙。active は明るいアイコン＋送話中の赤い点、
  * connecting はアイコン形状（スピナー）、error は失敗の赤系
  * （tab-indicator の失敗と同系）と隣接テキストで区別する。
  */
 .title-bar-voice-button[data-voice-state="active"] {
   position: relative;
-  color: color-mix(in srgb, var(--yorishiro-accent) 60%, white);
+  color: #f0f0f0;
 }
 
 .title-bar-voice-button[data-voice-state="active"] svg {
   opacity: 1;
-  filter: drop-shadow(0 0 3px color-mix(in srgb, var(--yorishiro-accent) 55%, transparent));
 }
 
 .title-bar-voice-status-dot {
@@ -161,8 +160,8 @@ body,
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: currentColor;
-  box-shadow: 0 0 4px color-mix(in srgb, var(--yorishiro-accent) 70%, transparent);
+  background: #ff5f5f;
+  box-shadow: 0 0 4px rgba(255, 95, 95, 0.65);
   pointer-events: none;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -119,7 +119,7 @@ body,
 }
 
 .title-bar-button svg {
-  opacity: 0.68;
+  opacity: 0.82;
   transition: opacity 0.15s;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -139,12 +139,40 @@ body,
   color: #f0f0f0;
 }
 
-.title-bar-voice-button.is-active {
-  color: #8bd7ff;
+/*
+ * GPT Live 音声会話ボタンの状態語彙。色相だけに頼らず、active は塗り+枠の
+ * 明度差、connecting はアイコン形状（スピナー）、error は失敗の赤系
+ * （tab-indicator の失敗と同系）でも区別できるようにする。
+ */
+.title-bar-voice-button[data-voice-state="active"] {
+  color: var(--yorishiro-accent);
+  border-color: var(--yorishiro-accent-border);
+  background: var(--yorishiro-accent-soft);
 }
 
-.title-bar-voice-button.is-busy svg {
+.title-bar-voice-button[data-voice-state="active"] svg,
+.title-bar-voice-button[data-voice-state="error"] svg {
+  opacity: 1;
+}
+
+.title-bar-voice-button[data-voice-state="connecting"] svg {
   animation: title-bar-voice-spin 0.9s linear infinite;
+}
+
+.title-bar-voice-button[data-voice-state="error"] {
+  color: #ffb8b8;
+  border-color: rgba(255, 95, 95, 0.36);
+}
+
+.title-bar-voice-button[data-voice-state="error"]:hover,
+.title-bar-voice-button[data-voice-state="error"]:focus-visible {
+  color: #ffd2d2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .title-bar-voice-button[data-voice-state="connecting"] svg {
+    animation: none;
+  }
 }
 
 .title-bar-voice-billing {

--- a/src/App.css
+++ b/src/App.css
@@ -119,7 +119,7 @@ body,
 }
 
 .title-bar-button svg {
-  opacity: 0.82;
+  opacity: 0.68;
   transition: opacity 0.15s;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4479,21 +4479,20 @@ function App() {
         onToggleSidebar={handleToggleSidebar}
         onOpenSettings={handleOpenSettings}
         voiceAvailable={voiceEntryAvailable}
-        voiceActive={codexRealtimeState.status === "active"}
-        voiceBusy={codexRealtimeState.status === "connecting"}
+        voiceState={codexRealtimeState.status}
         voiceLabel={
           codexRealtimeState.status === "active"
-            ? strings.codexVoiceStop
+            ? strings.gptLiveVoiceStop
             : codexRealtimeState.status === "connecting"
-              ? strings.codexVoiceConnecting
+              ? strings.gptLiveVoiceConnecting
               : codexRealtimeState.status === "error"
-                ? strings.codexVoiceRetry
-                : strings.codexVoiceStart
+                ? strings.gptLiveVoiceRetry
+                : strings.gptLiveVoiceStart
         }
         voiceBillingLabel={
           codexRealtimeState.billing === "api" &&
           (codexRealtimeState.status === "connecting" || codexRealtimeState.status === "active")
-            ? strings.codexVoiceApiBilling
+            ? strings.gptLiveVoiceApiBilling
             : undefined
         }
         voiceError={codexRealtimeState.error}

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -34,11 +34,15 @@ export interface UiStrings {
   readonly voiceFrequency: string;
   readonly voiceOn: string;
   readonly voiceOff: string;
-  readonly codexVoiceStart: string;
-  readonly codexVoiceStop: string;
-  readonly codexVoiceConnecting: string;
-  readonly codexVoiceRetry: string;
-  readonly codexVoiceApiBilling: string;
+  /**
+   * GPT Live 音声会話ボタンの tooltip / aria-label。ユーザー向け文言は provider
+   * （Codex）ではなく「GPT Liveの音声会話」で統一する。
+   */
+  readonly gptLiveVoiceStart: string;
+  readonly gptLiveVoiceStop: string;
+  readonly gptLiveVoiceConnecting: string;
+  readonly gptLiveVoiceRetry: string;
+  readonly gptLiveVoiceApiBilling: string;
   readonly gptLiveRequiresCodex: string;
   readonly gptLiveSwitchBody: string;
   readonly gptLiveSetupBody: string;
@@ -163,11 +167,11 @@ const EN: UiStrings = {
   voiceFrequency: "Voice Summary",
   voiceOn: "On",
   voiceOff: "Off",
-  codexVoiceStart: "Start Codex voice",
-  codexVoiceStop: "Stop Codex voice",
-  codexVoiceConnecting: "Connecting Codex voice…",
-  codexVoiceRetry: "Retry Codex voice",
-  codexVoiceApiBilling: "API billing",
+  gptLiveVoiceStart: "Start GPT Live voice conversation",
+  gptLiveVoiceStop: "Stop GPT Live voice conversation",
+  gptLiveVoiceConnecting: "Connecting GPT Live voice conversation… (click to cancel)",
+  gptLiveVoiceRetry: "Retry GPT Live voice conversation",
+  gptLiveVoiceApiBilling: "API billing",
   gptLiveRequiresCodex: "Voice conversation (GPT Live) currently requires Codex",
   gptLiveSwitchBody:
     "Your current Main Agent does not support voice conversation. Switch to Codex and start a voice conversation? Your current conversation and work state are preserved, and switching back to the original agent resumes where you left off.",
@@ -290,14 +294,14 @@ const JA: UiStrings = {
   voiceFrequency: "Voice Summary",
   voiceOn: "On",
   voiceOff: "Off",
-  codexVoiceStart: "Codex 音声会話を始める",
-  codexVoiceStop: "Codex 音声会話を終了",
-  codexVoiceConnecting: "Codex 音声会話に接続中…",
-  codexVoiceRetry: "Codex 音声会話を再試行",
-  codexVoiceApiBilling: "API従量課金",
-  gptLiveRequiresCodex: "音声対話（GPT Live）の利用には、現在Codexが必要です",
+  gptLiveVoiceStart: "GPT Liveの音声会話を始める",
+  gptLiveVoiceStop: "GPT Liveの音声会話を終了",
+  gptLiveVoiceConnecting: "GPT Liveの音声会話に接続中…（クリックで中止）",
+  gptLiveVoiceRetry: "GPT Liveの音声会話を再試行",
+  gptLiveVoiceApiBilling: "API従量課金",
+  gptLiveRequiresCodex: "音声会話（GPT Live）の利用には、現在Codexが必要です",
   gptLiveSwitchBody:
-    "現在のメインエージェントは音声対話に対応していません。Codexへ切り替えて、音声対話を始めますか？現在の会話と作業状態は保持され、元のエージェントへ戻すと続きから再開できます。",
+    "現在のメインエージェントは音声会話に対応していません。Codexへ切り替えて、音声会話を始めますか？現在の会話と作業状態は保持され、元のエージェントへ戻すと続きから再開できます。",
   gptLiveSetupBody:
     "Codex CLIをインストールし、ChatGPTでサインイン（またはAPIキーを設定）してから、SettingsでMain AgentにCodexを選んでください。",
   gptLiveCancel: "キャンセル",

--- a/src/title-bar.test.tsx
+++ b/src/title-bar.test.tsx
@@ -148,6 +148,7 @@ describe("TitleBar", () => {
     expect(button.getAttribute("aria-pressed")).toBe("true");
     expect(button.querySelector(".lucide-mic")).toBeTruthy();
     expect(button.querySelector(".lucide-mic-off")).toBeNull();
+    expect(button.querySelector(".title-bar-voice-status-dot")).toBeTruthy();
   });
 
   it("exposes the error state for retry with an alert message", () => {

--- a/src/title-bar.test.tsx
+++ b/src/title-bar.test.tsx
@@ -78,7 +78,7 @@ describe("TitleBar", () => {
     expect(screen.getByRole("button", { name: "shell-1" })).toBeTruthy();
   });
 
-  it("shows the Codex voice control only when available", () => {
+  it("shows the GPT Live voice control only when available", () => {
     const onToggleVoice = vi.fn();
     const { rerender } = renderTitleBar();
     expect(screen.queryByRole("button", { name: "Start voice" })).toBeNull();
@@ -90,7 +90,7 @@ describe("TitleBar", () => {
         sidebarLabel="Sidebar"
         settingsLabel="Settings"
         voiceAvailable
-        voiceActive={false}
+        voiceState="idle"
         voiceLabel="Start voice"
         onToggleVoice={onToggleVoice}
         onToggleSidebar={vi.fn()}
@@ -101,23 +101,92 @@ describe("TitleBar", () => {
     expect(onToggleVoice).toHaveBeenCalledTimes(1);
   });
 
-  it("marks the voice control active during a conversation", () => {
+  it("shows a plain unpressed mic while idle", () => {
     renderTitleBar({
       voiceAvailable: true,
-      voiceActive: true,
+      voiceState: "idle",
+      voiceLabel: "Start voice",
+      onToggleVoice: vi.fn(),
+    });
+
+    const button = screen.getByRole("button", { name: "Start voice" });
+    expect(button.getAttribute("data-voice-state")).toBe("idle");
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+    expect(button.getAttribute("aria-busy")).toBeNull();
+    expect(button.querySelector(".lucide-mic")).toBeTruthy();
+    expect(button.querySelector(".lucide-mic-off")).toBeNull();
+  });
+
+  it("shows a spinner and aria-busy while connecting", () => {
+    renderTitleBar({
+      voiceAvailable: true,
+      voiceState: "connecting",
+      voiceLabel: "Connecting voice…",
+      onToggleVoice: vi.fn(),
+    });
+
+    const button = screen.getByRole("button", { name: "Connecting voice…" });
+    expect(button.getAttribute("data-voice-state")).toBe("connecting");
+    expect(button.getAttribute("aria-busy")).toBe("true");
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+    expect(button.querySelector(".lucide-loader-circle")).toBeTruthy();
+    expect(button.querySelector(".lucide-mic")).toBeNull();
+  });
+
+  // active はスラッシュ無しの Mic のまま。MicOff は「ミュート」の慣習アイコンで、
+  // ミュート状態が存在しない現状ではどの状態にも出さない。
+  it("keeps the plain mic (never a slashed mic) while the conversation is live", () => {
+    renderTitleBar({
+      voiceAvailable: true,
+      voiceState: "active",
       voiceLabel: "Stop voice",
       onToggleVoice: vi.fn(),
     });
 
-    expect(screen.getByRole("button", { name: "Stop voice" }).getAttribute("aria-pressed")).toBe(
-      "true",
-    );
+    const button = screen.getByRole("button", { name: "Stop voice" });
+    expect(button.getAttribute("data-voice-state")).toBe("active");
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    expect(button.querySelector(".lucide-mic")).toBeTruthy();
+    expect(button.querySelector(".lucide-mic-off")).toBeNull();
+  });
+
+  it("exposes the error state for retry with an alert message", () => {
+    renderTitleBar({
+      voiceAvailable: true,
+      voiceState: "error",
+      voiceLabel: "Retry voice",
+      voiceError: "connection failed",
+      onToggleVoice: vi.fn(),
+    });
+
+    const button = screen.getByRole("button", { name: "Retry voice" });
+    expect(button.getAttribute("data-voice-state")).toBe("error");
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+    expect(button.querySelector(".lucide-mic")).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toBe("connection failed");
+  });
+
+  // 回転 animation は CSS class（data-voice-state="connecting"）にだけ紐づける。
+  // inline style で animation を焼き込むと prefers-reduced-motion の media query で
+  // 止められなくなる。
+  it("does not inline animation styles so reduced-motion CSS can disable the spinner", () => {
+    renderTitleBar({
+      voiceAvailable: true,
+      voiceState: "connecting",
+      voiceLabel: "Connecting voice…",
+      onToggleVoice: vi.fn(),
+    });
+
+    const svg = screen
+      .getByRole("button", { name: "Connecting voice…" })
+      .querySelector(".lucide-loader-circle");
+    expect(svg?.getAttribute("style") ?? "").not.toContain("animation");
   });
 
   it("shows API billing only when the voice session uses API-key auth", () => {
     const { rerender } = renderTitleBar({
       voiceAvailable: true,
-      voiceActive: true,
+      voiceState: "active",
       voiceLabel: "Stop voice",
       onToggleVoice: vi.fn(),
     });
@@ -131,7 +200,7 @@ describe("TitleBar", () => {
         sidebarLabel="Sidebar"
         settingsLabel="Settings"
         voiceAvailable
-        voiceActive
+        voiceState="active"
         voiceLabel="Stop voice"
         voiceBillingLabel="API billing"
         onToggleVoice={vi.fn()}

--- a/src/title-bar.tsx
+++ b/src/title-bar.tsx
@@ -83,6 +83,9 @@ export default function TitleBar({
             ) : (
               <Mic size={15} strokeWidth={1.8} aria-hidden="true" />
             )}
+            {voiceState === "active" ? (
+              <span className="title-bar-voice-status-dot" aria-hidden="true" />
+            ) : null}
           </button>
         ) : null}
         {voiceAvailable && voiceBillingLabel ? (

--- a/src/title-bar.tsx
+++ b/src/title-bar.tsx
@@ -1,5 +1,13 @@
-import { LoaderCircle, Mic, MicOff, PanelLeftClose, PanelLeftOpen, Settings } from "lucide-react";
+import { LoaderCircle, Mic, PanelLeftClose, PanelLeftOpen, Settings } from "lucide-react";
 import type { ReactNode } from "react";
+
+/**
+ * GPT Live 音声会話ボタンの表示状態。realtime client の status をそのまま写す。
+ * スラッシュ付きマイク（MicOff）は「マイクのミュート」を意味する慣習アイコンの
+ * ため、会話が生きている active 状態には使わない。ミュート状態が実装されるまで
+ * MicOff はこのボタンに登場させないこと。
+ */
+export type VoiceControlState = "idle" | "connecting" | "active" | "error";
 
 export interface TitleBarProps {
   readonly onToggleSidebar: () => void;
@@ -9,8 +17,7 @@ export interface TitleBarProps {
   readonly settingsLabel: string;
   readonly sidebarLabel: string;
   readonly voiceAvailable?: boolean;
-  readonly voiceActive?: boolean;
-  readonly voiceBusy?: boolean;
+  readonly voiceState?: VoiceControlState;
   readonly voiceLabel?: string;
   readonly voiceBillingLabel?: string;
   readonly voiceError?: string;
@@ -26,8 +33,7 @@ export default function TitleBar({
   settingsLabel,
   sidebarLabel,
   voiceAvailable = false,
-  voiceActive = false,
-  voiceBusy = false,
+  voiceState = "idle",
   voiceLabel = "",
   voiceBillingLabel,
   voiceError,
@@ -64,18 +70,16 @@ export default function TitleBar({
         {voiceAvailable ? (
           <button
             type="button"
-            className={`title-bar-button title-bar-voice-button${
-              voiceActive ? " is-active" : ""
-            }${voiceBusy ? " is-busy" : ""}`}
+            className="title-bar-button title-bar-voice-button"
+            data-voice-state={voiceState}
             onClick={onToggleVoice}
             aria-label={voiceLabel}
-            aria-pressed={voiceActive}
+            aria-pressed={voiceState === "active"}
+            aria-busy={voiceState === "connecting" || undefined}
             title={voiceLabel}
           >
-            {voiceBusy ? (
+            {voiceState === "connecting" ? (
               <LoaderCircle size={15} strokeWidth={1.8} aria-hidden="true" />
-            ) : voiceActive ? (
-              <MicOff size={15} strokeWidth={1.8} aria-hidden="true" />
             ) : (
               <Mic size={15} strokeWidth={1.8} aria-hidden="true" />
             )}
@@ -88,7 +92,7 @@ export default function TitleBar({
         ) : null}
       </div>
       {voiceError ? (
-        <div className="title-bar-voice-error" role="status" title={voiceError}>
+        <div className="title-bar-voice-error" role="alert" title={voiceError}>
           {voiceError}
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

- clarify GPT Live voice states with idle, connecting, active, and error presentations
- show a spinner only while connecting and a bright microphone with a steady red live-audio indicator while connected
- remove the misleading slashed-microphone treatment and active-state frame
- rename user-facing labels from Codex voice conversation to GPT Live voice conversation
- respect `prefers-reduced-motion` and expose state through ARIA attributes and alert text

## Why

The previous active icon used a slashed microphone, which could be read as muted even though audio was live. Color alone was also too subtle in the production UI. The new presentation distinguishes the state by both shape and a small live-audio indicator without adding a disruptive confirmation dialog.

## Validation

- `npm test -- --run src/title-bar.test.tsx` (13 tests)
- `npm run check`
- production macOS `.app` build and manual visual verification
