### PR TITLE
fix: capitalize Yorishiro app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
 
-      # updater artifact（.app.tar.gz + .sig）は両アーキで同名（yorishiro.app.tar.gz）に
+      # updater artifact（.app.tar.gz + .sig）は両アーキで同名（Yorishiro.app.tar.gz）に
       # なるため、arch を含む名前にリネームしてから artifact 化する。この名前が
       # そのまま Release asset 名になり、latest.json の url が指す。
       - name: Stage updater artifacts
@@ -131,7 +131,7 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      # versioned dmg（yorishiro_<ver>_<arch>.dmg）に加えて、バージョンレスの安定名
+      # versioned dmg（Yorishiro_<ver>_<arch>.dmg）に加えて、バージョンレスの安定名
       # コピーを作る。README の `releases/latest/download/<固定名>` 直リンクは、
       # リリース間でファイル名が固定であることが必須なため。
       - name: Stage stable-named assets

--- a/README.ja.md
+++ b/README.ja.md
@@ -60,7 +60,7 @@ brew install --cask sktkkoo/yorishiro/yorishiro
   <a href="https://github.com/sktkkoo/Yorishiro/releases/latest/download/Yorishiro-Intel.dmg"><img src="https://img.shields.io/badge/Intel-8B949E?style=for-the-badge&logo=apple&logoColor=white" alt="Intel版をダウンロード" /></a>
 </p>
 
-ダウンロードした`.dmg`を開き、`yorishiro.app`を`/Applications`にドラッグしてください。署名・公証（notarize）済みのため、特別な操作なしに起動できます。
+ダウンロードした`.dmg`を開き、`Yorishiro.app`を`/Applications`にドラッグしてください。署名・公証（notarize）済みのため、特別な操作なしに起動できます。
 
 インストール後の更新はアプリ内で完結します。設定画面を開くと新しいバージョンを自動で確認し、「更新して再起動」を押すだけで署名検証つきの更新が適用されます。
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Or download the latest build below.
   <a href="https://github.com/sktkkoo/Yorishiro/releases/latest/download/Yorishiro-Intel.dmg"><img src="https://img.shields.io/badge/Intel-8B949E?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Intel" /></a>
 </p>
 
-Open the `.dmg` and drag `yorishiro.app` to `/Applications`. The builds are signed and notarized with an Apple Developer ID, so they launch without any extra steps.
+Open the `.dmg` and drag `Yorishiro.app` to `/Applications`. The builds are signed and notarized with an Apple Developer ID, so they launch without any extra steps.
 
 Updates after install are handled in-app: opening Settings checks for a new version, and a single click on "Update and restart" applies a signature-verified update.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -41,7 +41,7 @@ Notes:
 - Releases before v0.5.3 do not contain the in-app updater, so those installs
   only update via Homebrew (`brew upgrade`) or manual download.
 - The tap needs no per-release work. It only needs manual edits if the `.dmg`
-  naming scheme or the `yorishiro.app` bundle name changes. Also note GitHub
+  naming scheme or the `Yorishiro.app` bundle name changes. Also note GitHub
   disables cron workflows in repos with no activity for 60 days; if releases
   pause that long, re-enable the tap's bump workflow with
   `gh workflow enable bump-yorishiro.yml -R sktkkoo/homebrew-yorishiro`.
@@ -70,8 +70,8 @@ npm run check:macos-signature
 The verification script runs the equivalent of:
 
 ```bash
-codesign --verify --deep --strict src-tauri/target/release/bundle/macos/yorishiro.app
-codesign -d --entitlements :- src-tauri/target/release/bundle/macos/yorishiro.app
+codesign --verify --deep --strict src-tauri/target/release/bundle/macos/Yorishiro.app
+codesign -d --entitlements :- src-tauri/target/release/bundle/macos/Yorishiro.app
 ```
 
 and requires the audio-input, network-client, JIT, and unsigned executable
@@ -88,7 +88,7 @@ notarization flow.
   built ad-hoc signed bundles only, removing quarantine may still be necessary:
 
 ```bash
-xattr -cr /Applications/yorishiro.app
+xattr -cr /Applications/Yorishiro.app
 ```
 
 - Launch Yorishiro from Finder.
@@ -132,7 +132,7 @@ xattr -cr /Applications/yorishiro.app
 - Launch with:
 
 ```bash
-YORISHIRO_SAFE_MODE=1 open /Applications/yorishiro.app
+YORISHIRO_SAFE_MODE=1 open /Applications/Yorishiro.app
 ```
 
 - Confirm the window title includes `(Safe Mode)`.

--- a/docs/troubleshooting.ja.md
+++ b/docs/troubleshooting.ja.md
@@ -47,7 +47,7 @@ Safe mode はユーザー pack と `init.js` をスキップします。ユー�
 macOS:
 
 ```bash
-YORISHIRO_SAFE_MODE=1 open /Applications/yorishiro.app
+YORISHIRO_SAFE_MODE=1 open /Applications/Yorishiro.app
 ```
 
 ソースから:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,7 +47,7 @@ Safe mode skips user packs and `init.js`. It does not delete user data.
 macOS:
 
 ```bash
-YORISHIRO_SAFE_MODE=1 open /Applications/yorishiro.app
+YORISHIRO_SAFE_MODE=1 open /Applications/Yorishiro.app
 ```
 
 From source:

--- a/scripts/verify-macos-signature.mjs
+++ b/scripts/verify-macos-signature.mjs
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import process from "node:process";
 
-const appPath = process.argv[2] ?? "src-tauri/target/release/bundle/macos/yorishiro.app";
+const appPath = process.argv[2] ?? "src-tauri/target/release/bundle/macos/Yorishiro.app";
 
 if (process.platform !== "darwin") {
   console.error("macOS code signatures can only be verified on macOS.");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "yorishiro",
+  "productName": "Yorishiro",
   "version": "0.6.2",
   "identifier": "dev.yorishiro.app",
   "build": {

--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -158,7 +158,7 @@ export class AppErrorBoundary extends React.Component<
     const packsDir = homeDir ? `${homeDir}/packs/` : "~/.yorishiro/packs/";
     const safeModeCommand =
       navigator.platform.toLowerCase().includes("mac") || navigator.userAgent.includes("Mac")
-        ? "YORISHIRO_SAFE_MODE=1 open /Applications/yorishiro.app"
+        ? "YORISHIRO_SAFE_MODE=1 open /Applications/Yorishiro.app"
         : "YORISHIRO_SAFE_MODE=1 yorishiro";
     const issueUrl = "https://github.com/sktkkoo/Yorishiro/issues/new?template=crash_report.yml";
 


### PR DESCRIPTION
## Summary

- change the Tauri product name from `yorishiro` to `Yorishiro`
- update macOS app bundle references in user-facing docs, recovery UI, and signature verification
- align release workflow documentation with the capitalized generated bundle and DMG names

This is the Yorishiro application-side portion of #71. The coordinated Homebrew tap update remains separate so it can be timed with the first capitalized release.

## Validation

- `npm run build`
- `npm run test:run` (2287 tests)
- `npm run test:rust` (285 tests)
- `npm run build:macos:app`
- `npm run check:macos-signature`
- generated bundle metadata reports `CFBundleName = Yorishiro` and `CFBundleDisplayName = Yorishiro`