### PR TITLE
fix(realtime): diagnose and recover GPT Live connection startup

### DIFF
--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -1,7 +1,7 @@
 # Codex realtime voice
 
 **Status**: experimental
-**Last updated**: 2026-08-01
+**Last updated**: 2026-08-03
 
 ## TL;DR
 
@@ -186,6 +186,47 @@ voice approval UIを正式に設計するまではTUIへ委ねる。
 
 Appだけのgeneration guardではlate Rust/WebRTC resourceを閉じられず、clientだけのepochではstale React
 refを解放できないため、この二層を一つに省略しない。
+
+### connection diagnostics / retry / 二重接続防止
+
+Realtime接続は一つの非同期処理ではなく、bridge接続、initialize、account確認、thread discovery、
+microphone取得、WebRTC offer、ICE gathering、`thread/realtime/start`、remote SDP適用という複数段階から
+成る。単一の`Voice connection failed`だけでは原因も復旧可否も判断できないため、接続attemptごとに
+correlation IDとcurrent stageを持つ。
+
+同時に、接続開始の所有権は次の規則で一つに限定する。
+
+- `start()`実行中は同じ`startPromise`を返し、button連打やretry中の手動startで別runを作らない
+- 各run / attemptにepochを発行し、stopやowner切替後に返ったbridge、microphone、RPC、SDP、callbackを
+  staleとして無視する。遅れて取得したresourceはその場で解放する
+- timeout後の古いattemptと新しいattemptが同じfieldやUI stateを書き換えない
+- app / WebView再mount、HMR、manual retry、automatic retryを、同じsingle-owner contractの例外にしない
+
+failureは文字列をそのままUI policyにせず、少なくともpermission、authentication、configuration、
+ownership、timeout、network、remote、unknownへ分類する。timeout、network、一時的なremote failureだけを
+transientとして扱い、短いjitter付きbackoffで最大3 attemptまで再試行する。permission拒否、認証不備、
+invalid configuration、thread ownership ambiguityは自動再試行しない。永久failureをloopさせると、
+permission prompt、microphone取得、server session、課金を意図せず繰り返すためである。
+
+retryは同じconnectionを延命する処理ではなく、前attemptを完全に終了してfresh attemptを作る処理である。
+failure teardownでは、local / remote audio track、data channel、peer connection、Web Audio node、timer、
+pending request、bridge connection、thread ownershipを全て解放する。serverがRealtime startを受理した可能性が
+あり、connection IDとthread IDが判明している場合は、bridge disconnectのfinal messageとして
+`thread/realtime/stop`も送る。client側だけ閉じてserver sessionを残してはならない。
+
+接続成立後のunexpected close、peer failure、playback failureは同じfatal teardownを通すが、現在は
+自動でmicrophoneを再取得しない。backgroundで勝手にcaptureを再開する驚きと無限reconnect loopを避け、
+UIをerrorまたはidleへ戻してuserの明示的な再接続を待つ。将来自動復旧を追加する場合も、voice intent、
+foreground状態、retry budgetを独立して設計し、この境界を暗黙に変えない。
+
+診断はlocalStorageのbounded ring（直近40 record）へ保存し、reloadを跨ぐ調査を可能にする。recordには
+attempt ID、timestamp、stage、finite category/code、elapsed time、retry decision、termination request、
+peer / ICE state、app versionだけを含める。audio、transcript、prompt、tool argument、approval payload、
+credential、SDP / ICE credential、server由来のraw error messageは永続化しない。`negotiated`はremote SDP適用が
+完了したことだけを表し、ICE / peerが実際にconnectedになった証明として扱わない。
+
+この診断は初期の原因調査用であり、通常user向けUIはまだ持たない。設定画面へ表示やcopy/exportを追加する
+場合も、同じallowlist済みstructured recordだけを用い、Web Inspectorのraw logをsupport bundleへ含めない。
 
 ### audio startup order
 

--- a/docs/decisions/codex-realtime-voice.md
+++ b/docs/decisions/codex-realtime-voice.md
@@ -189,6 +189,26 @@ refを解放できないため、この二層を一つに省略しない。
 
 ### connection diagnostics / retry / 二重接続防止
 
+この領域の実装・修正では、個別のfailure caseへの対症療法より、次の4原則を優先する。将来別の
+接続不良を扱う場合も、まずこの原則に沿って原因の観測、resource ownership、復旧方法を設計する。
+
+1. **一つの接続runには一人のownerだけを持たせる。**
+   同時に始まった`start()`、manual retry、automatic retry、late callbackを独立した正当な接続として
+   競合させない。現在のownerだけがresourceとUI stateを変更できる。
+2. **再接続は部分修理による延命ではなく、完全cleanup後の再生成とする。**
+   半壊したpeer、microphone、bridge、server sessionを使い回さない。短い中断より、古い状態を
+   引き継がず確実に正常な状態へ戻ることを優先する。
+3. **自動retryは一時障害だけに限定し、必ず回数上限を持たせる。**
+   timeout、network、一時的なremote failureはfresh attemptで再試行できる。一方、permission、
+   authentication、configuration、ownershipの問題はuser操作や設定変更なしには改善しないため繰り返さない。
+4. **診断は接続stageを正本とし、privacy-safeな構造化情報だけを残す。**
+   共通のerror messageだけで判断せず、attempt、stage、category、retry decisionを記録する。ただし
+   audio、transcript、prompt、credential、server由来のraw messageは診断のためにも永続化しない。
+
+この4原則は、現在の実装方式を説明するだけでなく、今後のconnection recovery変更をreviewする際の
+判断基準である。例外を設ける場合は、途切れの短縮とownership・cleanup・privacyのどれを交換条件にするかを
+新しいDecisionで明示する。
+
 Realtime接続は一つの非同期処理ではなく、bridge接続、initialize、account確認、thread discovery、
 microphone取得、WebRTC offer、ICE gathering、`thread/realtime/start`、remote SDP適用という複数段階から
 成る。単一の`Voice connection failed`だけでは原因も復旧可否も判断できないため、接続attemptごとに

--- a/src/runtime/codex-realtime/codex-realtime-client.test.ts
+++ b/src/runtime/codex-realtime/codex-realtime-client.test.ts
@@ -8,6 +8,7 @@ import {
   type CodexRealtimeState,
   type CodexRealtimeVoiceFallback,
 } from "./codex-realtime-client";
+import { readRealtimeDiagnostics } from "./realtime-diagnostics";
 
 interface FakeChannel<T> {
   onmessage: (message: T) => void;
@@ -28,7 +29,9 @@ const bridge = vi.hoisted(() => ({
     return bridge.connectPromise ? await bridge.connectPromise : "connection-1";
   }),
   connectPromise: null as Promise<string> | null,
-  disconnect: vi.fn(async () => {}),
+  disconnect: vi.fn(
+    async (_args?: { readonly connectionId: string; readonly finalMessage?: string }) => {},
+  ),
   accountType: "chatgpt",
   accountPrelude: null as "server-request" | "id-only" | "error-response" | null,
   loadedThreadResponses: [] as string[][],
@@ -36,6 +39,7 @@ const bridge = vi.hoisted(() => ({
   threadReadFailures: {} as Record<string, number>,
   /** voice → error message。entry がある voice の thread/realtime/start を error 応答にする。 */
   realtimeStartErrors: {} as Record<string, string>,
+  suppressRealtimeSdp: false,
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -126,14 +130,16 @@ vi.mock("../../bindings/tauri-commands", () => ({
           return;
         }
         respond({});
-        queueMicrotask(() => {
-          bridge.channel?.onmessage(
-            JSON.stringify({
-              method: "thread/realtime/sdp",
-              params: { threadId: "thread-1", sdp: "remote-answer" },
-            }),
-          );
-        });
+        if (!bridge.suppressRealtimeSdp) {
+          queueMicrotask(() => {
+            bridge.channel?.onmessage(
+              JSON.stringify({
+                method: "thread/realtime/sdp",
+                params: { threadId: "thread-1", sdp: "remote-answer" },
+              }),
+            );
+          });
+        }
       } else {
         respond({});
       }
@@ -208,6 +214,7 @@ describe("CodexRealtimeClient", () => {
   let microphoneTrack: FakeAudioTrack;
 
   beforeEach(() => {
+    localStorage.clear();
     microphoneTrack = new FakeAudioTrack();
     vi.stubGlobal("MediaStream", FakeMediaStream);
     vi.stubGlobal("RTCPeerConnection", FakePeerConnection);
@@ -224,6 +231,7 @@ describe("CodexRealtimeClient", () => {
     vi.mocked(ensureAudioContextRunning).mockResolvedValue({} as AudioContext);
     bridge.threadReadFailures = {};
     bridge.realtimeStartErrors = {};
+    bridge.suppressRealtimeSdp = false;
     Object.defineProperty(navigator, "mediaDevices", {
       configurable: true,
       value: {
@@ -709,6 +717,20 @@ describe("CodexRealtimeClient", () => {
     expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
     expect(bridge.sent.some((message) => message.method === "thread/realtime/start")).toBe(false);
     expect(client.getStatus()).toBe("error");
+    expect(readRealtimeDiagnostics()).toEqual([
+      expect.objectContaining({
+        attemptId: expect.any(String),
+        event: "started",
+        stage: "preflight",
+      }),
+      expect.objectContaining({
+        event: "failed",
+        stage: "thread-discovery",
+        category: "ownership",
+        retryDecision: "none",
+        terminationRequested: false,
+      }),
+    ]);
   });
 
   it("uses the tracker-selected top-level thread while a cleared thread remains loaded", async () => {
@@ -739,6 +761,7 @@ describe("CodexRealtimeClient", () => {
 
   it("disconnects a bridge connection that arrives after the connect timeout", async () => {
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
     let resolveConnection: ((connectionId: string) => void) | undefined;
     bridge.connectPromise = new Promise((resolve) => {
       resolveConnection = resolve;
@@ -748,13 +771,144 @@ describe("CodexRealtimeClient", () => {
 
     await vi.advanceTimersByTimeAsync(0);
     expect(bridge.connect).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(15_000);
+    // Three bounded attempts: 15s timeout, then 0.5s / 1.5s backoff.
+    await vi.advanceTimersByTimeAsync(47_000);
     expect(await result).toEqual(new Error("Codex app-server connection timed out"));
 
     resolveConnection?.("late-connection");
     await vi.advanceTimersByTimeAsync(0);
     expect(bridge.disconnect).toHaveBeenCalledWith({ connectionId: "late-connection" });
+    expect(bridge.connect).toHaveBeenCalledTimes(3);
     expect(client.getStatus()).toBe("error");
+  });
+
+  it("cancels a pending transient retry when explicitly stopped", async () => {
+    vi.useFakeTimers();
+    vi.mocked(ensureAudioContextRunning).mockRejectedValueOnce(
+      new Error("network connection failed"),
+    );
+    const client = new CodexRealtimeClient("main-session");
+    const result = client.start().catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(client.getStatus()).toBe("connecting");
+    expect(ensureAudioContextRunning).toHaveBeenCalledTimes(1);
+
+    client.stop();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await result).toBeInstanceOf(Error);
+    expect(ensureAudioContextRunning).toHaveBeenCalledTimes(1);
+    expect(client.getStatus()).toBe("idle");
+  });
+
+  it("deduplicates start calls while a transient retry is pending", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    vi.mocked(ensureAudioContextRunning).mockRejectedValueOnce(
+      new Error("network connection failed"),
+    );
+    const client = new CodexRealtimeClient("main-session");
+    const first = client.start();
+    const second = client.start();
+
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.all([first, second]);
+
+    expect(ensureAudioContextRunning).toHaveBeenCalledTimes(2);
+    expect(bridge.connect).toHaveBeenCalledTimes(1);
+    expect(client.getStatus()).toBe("active");
+    client.stop();
+  });
+
+  it("sends realtime stop before retrying after an accepted start times out", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    bridge.suppressRealtimeSdp = true;
+    const client = new CodexRealtimeClient("main-session");
+    const result = client.start().catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(47_000);
+    expect(await result).toEqual(new Error("Codex realtime SDP answer timed out"));
+    expect(bridge.disconnect).toHaveBeenCalledTimes(3);
+    for (const call of bridge.disconnect.mock.calls) {
+      expect(call[0]).toEqual(
+        expect.objectContaining({
+          finalMessage: expect.stringContaining('"method":"thread/realtime/stop"'),
+        }),
+      );
+    }
+  });
+
+  it("fully tears down an active session after a remote error", async () => {
+    const client = new CodexRealtimeClient("main-session");
+    await client.start();
+    const peer = FakePeerConnection.latest;
+    const channel = peer?.channel;
+
+    bridge.channel?.onmessage(
+      JSON.stringify({
+        method: "thread/realtime/error",
+        params: { message: "remote failed token=must-not-be-persisted" },
+      }),
+    );
+
+    expect(client.getStatus()).toBe("error");
+    expect(microphoneTrack.stop).toHaveBeenCalledTimes(1);
+    expect(peer?.close).toHaveBeenCalledTimes(1);
+    expect(channel?.close).toHaveBeenCalledTimes(1);
+    expect(bridge.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: "connection-1",
+        finalMessage: expect.stringContaining('"method":"thread/realtime/stop"'),
+      }),
+    );
+    expect(JSON.stringify(readRealtimeDiagnostics())).not.toContain("must-not-be-persisted");
+  });
+
+  it("fully tears down an active session after peer connection failure", async () => {
+    const client = new CodexRealtimeClient("main-session");
+    await client.start();
+    const peer = FakePeerConnection.latest;
+    Object.defineProperty(peer, "connectionState", { configurable: true, value: "failed" });
+
+    peer?.dispatchEvent(new Event("connectionstatechange"));
+
+    expect(client.getStatus()).toBe("error");
+    expect(microphoneTrack.stop).toHaveBeenCalledTimes(1);
+    expect(peer?.close).toHaveBeenCalledTimes(1);
+    expect(bridge.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        finalMessage: expect.stringContaining('"method":"thread/realtime/stop"'),
+      }),
+    );
+  });
+
+  it("fully tears down an active session after remote playback setup fails", async () => {
+    const client = new CodexRealtimeClient("main-session");
+    await client.start();
+    const peer = FakePeerConnection.latest;
+    vi.mocked(ensureAudioContextRunning).mockRejectedValueOnce(
+      new Error("audio playback setup failed"),
+    );
+    const remoteTrack = new FakeAudioTrack();
+    const remoteStream = new FakeMediaStream([remoteTrack]);
+    const trackEvent = new Event("track");
+    Object.defineProperties(trackEvent, {
+      streams: { value: [remoteStream] },
+      track: { value: remoteTrack },
+    });
+
+    peer?.dispatchEvent(trackEvent);
+    await vi.waitFor(() => expect(client.getStatus()).toBe("error"));
+
+    expect(microphoneTrack.stop).toHaveBeenCalledTimes(1);
+    expect(remoteTrack.stop).toHaveBeenCalledTimes(1);
+    expect(peer?.close).toHaveBeenCalledTimes(1);
+    expect(bridge.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        finalMessage: expect.stringContaining('"method":"thread/realtime/stop"'),
+      }),
+    );
   });
 
   it("stops microphone tracks returned after stop invalidates the start attempt", async () => {

--- a/src/runtime/codex-realtime/codex-realtime-client.ts
+++ b/src/runtime/codex-realtime/codex-realtime-client.ts
@@ -14,6 +14,13 @@ import {
   type RealtimeStateExpressionControllerOptions,
 } from "../agent-state-expression/controller";
 import type { StateExpressionSchedulerCallbacks } from "../agent-state-expression/scheduler";
+import {
+  appendRealtimeDiagnostic,
+  classifyRealtimeFailure,
+  createRealtimeAttemptId,
+  type RealtimeConnectionStage,
+  realtimeDiagnosticCode,
+} from "./realtime-diagnostics";
 import { isCodexVoiceRejectionMessage } from "./voice-rejection";
 
 export type CodexRealtimeStatus = "idle" | "connecting" | "active" | "error";
@@ -76,11 +83,18 @@ const RPC_TIMEOUT_MS = 15_000;
 const THREAD_DISCOVERY_TIMEOUT_MS = 8_000;
 export const DEFAULT_CODEX_REALTIME_VOICE = "sol";
 const REMOTE_SPEECH_SAMPLE_INTERVAL_MS = 33;
+const START_RETRY_BASE_DELAYS_MS = [500, 1_500] as const;
+const APP_VERSION = "0.6.2";
 
 class StartAttemptCancelledError extends Error {
   constructor() {
     super("Codex realtime start attempt is no longer active");
+    this.name = "StartAttemptCancelledError";
   }
+}
+
+export function realtimeRetryDelay(baseDelayMs: number, random = Math.random): number {
+  return Math.round(baseDelayMs * (0.8 + random() * 0.4));
 }
 
 /**
@@ -109,6 +123,16 @@ export class CodexRealtimeClient implements LipSyncSource {
   private state: CodexRealtimeState = { status: "idle" };
   private stopping = false;
   private startAttemptEpoch = 0;
+  private startRunEpoch = 0;
+  private startPromise: Promise<void> | null = null;
+  private retryWait: {
+    readonly run: number;
+    readonly timeoutId: number;
+    readonly reject: (reason: Error) => void;
+  } | null = null;
+  private currentAttemptId = "";
+  private currentAttemptStartedAt = 0;
+  private currentStage: RealtimeConnectionStage = "preflight";
   private readonly stateExpressionController: RealtimeStateExpressionController | null;
   private readonly getPreferredThreadId: () => string | null;
   private readonly getVoiceCandidates: () => Promise<ReadonlyArray<string>>;
@@ -151,79 +175,111 @@ export class CodexRealtimeClient implements LipSyncSource {
   }
 
   async start(): Promise<void> {
-    if (this.state.status === "connecting" || this.state.status === "active") return;
-    const attempt = ++this.startAttemptEpoch;
-    this.stopping = false;
-    this.setState({ status: "connecting" });
-
+    if (this.state.status === "active") return;
+    if (this.startPromise) return this.startPromise;
+    const promise = this.startWithRetries();
+    this.startPromise = promise;
     try {
-      // Click gesture の直後に resume し、WebKit の autoplay 制限を先に解く。
-      await ensureAudioContextRunning();
-      this.assertAttemptOwner(attempt);
-      await withTimeout(
-        this.connectBridge(attempt),
-        RPC_TIMEOUT_MS,
-        "Codex app-server connection timed out",
-      );
-      this.assertAttemptOwner(attempt);
-      await this.request("initialize", {
-        clientInfo: {
-          name: "yorishiro",
-          title: "Yorishiro",
-          version: "0.6.1",
-        },
-        capabilities: { experimentalApi: true },
-      });
-      this.assertAttemptOwner(attempt);
-      this.notify("initialized", {});
-
-      const account = (await this.request("account/read", { refreshToken: false })) as {
-        readonly account?: { readonly type?: string } | null;
-      };
-      this.assertAttemptOwner(attempt);
-      const billing =
-        account.account?.type === "chatgpt"
-          ? "subscription"
-          : account.account?.type === "apiKey"
-            ? "api"
-            : null;
-      if (!billing) {
-        throw new Error("Voice requires Codex to be signed in with ChatGPT or an API key.");
-      }
-      if (billing === "api") {
-        // API 認証時はマイク取得と realtime 開始より先に UI へ課金モードを通知する。
-        this.setState({ status: "connecting", billing });
-      }
-
-      const threadId = await this.waitForLoadedThread(attempt);
-      this.assertAttemptOwner(attempt);
-      this.threadId = threadId;
-      await this.startWebRtc(threadId, attempt);
-      this.assertAttemptOwner(attempt);
-      this.setState({ status: "active", billing });
-    } catch (error) {
-      if (!this.isAttemptOwner(attempt)) throw error;
-      const message = error instanceof Error ? error.message : String(error);
-      this.invalidateAttempt(attempt);
-      this.stopping = true;
-      this.disposeResources();
-      this.setState({ status: "error", error: message });
-      throw error;
+      await promise;
+    } finally {
+      if (this.startPromise === promise) this.startPromise = null;
     }
   }
 
+  private async startWithRetries(): Promise<void> {
+    const run = ++this.startRunEpoch;
+    this.stopping = false;
+    this.setState({ status: "connecting" });
+    for (let retryIndex = 0; ; retryIndex++) {
+      if (this.startRunEpoch !== run) throw new StartAttemptCancelledError();
+      const attempt = ++this.startAttemptEpoch;
+      this.stopping = false;
+      this.currentAttemptId = createRealtimeAttemptId();
+      this.currentAttemptStartedAt = Date.now();
+      this.currentStage = "preflight";
+      this.recordDiagnostic("started", "none");
+      try {
+        const billing = await this.performStartAttempt(attempt);
+        this.assertAttemptOwner(attempt);
+        // SDP negotiation succeeded. Actual peer connectivity can still fail asynchronously.
+        this.recordDiagnostic("negotiated", "none");
+        this.setState({ status: "active", billing });
+        return;
+      } catch (error) {
+        if (!this.isAttemptOwner(attempt) || this.startRunEpoch !== run) throw error;
+        const classification = classifyRealtimeFailure(error, this.currentStage);
+        const retryBase = classification.retryable
+          ? START_RETRY_BASE_DELAYS_MS[retryIndex]
+          : undefined;
+        this.recordDiagnostic(
+          "failed",
+          retryBase === undefined ? (classification.retryable ? "exhausted" : "none") : "scheduled",
+          error,
+          classification.category,
+        );
+        this.invalidateAttempt(attempt);
+        this.stopping = true;
+        this.disposeResources(this.createStopMessage());
+        this.threadId = null;
+        if (retryBase === undefined) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.setState({ status: "error", error: message });
+          throw error;
+        }
+        await this.waitForRetry(run, realtimeRetryDelay(retryBase));
+      }
+    }
+  }
+
+  private async performStartAttempt(attempt: number): Promise<CodexRealtimeBilling> {
+    await ensureAudioContextRunning();
+    this.assertAttemptOwner(attempt);
+    this.currentStage = "bridge-connect";
+    await withTimeout(
+      this.connectBridge(attempt),
+      RPC_TIMEOUT_MS,
+      "Codex app-server connection timed out",
+    );
+    this.assertAttemptOwner(attempt);
+    this.currentStage = "initialize";
+    await this.request("initialize", {
+      clientInfo: { name: "yorishiro", title: "Yorishiro", version: APP_VERSION },
+      capabilities: { experimentalApi: true },
+    });
+    this.assertAttemptOwner(attempt);
+    this.notify("initialized", {});
+    this.currentStage = "account";
+    const account = (await this.request("account/read", { refreshToken: false })) as {
+      readonly account?: { readonly type?: string } | null;
+    };
+    this.assertAttemptOwner(attempt);
+    const billing =
+      account.account?.type === "chatgpt"
+        ? "subscription"
+        : account.account?.type === "apiKey"
+          ? "api"
+          : null;
+    if (!billing)
+      throw new Error("Voice requires Codex to be signed in with ChatGPT or an API key.");
+    if (billing === "api") this.setState({ status: "connecting", billing });
+    this.currentStage = "thread-discovery";
+    const threadId = await this.waitForLoadedThread(attempt);
+    this.assertAttemptOwner(attempt);
+    this.threadId = threadId;
+    await this.startWebRtc(threadId, attempt);
+    this.assertAttemptOwner(attempt);
+    return billing;
+  }
+
   stop(): void {
+    this.startRunEpoch++;
+    this.cancelRetryWait();
+    // Explicit stop permits an immediate fresh start even if a cancelled browser API
+    // (notably getUserMedia) has not settled yet. Epoch ownership keeps that late work inert.
+    this.startPromise = null;
     this.invalidateAttempt();
     this.stopping = true;
-    const finalMessage =
-      this.connectionId && this.threadId
-        ? JSON.stringify({
-            method: "thread/realtime/stop",
-            id: this.nextRequestId++,
-            params: { threadId: this.threadId },
-          })
-        : undefined;
-    this.disposeResources(finalMessage);
+    this.disposeResources(this.createStopMessage());
     this.threadId = null;
     this.setState({ status: "idle" });
   }
@@ -339,6 +395,7 @@ export class CodexRealtimeClient implements LipSyncSource {
 
   private async startWebRtc(threadId: string, attempt: number): Promise<void> {
     this.assertAttemptOwner(attempt);
+    this.currentStage = "microphone";
     const peer = new RTCPeerConnection();
     this.peer = peer;
     this.remoteStream = new MediaStream();
@@ -354,7 +411,9 @@ export class CodexRealtimeClient implements LipSyncSource {
     });
     peer.addEventListener("connectionstatechange", () => {
       if (this.isAttemptOwner(attempt) && peer.connectionState === "failed") {
-        this.setState({ status: "error", error: `Voice connection ${peer.connectionState}` });
+        const error = new Error(`Voice connection ${peer.connectionState}`);
+        this.currentStage = "peer-connection";
+        this.failActiveAttempt(attempt, error, "network");
       }
     });
 
@@ -375,10 +434,12 @@ export class CodexRealtimeClient implements LipSyncSource {
     }
     this.eventChannel = peer.createDataChannel("oai-events");
 
+    this.currentStage = "webrtc-offer";
     const offer = await peer.createOffer();
     this.assertAttemptOwner(attempt, peer);
     await peer.setLocalDescription(offer);
     this.assertAttemptOwner(attempt, peer);
+    this.currentStage = "ice-gathering";
     await withTimeout(waitForIceGathering(peer), 10_000, "WebRTC ICE gathering timed out");
     this.assertAttemptOwner(attempt, peer);
     const sdp = peer.localDescription?.sdp;
@@ -392,6 +453,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     // （persona override → global → built-in default）で再試行する。認証・接続などの
     // 一般エラーはそのまま投げ、voice fallback で隠さない。
     let remoteSdp: Promise<string> | null = null;
+    this.currentStage = "realtime-start";
     for (let index = 0; index < candidates.length && remoteSdp === null; index++) {
       const voice = candidates[index];
       this.assertAttemptOwner(attempt, peer);
@@ -430,6 +492,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     this.assertAttemptOwner(attempt, peer);
     this.acceptRemoteSdp = null;
     this.rejectRemoteSdp = null;
+    this.currentStage = "sdp-application";
     await peer.setRemoteDescription({ type: "answer", sdp: answerSdp });
     this.assertAttemptOwner(attempt, peer);
   }
@@ -439,6 +502,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     void ensureAudioContextRunning()
       .then((context) => {
         if (!this.isAttemptOwner(attempt) || this.remoteSource) return;
+        this.currentStage = "playback";
         const analyser = LipSyncAnalyser.createAnalyserNode(context);
         const source = context.createMediaStreamSource(stream);
         source.connect(analyser);
@@ -450,8 +514,9 @@ export class CodexRealtimeClient implements LipSyncSource {
       })
       .catch((error) => {
         if (!this.isAttemptOwner(attempt)) return;
-        const message = error instanceof Error ? error.message : String(error);
-        this.setState({ status: "error", error: message });
+        const classification = classifyRealtimeFailure(error, "playback");
+        this.currentStage = "playback";
+        this.failActiveAttempt(attempt, error, classification.category);
       });
   }
 
@@ -536,15 +601,25 @@ export class CodexRealtimeClient implements LipSyncSource {
     } else if (message.method === "thread/realtime/error") {
       const error = new Error(params?.message ?? "Codex realtime conversation failed");
       this.rejectRemoteSdp?.(error);
-      if (!this.stopping) this.setState({ status: "error", error: error.message });
+      if (!this.stopping && this.state.status === "active") {
+        const classification = classifyRealtimeFailure(error, "realtime-start");
+        this.failActiveAttempt(attempt, error, classification.category, "remote-error");
+      }
     } else if (message.method === "thread/realtime/closed" && !this.stopping) {
+      this.recordDiagnostic(
+        "closed",
+        "none",
+        new Error("Codex realtime conversation closed"),
+        "remote",
+      );
       this.invalidateAttempt(attempt);
       this.stopping = true;
-      this.disposeResources();
+      this.disposeResources(this.createStopMessage());
       this.threadId = null;
       this.setState({ status: "idle" });
     } else if (message.method === "yorishiro/realtime-bridge/closed" && !this.stopping) {
       const error = new Error(params?.message ?? "Codex app-server connection closed");
+      this.recordDiagnostic("closed", "none", error, "network");
       this.invalidateAttempt(attempt);
       this.stopping = true;
       this.rejectAllPending(error);
@@ -612,6 +687,81 @@ export class CodexRealtimeClient implements LipSyncSource {
       globalThis.clearInterval(this.remoteSpeechSampleInterval);
       this.remoteSpeechSampleInterval = null;
     }
+  }
+
+  private waitForRetry(run: number, delayMs: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const wait = {
+        run,
+        timeoutId: window.setTimeout(() => {
+          if (this.retryWait === wait) this.retryWait = null;
+          if (this.startRunEpoch !== run) reject(new StartAttemptCancelledError());
+          else resolve();
+        }, delayMs),
+        reject,
+      };
+      this.retryWait = wait;
+    });
+  }
+
+  private cancelRetryWait(): void {
+    const wait = this.retryWait;
+    this.retryWait = null;
+    if (!wait) return;
+    window.clearTimeout(wait.timeoutId);
+    wait.reject(new StartAttemptCancelledError());
+  }
+
+  private failActiveAttempt(
+    attempt: number,
+    error: unknown,
+    category: Parameters<typeof appendRealtimeDiagnostic>[0]["category"],
+    event: "failed" | "remote-error" = "failed",
+  ): void {
+    if (!this.isAttemptOwner(attempt)) return;
+    const message = error instanceof Error ? error.message : String(error);
+    this.recordDiagnostic(event, "none", error, category);
+    this.invalidateAttempt(attempt);
+    this.stopping = true;
+    this.disposeResources(this.createStopMessage());
+    this.threadId = null;
+    // Established-session failures deliberately require a user restart. Automatically
+    // reopening the microphone after a remote disconnect would be surprising and can loop.
+    this.setState({ status: "error", error: message });
+  }
+
+  private createStopMessage(): string | undefined {
+    if (!this.connectionId || !this.threadId) return undefined;
+    return JSON.stringify({
+      method: "thread/realtime/stop",
+      id: this.nextRequestId++,
+      params: { threadId: this.threadId },
+    });
+  }
+
+  private recordDiagnostic(
+    event: "started" | "negotiated" | "failed" | "remote-error" | "closed",
+    retryDecision: "none" | "scheduled" | "exhausted",
+    error?: unknown,
+    category?: Parameters<typeof appendRealtimeDiagnostic>[0]["category"],
+  ): void {
+    appendRealtimeDiagnostic({
+      attemptId: this.currentAttemptId,
+      timestamp: new Date().toISOString(),
+      stage: this.currentStage,
+      event,
+      category,
+      elapsedMs: Math.max(0, Date.now() - this.currentAttemptStartedAt),
+      retryDecision,
+      terminationRequested: this.stopping,
+      peerConnectionState: this.peer?.connectionState,
+      iceConnectionState: this.peer?.iceConnectionState,
+      code:
+        error === undefined || category === undefined
+          ? undefined
+          : realtimeDiagnosticCode(category, this.currentStage),
+      appVersion: APP_VERSION,
+    });
   }
 
   private disposeResources(finalMessage?: string): void {

--- a/src/runtime/codex-realtime/index.ts
+++ b/src/runtime/codex-realtime/index.ts
@@ -6,3 +6,10 @@ export {
   type CodexRealtimeStatus,
   type CodexRealtimeVoiceFallback,
 } from "./codex-realtime-client";
+export {
+  type RealtimeConnectionStage,
+  type RealtimeDiagnosticCode,
+  type RealtimeDiagnosticRecord,
+  type RealtimeFailureCategory,
+  readRealtimeDiagnostics,
+} from "./realtime-diagnostics";

--- a/src/runtime/codex-realtime/realtime-diagnostics.test.ts
+++ b/src/runtime/codex-realtime/realtime-diagnostics.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  appendRealtimeDiagnostic,
+  classifyRealtimeFailure,
+  readRealtimeDiagnostics,
+  realtimeDiagnosticCode,
+} from "./realtime-diagnostics";
+
+describe("realtime diagnostics", () => {
+  beforeEach(() => localStorage.clear());
+
+  it.each([
+    [new DOMException("denied", "NotAllowedError"), "microphone", "permission", false],
+    [new Error("thread/realtime/start timed out"), "realtime-start", "timeout", true],
+    [new Error("Codex app-server connection closed"), "bridge-connect", "network", true],
+    [new Error("service temporarily unavailable (503)"), "realtime-start", "remote", true],
+    [
+      new Error("Multiple top-level Codex threads are loaded"),
+      "thread-discovery",
+      "ownership",
+      false,
+    ],
+    [new Error("Invalid voice: maple"), "realtime-start", "configuration", false],
+  ] as const)("classifies %s", (error, stage, category, retryable) => {
+    expect(classifyRealtimeFailure(error, stage)).toEqual({ category, retryable });
+  });
+
+  it("uses a finite structured code instead of persisting arbitrary error text", () => {
+    const secret = "token=supersecretvalue123 candidate:secret-candidate";
+    const classification = classifyRealtimeFailure(new Error(secret), "realtime-start");
+    const code = realtimeDiagnosticCode(classification.category, "realtime-start");
+    expect(code).toBe("remote.realtime-start");
+    expect(code).not.toContain(secret);
+  });
+
+  it("treats thread discovery expiry as a retryable timeout", () => {
+    expect(
+      classifyRealtimeFailure(new Error("Codex thread was not loaded in time"), "thread-discovery"),
+    ).toEqual({ category: "timeout", retryable: true });
+  });
+
+  it("persists only a bounded ring of sanitized structured records", () => {
+    for (let index = 0; index < 45; index++) {
+      appendRealtimeDiagnostic({
+        attemptId: `attempt-${index}`,
+        timestamp: new Date(index).toISOString(),
+        stage: "preflight",
+        event: "started",
+        elapsedMs: 0,
+        retryDecision: "none",
+        terminationRequested: false,
+      });
+    }
+    const records = readRealtimeDiagnostics();
+    expect(records).toHaveLength(40);
+    expect(records[0].attemptId).toBe("attempt-5");
+    expect(records[records.length - 1]?.attemptId).toBe("attempt-44");
+  });
+});

--- a/src/runtime/codex-realtime/realtime-diagnostics.ts
+++ b/src/runtime/codex-realtime/realtime-diagnostics.ts
@@ -1,0 +1,166 @@
+export type RealtimeConnectionStage =
+  | "preflight"
+  | "bridge-connect"
+  | "initialize"
+  | "account"
+  | "thread-discovery"
+  | "microphone"
+  | "webrtc-offer"
+  | "ice-gathering"
+  | "realtime-start"
+  | "sdp-application"
+  | "peer-connection"
+  | "playback";
+
+export type RealtimeFailureCategory =
+  | "cancelled"
+  | "permission"
+  | "authentication"
+  | "configuration"
+  | "ownership"
+  | "timeout"
+  | "network"
+  | "remote"
+  | "unknown";
+
+export type RealtimeDiagnosticCode = `${RealtimeFailureCategory}.${RealtimeConnectionStage}`;
+
+export interface RealtimeDiagnosticRecord {
+  readonly attemptId: string;
+  readonly timestamp: string;
+  readonly stage: RealtimeConnectionStage;
+  readonly event: "started" | "negotiated" | "failed" | "remote-error" | "closed";
+  readonly category?: RealtimeFailureCategory;
+  readonly elapsedMs: number;
+  readonly retryDecision: "none" | "scheduled" | "exhausted";
+  readonly terminationRequested: boolean;
+  readonly peerConnectionState?: string;
+  readonly iceConnectionState?: string;
+  /** Privacy-safe, finite diagnostic identifier. Never contains a server error message. */
+  readonly code?: RealtimeDiagnosticCode;
+  readonly appVersion?: string;
+}
+
+const STORAGE_KEY = "yorishiro.codex-realtime.diagnostics.v1";
+const MAX_RECORDS = 40;
+
+export function createRealtimeAttemptId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `rt-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+  );
+}
+
+export function classifyRealtimeFailure(
+  error: unknown,
+  stage: RealtimeConnectionStage,
+): { readonly category: RealtimeFailureCategory; readonly retryable: boolean } {
+  const record =
+    typeof error === "object" && error !== null
+      ? (error as { name?: unknown; message?: unknown })
+      : null;
+  const name = typeof record?.name === "string" ? record.name.toLowerCase() : "";
+  const message =
+    typeof record?.message === "string"
+      ? record.message.toLowerCase()
+      : String(error).toLowerCase();
+  if (name === "startattemptcancellederror" || message.includes("no longer active")) {
+    return { category: "cancelled", retryable: false };
+  }
+  if (
+    name === "notallowederror" ||
+    name === "securityerror" ||
+    message.includes("permission denied") ||
+    message.includes("microphone permission")
+  ) {
+    return { category: "permission", retryable: false };
+  }
+  if (
+    message.includes("sign in") ||
+    message.includes("authentication") ||
+    message.includes("unauthorized") ||
+    message.includes("api key")
+  ) {
+    return { category: "authentication", retryable: false };
+  }
+  if (message.includes("multiple top-level") || message.includes("ownership")) {
+    return { category: "ownership", retryable: false };
+  }
+  if (
+    message.includes("invalid voice") ||
+    message.includes("invalid loaded thread") ||
+    message.includes("did not contain sdp") ||
+    message.includes("not accept any voice")
+  ) {
+    return { category: "configuration", retryable: false };
+  }
+  if (
+    message.includes("timed out") ||
+    message.includes("not loaded in time") ||
+    name === "timeouterror"
+  ) {
+    return { category: "timeout", retryable: true };
+  }
+  if (
+    message.includes("network") ||
+    message.includes("connection closed") ||
+    message.includes("connection failed") ||
+    message.includes("ice failed")
+  ) {
+    return { category: "network", retryable: true };
+  }
+  if (
+    message.includes("rate limit") ||
+    message.includes("temporarily unavailable") ||
+    message.includes("overloaded") ||
+    message.includes("internal server error") ||
+    /\b(?:429|5\d\d)\b/.test(message)
+  ) {
+    return { category: "remote", retryable: true };
+  }
+  if (stage === "realtime-start" || stage === "sdp-application") {
+    return { category: "remote", retryable: false };
+  }
+  return { category: "unknown", retryable: false };
+}
+
+export function realtimeDiagnosticCode(
+  category: RealtimeFailureCategory,
+  stage: RealtimeConnectionStage,
+): RealtimeDiagnosticCode {
+  return `${category}.${stage}`;
+}
+
+export function appendRealtimeDiagnostic(
+  record: RealtimeDiagnosticRecord,
+  storage: Pick<Storage, "getItem" | "setItem"> | null = safeStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(STORAGE_KEY) ?? "[]");
+    const previous = Array.isArray(parsed) ? parsed : [];
+    storage.setItem(STORAGE_KEY, JSON.stringify([...previous, record].slice(-MAX_RECORDS)));
+  } catch {
+    // Diagnostics must never interfere with voice lifecycle.
+  }
+}
+
+export function readRealtimeDiagnostics(
+  storage: Pick<Storage, "getItem"> | null = safeStorage(),
+): ReadonlyArray<RealtimeDiagnosticRecord> {
+  if (!storage) return [];
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(STORAGE_KEY) ?? "[]");
+    return Array.isArray(parsed) ? (parsed as RealtimeDiagnosticRecord[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function safeStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- persist bounded privacy-safe GPT Live connection diagnostics by attempt and stage
- classify transient and permanent startup failures
- retry transient startup failures with bounded jittered backoff
- deduplicate concurrent starts and cancel pending retries on explicit stop
- fully tear down microphone, peer, channel, bridge, pending requests, and thread ownership on fatal failures
- send thread/realtime/stop when a server-side session may have been accepted
- require manual restart after an established-session failure instead of silently reopening the microphone

## Review fixes

An independent review found resource leaks after remote/playback failures and missing server-side stop messages during retry. This branch now uses a shared fatal teardown, stops accepted Realtime sessions, prevents retry/start races, removes arbitrary server messages from persistent diagnostics, and records SDP success as negotiated rather than connected.

## Validation

- codex-realtime test suite: 6 files, 113 tests passed
- TypeScript typecheck
- Biome check
- cargo fmt
- cargo clippy
- TypeDoc validation

## Remaining physical validation

The stable-run versus HMR/reload comparison and physical-device failure distribution still require observation over real sessions. This PR adds the diagnostics needed for that comparison without claiming HMR as the cause.

Closes #98