### PR TITLE
fix: recover Codex startup from writer lock conflicts

### DIFF
--- a/docs/decisions/codex-sidecar-lifecycle.md
+++ b/docs/decisions/codex-sidecar-lifecycle.md
@@ -42,8 +42,8 @@ debug build を例外にしない理由は経験的で、実装当日に確認�
 
 - app 終了は agent session 終了を意味する。app 終了後も作業を継続する正式な background mode ではない。
 - 自己改修 workflow（Yorishiro 内の agent が Yorishiro の Rust code を触る）では、hot reload のたびに agent session が終わる。継続性が必要になった時点で session supervisor を設計する。lifecycle の例外を増やす方向では解決しない。
-- reaper は「registry に記録した endpoint がコマンドラインに現れる codex app-server」以外を殺さない。Yorishiro 以外が起動した app-server や PID 再利用先には触れない。
-- 導入以前の build が取り残した sidecar は registry に記録がなく整理できない。手動 cleanup（PPID=1 の `codex app-server --listen` を選んで kill）が一度だけ必要になる。
+- registry reap は「registry に記録した endpoint がコマンドラインに現れる codex app-server」以外を殺さない。Yorishiro 以外が起動した app-server や PID 再利用先には触れない。
+- registry 導入前の build（v0.6.x 以前）が取り残した sidecar は記録がないため、移行用 sweep が別途整理する。対象は「コマンドラインが `<codex binary> app-server --listen ws://127.0.0.1:<port>` そのもの」「PPID=1」「registry に記録なし」「listen port に ESTABLISHED な接続なし」の全条件を満たす process のみ。update の再起動では旧 build が codex session を開いたまま終了するため、この経路がないと更新直後の `resume --last` が確実に -32600 で失敗する（v0.7.0 で実際に発生）。
 
 ## 関連 reference
 

--- a/docs/decisions/codex-sidecar-lifecycle.md
+++ b/docs/decisions/codex-sidecar-lifecycle.md
@@ -22,6 +22,11 @@ Codex session ごとに起動する `codex app-server --listen <endpoint>` の l
 
 Codex CLI 0.147.0 以降は `~/.codex/thread-writer-locks/` の writer lock を使う。Tauri managed state は process exit で Drop されるとは限らず、leak した app-server が lock を握り続けると、次回の `resume --last` が `-32600 already has an active writer` で失敗する（issue #109）。明示的 teardown と次回起動時 reaper の二層は、この故障を塞ぐための最小構成であり、どちらを欠いても leak 経路が残る。
 
+reaper 後も別の正当な Codex client が最新 thread を使用中なら、その process は停止しない。
+Yorishiro は同一 thread の resume を先に試し、active writer error の場合だけ同じ履歴を
+fork して起動を継続する。これにより stale sidecar は可能な範囲で回収しつつ、利用中の
+別 client を巻き込まずに Terminal を開ける。
+
 debug build を例外にしない理由は経験的で、実装当日に確認された。Rust hot reload で backend process が再起動すると、現行構成では旧 process が所有していた PTY との接続が切れ、新 process から再 attach できない。sidecar だけ残しても session の継続は得られず、残留 sidecar が writer lock を握って次の session の `resume --last` を塞ぐ——つまり issue #109 と同じ故障を dev loop 内で再現する。実際、debug でこの teardown / reaper をスキップする変更を入れた直後の dev iteration で `-32600` が再発し、手動 cleanup が必要になった。
 
 ## 検討したが却下した代替案
@@ -43,6 +48,7 @@ debug build を例外にしない理由は経験的で、実装当日に確認�
 - app 終了は agent session 終了を意味する。app 終了後も作業を継続する正式な background mode ではない。
 - 自己改修 workflow（Yorishiro 内の agent が Yorishiro の Rust code を触る）では、hot reload のたびに agent session が終わる。継続性が必要になった時点で session supervisor を設計する。lifecycle の例外を増やす方向では解決しない。
 - registry reap は「registry に記録した endpoint がコマンドラインに現れる codex app-server」以外を殺さない。Yorishiro 以外が起動した app-server や PID 再利用先には触れない。
+- reaper が安全に停止できない利用中の writer は生かしたままにし、`resume` の active writer error を `fork` へ限定 fallback する。その他の resume error は fallback せず表示する。
 - registry への spawn 記録に失敗した場合は、未記録 sidecar を動かし続けず、その場で停止して session 起動を失敗させる。短期の可用性より、crash 後に provenance のない process を残さないことを優先する。
 - registry 導入前かつ sidecar 導入後の pre-release / source build が取り残した sidecar は記録がないため、移行用 sweep が別途整理する（v0.6.2 以前の release build は sidecar 自体を spawn しないため対象外）。対象は「binary basename が正確に `codex` で、コマンドラインが `<codex binary> app-server --listen ws://127.0.0.1:<port>` そのもの」「PPID=1」「registry に記録なし」「その process 自身の listen socket に client 接続なし」の全条件を満たす process のみ。update の再起動では旧 build が codex session を開いたまま終了するため、この経路がないと更新直後の `resume --last` が確実に -32600 で失敗する（v0.7.0 で実際に発生）。条件推定による cleanup を常設しないため、全候補の回収を確認した clean pass 後に marker を書き、以後は実行しない。process 一覧を観測できない、client 付き候補がいる、または signal 前後の再検査で候補を安全に回収できない場合は marker を書かず、次回起動で再試行する。TERM / KILL 前には socket 観測の前後で process start time・PPID・command を照合し、候補ごとに最新 registry を再読する。最後の identity 照合と raw PID への signal の間に残る syscall 単位の窓は、macOS に pidfd 相当がないため受け入れる制約とする。
 
@@ -57,4 +63,5 @@ debug build を例外にしない理由は経験的で、実装当日に確認�
 
 ## 改訂履歴
 
+- 2026-08-08: reaper で停止できない正当な active writer がいる場合の resume-first / fork fallback を追加。
 - 2026-08-08: 初版は build profile で teardown / reaper を分ける案だったが、debug スキップが dev loop 内で issue #109 の resume 失敗を再現したため、公開前に一律動作へ改めた。自己改修セッション保護は session supervisor の future work とする。

--- a/docs/decisions/codex-sidecar-lifecycle.md
+++ b/docs/decisions/codex-sidecar-lifecycle.md
@@ -43,7 +43,8 @@ debug build を例外にしない理由は経験的で、実装当日に確認�
 - app 終了は agent session 終了を意味する。app 終了後も作業を継続する正式な background mode ではない。
 - 自己改修 workflow（Yorishiro 内の agent が Yorishiro の Rust code を触る）では、hot reload のたびに agent session が終わる。継続性が必要になった時点で session supervisor を設計する。lifecycle の例外を増やす方向では解決しない。
 - registry reap は「registry に記録した endpoint がコマンドラインに現れる codex app-server」以外を殺さない。Yorishiro 以外が起動した app-server や PID 再利用先には触れない。
-- registry 導入前の build（v0.6.x 以前）が取り残した sidecar は記録がないため、移行用 sweep が別途整理する。対象は「コマンドラインが `<codex binary> app-server --listen ws://127.0.0.1:<port>` そのもの」「PPID=1」「registry に記録なし」「listen port に ESTABLISHED な接続なし」の全条件を満たす process のみ。update の再起動では旧 build が codex session を開いたまま終了するため、この経路がないと更新直後の `resume --last` が確実に -32600 で失敗する（v0.7.0 で実際に発生）。
+- registry への spawn 記録に失敗した場合は、未記録 sidecar を動かし続けず、その場で停止して session 起動を失敗させる。短期の可用性より、crash 後に provenance のない process を残さないことを優先する。
+- registry 導入前かつ sidecar 導入後の pre-release / source build が取り残した sidecar は記録がないため、移行用 sweep が別途整理する（v0.6.2 以前の release build は sidecar 自体を spawn しないため対象外）。対象は「binary basename が正確に `codex` で、コマンドラインが `<codex binary> app-server --listen ws://127.0.0.1:<port>` そのもの」「PPID=1」「registry に記録なし」「その process 自身の listen socket に client 接続なし」の全条件を満たす process のみ。update の再起動では旧 build が codex session を開いたまま終了するため、この経路がないと更新直後の `resume --last` が確実に -32600 で失敗する（v0.7.0 で実際に発生）。条件推定による cleanup を常設しないため、全候補の回収を確認した clean pass 後に marker を書き、以後は実行しない。process 一覧を観測できない、client 付き候補がいる、または signal 前後の再検査で候補を安全に回収できない場合は marker を書かず、次回起動で再試行する。TERM / KILL 前には socket 観測の前後で process start time・PPID・command を照合し、候補ごとに最新 registry を再読する。最後の identity 照合と raw PID への signal の間に残る syscall 単位の窓は、macOS に pidfd 相当がないため受け入れる制約とする。
 
 ## 関連 reference
 

--- a/docs/decisions/codex-terminal-agent.md
+++ b/docs/decisions/codex-terminal-agent.md
@@ -24,6 +24,11 @@ Rust の PTY 層は `AgentKind` を受け取り、agent ごとに起動引数を
 - Claude Code: 既存 session があれば `-c`、hook settings、bundled plugin、MCP config、`--append-system-prompt`
 - Codex: process cwd、Yorishiro MCP config、`~/.agents/skills/` の Yorishiro user skills、persona prompt があれば `-c developer_instructions="<prompt>"`
 
+Codex の既存 thread はまず `resume --last` で同一 thread の継続を試す。別 process が
+writer lock を保持していて `-32600 already has an active writer` で拒否した場合だけ、
+TUI proxy が同じ選択 request を `thread/fork` として再送し、履歴を引き継いだ新しい
+thread で起動する。lock 競合以外の resume error は隠さず、そのまま user に返す。
+
 Hook server は現時点では Claude Code 専用。Codex でも Yorishiro MCP tools、`$yori-*` skills、PTY output / user input / idle の observation は動くが、Claude hook 由来の tool lifecycle event は入らない。
 
 Codex の Yorishiro entrypoint は `/yori:*` slash command ではなく `$yori-*` skill。起動準備時に `~/.agents/skills/yori*/` へ user skill として生成する。コマンドファイルは Claude Code の YAML frontmatter 形式から Codex の `yori-*/SKILL.md` 形式に自動変換される。生成ディレクトリには管理 marker を置き、次回生成時は Yorishiro 管理分だけを置き換える。
@@ -54,6 +59,7 @@ OpenClaw は OpenClaw-owned system prompt を組み立て、provider contributio
 
 - `terminalAgent` の切り替えは次の Terminal session 起動時に反映する。既存 PTY session へ注入し直さない。
 - Codex support の範囲は「自動起動 + persona prompt overlay + Yorishiro MCP + `$yori-*` skills + PTY observation」。Claude Code hook 由来の tool lifecycle event は対象外。
+- Codex の自動継続は resume-first / fork-on-active-writer とする。通常は同じ thread ID を継続し、別の正当な Codex client が利用中でもその process は停止せず、新しい thread ID へ分岐する。
 - Codex の Yorishiro MCP は `~/.codex/config.toml` を変更せず、起動時の `-c` config override で注入する。skills は `~/.agents/skills/` に生成するため、一度生成した後は Yorishiro 外の Codex からも見える。
 - PTY observation-only 制約は変わらない。agent が Claude でも Codex でも、persona / amenity から PTY に書き込む API は追加しない。
 
@@ -69,6 +75,7 @@ OpenClaw は OpenClaw-owned system prompt を組み立て、provider contributio
 
 ## 改訂履歴
 
+- 2026-08-08: Codex 0.147.0 の cross-process writer lock に合わせ、既存 thread は resume を優先し、active writer 競合時だけ fork する方針を追加。
 - 2026-07-11: Codex 0.144.1 の plugin discovery と namespace を実機確認し、`$yori-*` を `~/.agents/skills/` の user skills として生成する方式へ変更。旧 `yorishiro-local` plugin cache は生成時に削除する。
 - 2026-05-26: TerminalAgent trait + capability flag への refactor を [agent-adapter.md](agent-adapter.md) で実施。本 doc は 2-agent 時代の決定として保持し、capability flag (`lifecycle_hooks: false`) の宣言根拠として参照される。
 - 2026-05-28: Codex CLI は Yorishiro custom slash command を認識しないため、Codex entrypoint を `$yori-*` skills としてインストールする方針に修正。

--- a/src-tauri/src/sessions/codex_sidecar_registry.rs
+++ b/src-tauri/src/sessions/codex_sidecar_registry.rs
@@ -82,6 +82,7 @@ pub fn reap_stale_sidecars() {
         return;
     };
     reap_stale_at(&path, &SystemProbe);
+    reap_unrecorded_orphans_at(&path, &SystemProbe, &SystemOrphanScanner);
 }
 
 /// 3 相で reap する。kill は bounded wait（最長 2 秒）を含むため lock の外で
@@ -141,6 +142,102 @@ fn reap_stale_at(path: &Path, probe: &dyn ProcessProbe) {
     if reaped > 0 {
         eprintln!("[codex-sidecar] reaped {reaped} leaked app-server process(es)");
     }
+}
+
+/// 移行用 sweep が必要とする process 一覧と接続状態の観測。テストでは fake。
+pub(crate) trait OrphanScanProbe {
+    /// 全 process の (pid, ppid, command line)。
+    fn list_processes(&self) -> Vec<(u32, u32, String)>;
+    /// その port へ ESTABLISHED な TCP 接続が存在するか。
+    fn has_established_client(&self, port: u16) -> bool;
+}
+
+/// registry 導入前の build（v0.6.x 以前）が leak した sidecar の移行用 sweep。
+///
+/// 旧 build は spawn を記録しないため registry reap では回収できない。update
+/// では「旧 build が codex session を開いたまま終了 → 記録なしの orphan が
+/// 最新 thread の writer lock を握る → 新 build の `resume --last` が -32600」
+/// という経路が必ず成立するため、記録の代わりに以下の全条件で判定する：
+///
+/// 1. コマンドラインが `<codex binary> app-server --listen ws://127.0.0.1:<port>`
+///    そのもの（末尾まで一致。daemon subcommand や unix socket は対象外）
+/// 2. PPID = 1（spawn した親が既に死んでいる）
+/// 3. registry に記録がない（記録があるものは registry reap の管轄）
+/// 4. その listen port に ESTABLISHED な接続が 1 本もない
+///    （生きた client が付いた server は、誰が spawn したかに関わらず殺さない）
+fn reap_unrecorded_orphans_at(
+    path: &Path,
+    probe: &dyn ProcessProbe,
+    scanner: &dyn OrphanScanProbe,
+) {
+    let recorded: std::collections::HashSet<u32> = with_registry_lock(path, || read_entries(path))
+        .iter()
+        .map(|e| e.sidecar_pid)
+        .collect();
+    let targets = plan_unrecorded_reap(&scanner.list_processes(), &recorded, scanner);
+    if targets.is_empty() {
+        return;
+    }
+    for entry in &targets {
+        if still_matches(probe, entry) {
+            probe.terminate(entry.sidecar_pid);
+        }
+    }
+    wait_for_death_or_escalate(&targets, probe);
+    let reaped = targets
+        .iter()
+        .filter(|e| !probe.is_alive(e.sidecar_pid))
+        .count();
+    if reaped > 0 {
+        eprintln!(
+            "[codex-sidecar] migration: reaped {reaped} unrecorded orphan app-server process(es) left by a pre-registry build"
+        );
+    }
+}
+
+/// 条件 1〜4 を満たす orphan を、registry reap と同じ kill 経路に流せるよう
+/// `SidecarEntry` の形に合成して返す（owner は既に居ないので便宜上 1）。
+fn plan_unrecorded_reap(
+    processes: &[(u32, u32, String)],
+    recorded_pids: &std::collections::HashSet<u32>,
+    scanner: &dyn OrphanScanProbe,
+) -> Vec<SidecarEntry> {
+    let mut targets = Vec::new();
+    for (pid, ppid, command) in processes {
+        if *ppid != 1 || recorded_pids.contains(pid) {
+            continue;
+        }
+        let Some(port) = parse_sidecar_listen_port(command.trim()) else {
+            continue;
+        };
+        if scanner.has_established_client(port) {
+            continue;
+        }
+        targets.push(SidecarEntry {
+            owner_pid: 1,
+            sidecar_pid: *pid,
+            endpoint: format!("ws://127.0.0.1:{port}"),
+        });
+    }
+    targets
+}
+
+/// コマンドラインが Yorishiro 型 sidecar の形（`<binary> app-server --listen
+/// ws://127.0.0.1:<port>` で終端、binary は空白なしで "codex" を含む）なら
+/// port を返す。判定を狭く保つことが安全性の根拠なので、疑わしきは None。
+fn parse_sidecar_listen_port(command: &str) -> Option<u16> {
+    let marker = " app-server --listen ws://127.0.0.1:";
+    let idx = command.find(marker)?;
+    let binary = &command[..idx];
+    if binary.contains(char::is_whitespace) || !binary.contains("codex") {
+        return None;
+    }
+    let port_str = &command[idx + marker.len()..];
+    if port_str.is_empty() || !port_str.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let port: u32 = port_str.parse().ok()?;
+    u16::try_from(port).ok().filter(|p| *p > 0)
 }
 
 struct ReapPlan {
@@ -351,6 +448,62 @@ fn ps_field(pid: u32, field: &str) -> Option<String> {
         None
     } else {
         Some(trimmed.to_string())
+    }
+}
+
+/// 実 system に対する移行用 sweep の観測。ps で全 process、lsof で接続を読む。
+struct SystemOrphanScanner;
+
+#[cfg(unix)]
+impl OrphanScanProbe for SystemOrphanScanner {
+    fn list_processes(&self) -> Vec<(u32, u32, String)> {
+        let Ok(output) = std::process::Command::new("ps")
+            .args(["-axww", "-o", "pid=,ppid=,command="])
+            .output()
+        else {
+            return Vec::new();
+        };
+        if !output.status.success() {
+            return Vec::new();
+        }
+        let Ok(text) = String::from_utf8(output.stdout) else {
+            return Vec::new();
+        };
+        text.lines()
+            .filter_map(|line| {
+                let trimmed = line.trim_start();
+                let (pid_str, rest) = trimmed.split_once(char::is_whitespace)?;
+                let rest = rest.trim_start();
+                let (ppid_str, command) = rest.split_once(char::is_whitespace)?;
+                Some((
+                    pid_str.parse().ok()?,
+                    ppid_str.parse().ok()?,
+                    command.trim().to_string(),
+                ))
+            })
+            .collect()
+    }
+
+    fn has_established_client(&self, port: u16) -> bool {
+        let Ok(output) = std::process::Command::new("lsof")
+            .args(["-nP", &format!("-iTCP:{port}"), "-sTCP:ESTABLISHED", "-t"])
+            .output()
+        else {
+            // 確認できないときは「client あり」に倒して殺さない。
+            return true;
+        };
+        !String::from_utf8_lossy(&output.stdout).trim().is_empty()
+    }
+}
+
+#[cfg(not(unix))]
+impl OrphanScanProbe for SystemOrphanScanner {
+    fn list_processes(&self) -> Vec<(u32, u32, String)> {
+        Vec::new()
+    }
+
+    fn has_established_client(&self, _port: u16) -> bool {
+        true
     }
 }
 
@@ -735,6 +888,119 @@ mod tests {
         let remaining = read_entries(&path);
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].sidecar_pid, 556);
+    }
+
+    struct FakeScanner {
+        processes: Vec<(u32, u32, String)>,
+        established_ports: HashSet<u16>,
+    }
+
+    impl OrphanScanProbe for FakeScanner {
+        fn list_processes(&self) -> Vec<(u32, u32, String)> {
+            self.processes.clone()
+        }
+
+        fn has_established_client(&self, port: u16) -> bool {
+            self.established_ports.contains(&port)
+        }
+    }
+
+    #[test]
+    fn parses_only_exact_sidecar_command_shapes() {
+        assert_eq!(
+            parse_sidecar_listen_port(
+                "/Users/x/.local/bin/codex app-server --listen ws://127.0.0.1:50001"
+            ),
+            Some(50001)
+        );
+        // daemon subcommand・unix socket・追加引数・非 loopback・codex 以外の
+        // binary・空白入り binary はすべて対象外。
+        assert_eq!(
+            parse_sidecar_listen_port("codex app-server daemon run --port 50001"),
+            None
+        );
+        assert_eq!(
+            parse_sidecar_listen_port("codex app-server --listen unix:///tmp/x.sock"),
+            None
+        );
+        assert_eq!(
+            parse_sidecar_listen_port("codex app-server --listen ws://127.0.0.1:50001 --extra"),
+            None
+        );
+        assert_eq!(
+            parse_sidecar_listen_port("codex app-server --listen ws://0.0.0.0:50001"),
+            None
+        );
+        assert_eq!(
+            parse_sidecar_listen_port("/usr/bin/other app-server --listen ws://127.0.0.1:50001"),
+            None
+        );
+        assert_eq!(
+            parse_sidecar_listen_port("rg foo codex app-server --listen ws://127.0.0.1:50001"),
+            None
+        );
+        assert_eq!(
+            parse_sidecar_listen_port("codex app-server --listen ws://127.0.0.1:"),
+            None
+        );
+    }
+
+    #[test]
+    fn plan_unrecorded_targets_only_abandoned_unrecorded_clientless_sidecars() {
+        let sidecar = |pid: u32, ppid: u32, port: u16| (pid, ppid, sidecar_command(port));
+        let processes = vec![
+            sidecar(300, 1, 50001),            // 対象: 孤児・未記録・client なし
+            sidecar(301, 4242, 50002),         // 親が生きている → 対象外
+            sidecar(302, 1, 50003),            // registry に記録あり → 対象外
+            sidecar(303, 1, 50004),            // ESTABLISHED client あり → 対象外
+            (304, 1, "/usr/bin/vim x".into()), // 形が違う → 対象外
+        ];
+        let recorded = HashSet::from([302u32]);
+        let scanner = FakeScanner {
+            processes: processes.clone(),
+            established_ports: HashSet::from([50004u16]),
+        };
+
+        let targets = plan_unrecorded_reap(&processes, &recorded, &scanner);
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].sidecar_pid, 300);
+        assert_eq!(targets[0].endpoint, "ws://127.0.0.1:50001");
+    }
+
+    #[test]
+    fn migration_sweep_kills_pre_registry_orphan_end_to_end() {
+        let path = temp_registry("migration");
+        let probe = FakeProbe::new()
+            .with_alive(&[300])
+            .with_command(300, &sidecar_command(50001));
+        let scanner = FakeScanner {
+            processes: vec![(300, 1, sidecar_command(50001))],
+            established_ports: HashSet::new(),
+        };
+
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+
+        assert_eq!(*probe.terminated.lock().unwrap(), vec![300]);
+    }
+
+    #[test]
+    fn migration_sweep_skips_orphan_when_identity_recheck_fails() {
+        // plan と signal の間に PID が別プロセスへ化けた場合、still_matches の
+        // 再確認で signal を送らない。
+        let path = temp_registry("migration-flip");
+        let probe = FakeProbe::new()
+            .with_alive(&[300])
+            .with_command(300, "/usr/bin/vim important.txt");
+        let scanner = FakeScanner {
+            processes: vec![(300, 1, sidecar_command(50001))],
+            established_ports: HashSet::new(),
+        };
+
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+
+        assert!(probe.terminated.lock().unwrap().is_empty());
+        assert!(probe.force_killed.lock().unwrap().is_empty());
     }
 
     /// SystemProbe の実バインディング（signal 0 / ps 読み）を実 process で検証する。

--- a/src-tauri/src/sessions/codex_sidecar_registry.rs
+++ b/src-tauri/src/sessions/codex_sidecar_registry.rs
@@ -36,6 +36,11 @@ pub(crate) trait ProcessProbe {
     fn is_alive(&self, pid: u32) -> bool;
     fn parent_pid(&self, pid: u32) -> Option<u32>;
     fn command_line(&self, pid: u32) -> Option<String>;
+    /// PID reuse を検出するための process start identity。実 system では ps の
+    /// lstart。テスト fake は command がある限り安定値を返す。
+    fn start_time(&self, pid: u32) -> Option<String> {
+        self.command_line(pid).map(|_| format!("fake-start-{pid}"))
+    }
     fn terminate(&self, pid: u32);
     fn force_kill(&self, pid: u32);
 }
@@ -50,9 +55,9 @@ fn registry_path() -> Option<PathBuf> {
         .map(|home| registry_path_under(&home))
 }
 
-/// spawn 直後に呼ぶ。registry の失敗は spawn を止めない（session の可用性を
-/// 帳簿より優先する設計判断）が、false を返して caller に警告させる。
-/// 記録できなかった sidecar は crash 時に reap 不能になる。
+/// spawn 直後に呼ぶ。false の場合、caller は未記録 sidecar を即時停止して
+/// session 起動を失敗させる。provenance のない process を動かし続けると、crash
+/// 後に安全に reap できないため。
 #[must_use]
 pub fn record_spawn(path: &Path, entry: SidecarEntry) -> bool {
     with_registry_lock(path, || {
@@ -147,12 +152,35 @@ fn reap_stale_at(path: &Path, probe: &dyn ProcessProbe) {
 /// 移行用 sweep が必要とする process 一覧と接続状態の観測。テストでは fake。
 pub(crate) trait OrphanScanProbe {
     /// 全 process の (pid, ppid, command line)。
-    fn list_processes(&self) -> Vec<(u32, u32, String)>;
-    /// その port へ ESTABLISHED な TCP 接続が存在するか。
-    fn has_established_client(&self, port: u16) -> bool;
+    /// 観測自体に失敗した場合は None。空の一覧と区別し、失敗時に migration
+    /// 完了 marker を誤って書かないため。
+    fn list_processes(&self) -> Option<Vec<(u32, u32, String)>>;
+    /// その process 自身の socket に、当該 port で LISTEN 以外の TCP 状態
+    /// （ESTABLISHED / CLOSE_WAIT 等）が存在するか。pid でスコープすることで、
+    /// 無関係な process の同番 port 接続に reap を誤って見送らせない。
+    fn has_established_client(&self, pid: u32, port: u16) -> bool;
 }
 
-/// registry 導入前の build（v0.6.x 以前）が leak した sidecar の移行用 sweep。
+/// 移行 sweep 完了の marker。存在すれば以後の startup では sweep を走らせない。
+/// 「registry に記録のない process を条件推定で殺す」経路は、pre-registry
+/// build の残骸整理という一度きりの目的にだけ許す（常時掃除に格上げすると、
+/// user が意図して detach した clientless な codex app-server を定常的に
+/// 巻き込みうる）。client 検出で見送った候補や kill 失敗が残った回は marker を
+/// 書かず、次回 startup で再挑戦する。
+fn migration_marker_path(registry_path: &Path) -> PathBuf {
+    registry_path.with_file_name("codex-sidecars-migration-done")
+}
+
+fn recorded_sidecar_pids(path: &Path) -> std::collections::HashSet<u32> {
+    with_registry_lock(path, || read_entries(path))
+        .iter()
+        .map(|entry| entry.sidecar_pid)
+        .collect()
+}
+
+/// registry 導入前かつ sidecar 導入後の pre-release / source build が leak した
+/// sidecar の移行用 sweep。v0.6.2 以前の release build は sidecar 自体を spawn
+/// しないため対象外。
 ///
 /// 旧 build は spawn を記録しないため registry reap では回収できない。update
 /// では「旧 build が codex session を開いたまま終了 → 記録なしの orphan が
@@ -160,39 +188,92 @@ pub(crate) trait OrphanScanProbe {
 /// という経路が必ず成立するため、記録の代わりに以下の全条件で判定する：
 ///
 /// 1. コマンドラインが `<codex binary> app-server --listen ws://127.0.0.1:<port>`
-///    そのもの（末尾まで一致。daemon subcommand や unix socket は対象外）
+///    そのもの（末尾まで一致・binary basename は正確に "codex"。daemon
+///    subcommand や unix socket、別名 binary は対象外）
 /// 2. PPID = 1（spawn した親が既に死んでいる）
 /// 3. registry に記録がない（記録があるものは registry reap の管轄）
-/// 4. その listen port に ESTABLISHED な接続が 1 本もない
+/// 4. その process 自身の listen port に LISTEN 以外の TCP 状態がない
 ///    （生きた client が付いた server は、誰が spawn したかに関わらず殺さない）
+///
+/// plan 確定から signal までの間の PID 再利用・別 instance による record・
+/// client 接続に備え、TERM / KILL の送信直前に条件 1〜4 を丸ごと再検査する。
+/// なお process が自分の argv を偽装してこの形を名乗ることは可能だが、偽装
+/// できるのは自分のコマンドラインだけなので、それで殺せるのは偽装者自身に
+/// 限られる（ps 由来 identity の受け入れ済み限界）。
 fn reap_unrecorded_orphans_at(
     path: &Path,
     probe: &dyn ProcessProbe,
     scanner: &dyn OrphanScanProbe,
 ) {
-    let recorded: std::collections::HashSet<u32> = with_registry_lock(path, || read_entries(path))
-        .iter()
-        .map(|e| e.sidecar_pid)
-        .collect();
-    let targets = plan_unrecorded_reap(&scanner.list_processes(), &recorded, scanner);
-    if targets.is_empty() {
+    let marker = migration_marker_path(path);
+    if marker.exists() {
         return;
     }
-    for entry in &targets {
-        if still_matches(probe, entry) {
+    let recorded = recorded_sidecar_pids(path);
+    let Some(processes) = scanner.list_processes() else {
+        return;
+    };
+    // Unix の process table には少なくとも自 process が居る。成功扱いなのに
+    // 0 件なら ps format の非互換などを疑い、marker を残さず次回へ回す。
+    if processes.is_empty() {
+        return;
+    }
+    let plan = plan_unrecorded_reap(&processes, &recorded, scanner);
+
+    let mut signalled: Vec<(SidecarEntry, u16, String)> = Vec::new();
+    for (entry, port) in &plan.targets {
+        let Some(start_time) = probe.start_time(entry.sidecar_pid) else {
+            continue;
+        };
+        if migration_target_still_eligible(path, entry, *port, &start_time, probe, scanner) {
             probe.terminate(entry.sidecar_pid);
+            signalled.push((entry.clone(), *port, start_time));
         }
     }
-    wait_for_death_or_escalate(&targets, probe);
-    let reaped = targets
-        .iter()
-        .filter(|e| !probe.is_alive(e.sidecar_pid))
-        .count();
+
+    let mut survivors = 0usize;
+    let mut reaped = 0usize;
+    if !signalled.is_empty() {
+        wait_then_escalate_migration(path, &signalled, probe, scanner);
+        for (entry, _, _) in &signalled {
+            if probe.is_alive(entry.sidecar_pid) {
+                survivors += 1;
+            } else {
+                reaped += 1;
+            }
+        }
+    }
     if reaped > 0 {
         eprintln!(
             "[codex-sidecar] migration: reaped {reaped} unrecorded orphan app-server process(es) left by a pre-registry build"
         );
     }
+
+    // signal 前の再検査で候補を見送った場合も marker を書かない。特に plan 後に
+    // client が接続した候補は、次回 client が外れた時に再試行する必要がある。
+    if plan.pending_with_parent == 0
+        && plan.skipped_with_client == 0
+        && signalled.len() == plan.targets.len()
+        && survivors == 0
+    {
+        if let Err(e) = std::fs::write(&marker, b"") {
+            eprintln!(
+                "[codex-sidecar] migration marker write failed at {}: {e}",
+                marker.display()
+            );
+        }
+    }
+}
+
+struct MigrationPlan {
+    /// 条件 1〜4 を満たした kill 候補と、その listen port。
+    targets: Vec<(SidecarEntry, u16)>,
+    /// client 検出（条件 4）だけで見送った候補数。0 でない回は移行完了と
+    /// 見なさず、marker を書かない。
+    skipped_with_client: usize,
+    /// 形は一致する未記録 sidecar だが、まだ親が生きている候補数。複数 app
+    /// instance が並存する update 中かもしれないため、移行完了を保留する。
+    pending_with_parent: usize,
 }
 
 /// 条件 1〜4 を満たす orphan を、registry reap と同じ kill 経路に流せるよう
@@ -201,43 +282,138 @@ fn plan_unrecorded_reap(
     processes: &[(u32, u32, String)],
     recorded_pids: &std::collections::HashSet<u32>,
     scanner: &dyn OrphanScanProbe,
-) -> Vec<SidecarEntry> {
+) -> MigrationPlan {
     let mut targets = Vec::new();
+    let mut skipped_with_client = 0usize;
+    let mut pending_with_parent = 0usize;
     for (pid, ppid, command) in processes {
-        if *ppid != 1 || recorded_pids.contains(pid) {
+        if recorded_pids.contains(pid) {
             continue;
         }
         let Some(port) = parse_sidecar_listen_port(command.trim()) else {
             continue;
         };
-        if scanner.has_established_client(port) {
+        if *ppid != 1 {
+            pending_with_parent += 1;
             continue;
         }
-        targets.push(SidecarEntry {
-            owner_pid: 1,
-            sidecar_pid: *pid,
-            endpoint: format!("ws://127.0.0.1:{port}"),
-        });
+        if scanner.has_established_client(*pid, port) {
+            skipped_with_client += 1;
+            continue;
+        }
+        targets.push((
+            SidecarEntry {
+                owner_pid: 1,
+                sidecar_pid: *pid,
+                endpoint: format!("ws://127.0.0.1:{port}"),
+            },
+            port,
+        ));
     }
-    targets
+    MigrationPlan {
+        targets,
+        skipped_with_client,
+        pending_with_parent,
+    }
+}
+
+/// 移行 sweep の signal 直前再検査。plan snapshot からの経過中に起きうる
+/// PID 再利用（別プロセス化・新 sidecar 化）・別 instance による record・
+/// client 接続を、送信の直前にまとめて再確認する。registry reap の
+/// `still_matches` より厳格に、plan と同じ完全一致 parser で照合する。
+/// ps で読めない（判定不能）場合は殺さない側に倒す。
+fn migration_target_still_eligible(
+    path: &Path,
+    entry: &SidecarEntry,
+    port: u16,
+    expected_start_time: &str,
+    probe: &dyn ProcessProbe,
+    scanner: &dyn OrphanScanProbe,
+) -> bool {
+    if !migration_process_identity_matches(entry, port, expected_start_time, probe) {
+        return false;
+    }
+    if scanner.has_established_client(entry.sidecar_pid, port) {
+        return false;
+    }
+    // lsof は別 process なので、その実行中に対象が終了・PID reuse されうる。
+    // socket 観測後に最新 registry と process identity をもう一度確認する。
+    if recorded_sidecar_pids(path).contains(&entry.sidecar_pid) {
+        return false;
+    }
+    migration_process_identity_matches(entry, port, expected_start_time, probe)
+}
+
+fn migration_process_identity_matches(
+    entry: &SidecarEntry,
+    port: u16,
+    expected_start_time: &str,
+    probe: &dyn ProcessProbe,
+) -> bool {
+    if probe.start_time(entry.sidecar_pid).as_deref() != Some(expected_start_time) {
+        return false;
+    }
+    if probe.parent_pid(entry.sidecar_pid) != Some(1) {
+        return false;
+    }
+    probe
+        .command_line(entry.sidecar_pid)
+        .is_some_and(|command| parse_sidecar_listen_port(command.trim()) == Some(port))
+}
+
+/// TERM 済み対象の死亡を bounded に待ち、生き残りは条件を再々確認したうえで
+/// KILL に切り替える。
+fn wait_then_escalate_migration(
+    path: &Path,
+    signalled: &[(SidecarEntry, u16, String)],
+    probe: &dyn ProcessProbe,
+    scanner: &dyn OrphanScanProbe,
+) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        if signalled
+            .iter()
+            .all(|(entry, _, _)| !probe.is_alive(entry.sidecar_pid))
+        {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    for (entry, port, start_time) in signalled {
+        if probe.is_alive(entry.sidecar_pid)
+            && migration_target_still_eligible(path, entry, *port, start_time, probe, scanner)
+        {
+            probe.force_kill(entry.sidecar_pid);
+        }
+    }
 }
 
 /// コマンドラインが Yorishiro 型 sidecar の形（`<binary> app-server --listen
-/// ws://127.0.0.1:<port>` で終端、binary は空白なしで "codex" を含む）なら
-/// port を返す。判定を狭く保つことが安全性の根拠なので、疑わしきは None。
+/// ws://127.0.0.1:<port>` で終端）なら port を返す。binary は空白を含まず、
+/// basename が正確に "codex" であること——部分文字列一致では `/tmp/not-codex`
+/// のような別物や、user が意図して残した別名 binary を巻き込む。port の
+/// 先頭ゼロは自前 spawn（u16 の Display）からは決して出ない形なので拒否する
+/// （受理すると合成 endpoint と原文が食い違い、再検査と不整合になる）。
+/// 判定を狭く保つことが安全性の根拠なので、疑わしきは None。
 fn parse_sidecar_listen_port(command: &str) -> Option<u16> {
     let marker = " app-server --listen ws://127.0.0.1:";
     let idx = command.find(marker)?;
     let binary = &command[..idx];
-    if binary.contains(char::is_whitespace) || !binary.contains("codex") {
+    if binary.contains(char::is_whitespace) {
+        return None;
+    }
+    if binary.rsplit('/').next()? != "codex" {
         return None;
     }
     let port_str = &command[idx + marker.len()..];
-    if port_str.is_empty() || !port_str.bytes().all(|b| b.is_ascii_digit()) {
+    if port_str.is_empty()
+        || port_str.starts_with('0')
+        || !port_str.bytes().all(|b| b.is_ascii_digit())
+    {
         return None;
     }
     let port: u32 = port_str.parse().ok()?;
-    u16::try_from(port).ok().filter(|p| *p > 0)
+    u16::try_from(port).ok()
 }
 
 struct ReapPlan {
@@ -418,6 +594,10 @@ impl ProcessProbe for SystemProbe {
         ps_field(pid, "command=")
     }
 
+    fn start_time(&self, pid: u32) -> Option<String> {
+        ps_field(pid, "lstart=")
+    }
+
     fn terminate(&self, pid: u32) {
         if signalable(pid) {
             let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
@@ -456,53 +636,73 @@ struct SystemOrphanScanner;
 
 #[cfg(unix)]
 impl OrphanScanProbe for SystemOrphanScanner {
-    fn list_processes(&self) -> Vec<(u32, u32, String)> {
+    fn list_processes(&self) -> Option<Vec<(u32, u32, String)>> {
         let Ok(output) = std::process::Command::new("ps")
             .args(["-axww", "-o", "pid=,ppid=,command="])
             .output()
         else {
-            return Vec::new();
+            return None;
         };
         if !output.status.success() {
-            return Vec::new();
+            return None;
         }
-        let Ok(text) = String::from_utf8(output.stdout) else {
-            return Vec::new();
-        };
-        text.lines()
-            .filter_map(|line| {
-                let trimmed = line.trim_start();
-                let (pid_str, rest) = trimmed.split_once(char::is_whitespace)?;
-                let rest = rest.trim_start();
-                let (ppid_str, command) = rest.split_once(char::is_whitespace)?;
-                Some((
-                    pid_str.parse().ok()?,
-                    ppid_str.parse().ok()?,
-                    command.trim().to_string(),
-                ))
-            })
-            .collect()
+        // lossy: 1 行の非 UTF-8 で process table 全体を捨てない。化けた行は
+        // どのみち完全一致 parser を通らない。argv 内の改行で行が捏造されうる
+        // が、捏造 pid への signal は送信直前の per-pid 再検査（ps -p の実
+        // コマンドライン照合）が防ぐ。
+        Some(
+            String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .filter_map(|line| {
+                    let trimmed = line.trim_start();
+                    let (pid_str, rest) = trimmed.split_once(char::is_whitespace)?;
+                    let rest = rest.trim_start();
+                    let (ppid_str, command) = rest.split_once(char::is_whitespace)?;
+                    Some((
+                        pid_str.parse().ok()?,
+                        ppid_str.parse().ok()?,
+                        command.trim().to_string(),
+                    ))
+                })
+                .collect(),
+        )
     }
 
-    fn has_established_client(&self, port: u16) -> bool {
+    fn has_established_client(&self, pid: u32, port: u16) -> bool {
+        // -a で pid と port を AND し、対象 process 自身の socket に限定する。
+        // 状態フィルタは使わず、LISTEN 以外の TCP 行（ESTABLISHED /
+        // CLOSE_WAIT / FIN_WAIT 等）があれば client ありと見なす。
         let Ok(output) = std::process::Command::new("lsof")
-            .args(["-nP", &format!("-iTCP:{port}"), "-sTCP:ESTABLISHED", "-t"])
+            .args([
+                "-nP",
+                "-a",
+                "-p",
+                &pid.to_string(),
+                &format!("-iTCP:{port}"),
+            ])
             .output()
         else {
-            // 確認できないときは「client あり」に倒して殺さない。
+            // 実行できないときは「client あり」に倒して殺さない。
             return true;
         };
-        !String::from_utf8_lossy(&output.stdout).trim().is_empty()
+        // lsof は「該当なし」でも exit 1 を返し、権限エラー等と区別できない。
+        // stderr に何か出ていれば判定不能として client ありに倒す。
+        if !output.status.success() && !output.stderr.is_empty() {
+            return true;
+        }
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .any(|line| line.contains("TCP") && !line.contains("(LISTEN)"))
     }
 }
 
 #[cfg(not(unix))]
 impl OrphanScanProbe for SystemOrphanScanner {
-    fn list_processes(&self) -> Vec<(u32, u32, String)> {
-        Vec::new()
+    fn list_processes(&self) -> Option<Vec<(u32, u32, String)>> {
+        None
     }
 
-    fn has_established_client(&self, _port: u16) -> bool {
+    fn has_established_client(&self, _pid: u32, _port: u16) -> bool {
         true
     }
 }
@@ -516,6 +716,9 @@ impl ProcessProbe for SystemProbe {
         None
     }
     fn command_line(&self, _pid: u32) -> Option<String> {
+        None
+    }
+    fn start_time(&self, _pid: u32) -> Option<String> {
         None
     }
     fn terminate(&self, _pid: u32) {}
@@ -892,16 +1095,43 @@ mod tests {
 
     struct FakeScanner {
         processes: Vec<(u32, u32, String)>,
-        established_ports: HashSet<u16>,
+        established_ports: Mutex<HashSet<u16>>,
+        /// (call 回数, この回数目以降 client ありにする port)。plan 後に client
+        /// が接続してくる window を再現する。
+        connect_after_calls: Option<(usize, u16)>,
+        client_checks: Mutex<usize>,
+    }
+
+    impl FakeScanner {
+        fn new(processes: Vec<(u32, u32, String)>) -> Self {
+            Self {
+                processes,
+                established_ports: Mutex::new(HashSet::new()),
+                connect_after_calls: None,
+                client_checks: Mutex::new(0),
+            }
+        }
+
+        fn with_client_on(self, port: u16) -> Self {
+            self.established_ports.lock().unwrap().insert(port);
+            self
+        }
     }
 
     impl OrphanScanProbe for FakeScanner {
-        fn list_processes(&self) -> Vec<(u32, u32, String)> {
-            self.processes.clone()
+        fn list_processes(&self) -> Option<Vec<(u32, u32, String)>> {
+            Some(self.processes.clone())
         }
 
-        fn has_established_client(&self, port: u16) -> bool {
-            self.established_ports.contains(&port)
+        fn has_established_client(&self, _pid: u32, port: u16) -> bool {
+            let mut checks = self.client_checks.lock().unwrap();
+            *checks += 1;
+            if let Some((after, flip_port)) = self.connect_after_calls {
+                if *checks > after && port == flip_port {
+                    return true;
+                }
+            }
+            self.established_ports.lock().unwrap().contains(&port)
         }
     }
 
@@ -943,6 +1173,22 @@ mod tests {
             parse_sidecar_listen_port("codex app-server --listen ws://127.0.0.1:"),
             None
         );
+        // basename は正確に "codex"。部分文字列一致や別名 binary は対象外。
+        assert_eq!(
+            parse_sidecar_listen_port("/tmp/not-codex app-server --listen ws://127.0.0.1:50001"),
+            None
+        );
+        assert_eq!(
+            parse_sidecar_listen_port(
+                "/usr/bin/codex-fugu app-server --listen ws://127.0.0.1:50001"
+            ),
+            None
+        );
+        // 先頭ゼロの port は自前 spawn から出ない形なので拒否。
+        assert_eq!(
+            parse_sidecar_listen_port("codex app-server --listen ws://127.0.0.1:050001"),
+            None
+        );
     }
 
     #[test]
@@ -952,20 +1198,20 @@ mod tests {
             sidecar(300, 1, 50001),            // 対象: 孤児・未記録・client なし
             sidecar(301, 4242, 50002),         // 親が生きている → 対象外
             sidecar(302, 1, 50003),            // registry に記録あり → 対象外
-            sidecar(303, 1, 50004),            // ESTABLISHED client あり → 対象外
+            sidecar(303, 1, 50004),            // client あり → 対象外（要 marker 保留）
             (304, 1, "/usr/bin/vim x".into()), // 形が違う → 対象外
         ];
         let recorded = HashSet::from([302u32]);
-        let scanner = FakeScanner {
-            processes: processes.clone(),
-            established_ports: HashSet::from([50004u16]),
-        };
+        let scanner = FakeScanner::new(processes.clone()).with_client_on(50004);
 
-        let targets = plan_unrecorded_reap(&processes, &recorded, &scanner);
+        let plan = plan_unrecorded_reap(&processes, &recorded, &scanner);
 
-        assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].sidecar_pid, 300);
-        assert_eq!(targets[0].endpoint, "ws://127.0.0.1:50001");
+        assert_eq!(plan.targets.len(), 1);
+        assert_eq!(plan.targets[0].0.sidecar_pid, 300);
+        assert_eq!(plan.targets[0].0.endpoint, "ws://127.0.0.1:50001");
+        assert_eq!(plan.targets[0].1, 50001);
+        assert_eq!(plan.skipped_with_client, 1);
+        assert_eq!(plan.pending_with_parent, 1);
     }
 
     #[test]
@@ -973,34 +1219,298 @@ mod tests {
         let path = temp_registry("migration");
         let probe = FakeProbe::new()
             .with_alive(&[300])
+            .with_parent(300, 1)
             .with_command(300, &sidecar_command(50001));
-        let scanner = FakeScanner {
-            processes: vec![(300, 1, sidecar_command(50001))],
-            established_ports: HashSet::new(),
-        };
+        let scanner = FakeScanner::new(vec![(300, 1, sidecar_command(50001))]);
 
         reap_unrecorded_orphans_at(&path, &probe, &scanner);
 
         assert_eq!(*probe.terminated.lock().unwrap(), vec![300]);
+        // クリーンに完了した回は marker が書かれ、以後の sweep は走らない。
+        assert!(migration_marker_path(&path).exists());
+    }
+
+    #[test]
+    fn migration_sweep_runs_only_once_after_clean_pass() {
+        let path = temp_registry("migration-once");
+        let clean = FakeProbe::new();
+        let harmless_process = vec![(999, 42, "/usr/bin/vim notes.txt".into())];
+        reap_unrecorded_orphans_at(&path, &clean, &FakeScanner::new(harmless_process));
+        assert!(migration_marker_path(&path).exists());
+
+        // marker がある限り、新たな候補が現れても sweep は走らない。
+        let probe = FakeProbe::new()
+            .with_alive(&[300])
+            .with_parent(300, 1)
+            .with_command(300, &sidecar_command(50001));
+        let scanner = FakeScanner::new(vec![(300, 1, sidecar_command(50001))]);
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+        assert!(probe.terminated.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn migration_marker_is_withheld_when_process_listing_fails() {
+        struct FailingScanner;
+        impl OrphanScanProbe for FailingScanner {
+            fn list_processes(&self) -> Option<Vec<(u32, u32, String)>> {
+                None
+            }
+
+            fn has_established_client(&self, _pid: u32, _port: u16) -> bool {
+                unreachable!("a failed process listing must stop the sweep")
+            }
+        }
+
+        let path = temp_registry("migration-scan-failure");
+        reap_unrecorded_orphans_at(&path, &FakeProbe::new(), &FailingScanner);
+
+        assert!(!migration_marker_path(&path).exists());
+    }
+
+    #[test]
+    fn migration_marker_is_withheld_while_candidates_are_skipped_for_clients() {
+        // client 付きで見送った候補が居る回は移行完了と見なさず、次回また試す。
+        let path = temp_registry("migration-retry");
+        let probe = FakeProbe::new()
+            .with_alive(&[300])
+            .with_parent(300, 1)
+            .with_command(300, &sidecar_command(50001));
+        let scanner =
+            FakeScanner::new(vec![(300, 1, sidecar_command(50001))]).with_client_on(50001);
+
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+
+        assert!(probe.terminated.lock().unwrap().is_empty());
+        assert!(!migration_marker_path(&path).exists());
+    }
+
+    #[test]
+    fn migration_marker_is_withheld_while_pre_registry_parent_may_still_exit() {
+        // 複数 instance が並存する update では、新 build の初回 sweep 時点で
+        // 旧 build とその未記録 sidecar がまだ生きていることがある。ここで
+        // marker を書くと、旧 build 終了後に orphan 化しても二度と拾えない。
+        let path = temp_registry("migration-live-parent");
+        let scanner = FakeScanner::new(vec![(300, 4242, sidecar_command(50001))]);
+
+        reap_unrecorded_orphans_at(&path, &FakeProbe::new(), &scanner);
+
+        assert!(!migration_marker_path(&path).exists());
     }
 
     #[test]
     fn migration_sweep_skips_orphan_when_identity_recheck_fails() {
-        // plan と signal の間に PID が別プロセスへ化けた場合、still_matches の
-        // 再確認で signal を送らない。
+        // plan と signal の間に PID が別プロセスへ化けた場合、送信直前の
+        // 完全一致再検査で signal を送らない。
         let path = temp_registry("migration-flip");
         let probe = FakeProbe::new()
             .with_alive(&[300])
+            .with_parent(300, 1)
             .with_command(300, "/usr/bin/vim important.txt");
-        let scanner = FakeScanner {
-            processes: vec![(300, 1, sidecar_command(50001))],
-            established_ports: HashSet::new(),
-        };
+        let scanner = FakeScanner::new(vec![(300, 1, sidecar_command(50001))]);
 
         reap_unrecorded_orphans_at(&path, &probe, &scanner);
 
         assert!(probe.terminated.lock().unwrap().is_empty());
         assert!(probe.force_killed.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn migration_sweep_skips_orphan_reparented_between_plan_and_signal() {
+        // plan 時は PPID=1 だったが、signal 直前の再検査で親が付いていた
+        // （PID が新しい生きた sidecar に再利用された等）場合は送らない。
+        let path = temp_registry("migration-reparent");
+        let probe = FakeProbe::new()
+            .with_alive(&[300])
+            .with_parent(300, 4242)
+            .with_command(300, &sidecar_command(50001));
+        let scanner = FakeScanner::new(vec![(300, 1, sidecar_command(50001))]);
+
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+
+        assert!(probe.terminated.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn migration_sweep_skips_orphan_when_client_connects_after_plan() {
+        // plan 時点では client なし、signal 直前の再検査までに接続された場合は
+        // 送らない。1 回目の client check（plan）は false、2 回目（再検査）から
+        // true になる scanner で window を再現する。
+        let path = temp_registry("migration-late-client");
+        let probe = FakeProbe::new()
+            .with_alive(&[300])
+            .with_parent(300, 1)
+            .with_command(300, &sidecar_command(50001));
+        let mut scanner = FakeScanner::new(vec![(300, 1, sidecar_command(50001))]);
+        scanner.connect_after_calls = Some((1, 50001));
+
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+
+        assert!(probe.terminated.lock().unwrap().is_empty());
+        // client が外れた後に回収できるよう、完了扱いにはしない。
+        assert!(!migration_marker_path(&path).exists());
+    }
+
+    #[test]
+    fn migration_sweep_skips_pid_reused_during_socket_check() {
+        struct StartTimeFlipsAfterSocketCheck {
+            inner: FakeProbe,
+            start_checks: Mutex<usize>,
+        }
+        impl ProcessProbe for StartTimeFlipsAfterSocketCheck {
+            fn is_alive(&self, pid: u32) -> bool {
+                self.inner.is_alive(pid)
+            }
+            fn parent_pid(&self, pid: u32) -> Option<u32> {
+                self.inner.parent_pid(pid)
+            }
+            fn command_line(&self, pid: u32) -> Option<String> {
+                self.inner.command_line(pid)
+            }
+            fn start_time(&self, _pid: u32) -> Option<String> {
+                let mut checks = self.start_checks.lock().unwrap();
+                *checks += 1;
+                Some(if *checks >= 3 { "new" } else { "old" }.into())
+            }
+            fn terminate(&self, pid: u32) {
+                self.inner.terminate(pid);
+            }
+            fn force_kill(&self, pid: u32) {
+                self.inner.force_kill(pid);
+            }
+        }
+
+        let path = temp_registry("migration-pid-reuse-during-lsof");
+        let probe = StartTimeFlipsAfterSocketCheck {
+            inner: FakeProbe::new()
+                .with_alive(&[300])
+                .with_parent(300, 1)
+                .with_command(300, &sidecar_command(50001)),
+            start_checks: Mutex::new(0),
+        };
+        let scanner = FakeScanner::new(vec![(300, 1, sidecar_command(50001))]);
+
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+
+        assert!(probe.inner.terminated.lock().unwrap().is_empty());
+        assert!(!migration_marker_path(&path).exists());
+    }
+
+    #[test]
+    fn migration_sweep_skips_orphan_recorded_between_snapshots() {
+        struct RecordsWhileListing {
+            path: PathBuf,
+        }
+        impl OrphanScanProbe for RecordsWhileListing {
+            fn list_processes(&self) -> Option<Vec<(u32, u32, String)>> {
+                // reap の最初の registry snapshot 後、process plan 前に別 instance
+                // が同じ PID を記録する window を実際の呼び出し順で再現する。
+                assert!(record_spawn(&self.path, entry(9999, 300, 50001)));
+                Some(vec![(300, 1, sidecar_command(50001))])
+            }
+
+            fn has_established_client(&self, _pid: u32, _port: u16) -> bool {
+                false
+            }
+        }
+
+        let path = temp_registry("migration-recorded");
+        let probe = FakeProbe::new()
+            .with_alive(&[300])
+            .with_parent(300, 1)
+            .with_command(300, &sidecar_command(50001));
+        let scanner = RecordsWhileListing { path: path.clone() };
+
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+
+        assert!(probe.terminated.lock().unwrap().is_empty());
+        assert!(!migration_marker_path(&path).exists());
+    }
+
+    #[test]
+    fn migration_sweep_refreshes_registry_before_each_target_signal() {
+        struct RecordsSecondTarget {
+            inner: FakeProbe,
+            path: PathBuf,
+        }
+        impl ProcessProbe for RecordsSecondTarget {
+            fn is_alive(&self, pid: u32) -> bool {
+                self.inner.is_alive(pid)
+            }
+            fn parent_pid(&self, pid: u32) -> Option<u32> {
+                self.inner.parent_pid(pid)
+            }
+            fn command_line(&self, pid: u32) -> Option<String> {
+                self.inner.command_line(pid)
+            }
+            fn terminate(&self, pid: u32) {
+                self.inner.terminate(pid);
+                if pid == 300 {
+                    assert!(record_spawn(&self.path, entry(9999, 301, 50002)));
+                }
+            }
+            fn force_kill(&self, pid: u32) {
+                self.inner.force_kill(pid);
+            }
+        }
+
+        let path = temp_registry("migration-record-between-targets");
+        let probe = RecordsSecondTarget {
+            inner: FakeProbe::new()
+                .with_alive(&[300, 301])
+                .with_parent(300, 1)
+                .with_parent(301, 1)
+                .with_command(300, &sidecar_command(50001))
+                .with_command(301, &sidecar_command(50002)),
+            path: path.clone(),
+        };
+        let scanner = FakeScanner::new(vec![
+            (300, 1, sidecar_command(50001)),
+            (301, 1, sidecar_command(50002)),
+        ]);
+
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+
+        assert_eq!(*probe.inner.terminated.lock().unwrap(), vec![300]);
+        assert!(probe.inner.is_alive(301));
+        assert!(!migration_marker_path(&path).exists());
+    }
+
+    #[test]
+    fn migration_escalation_rechecks_eligibility_before_sigkill() {
+        // TERM を無視する生き残りには、条件の再々確認を通った場合のみ KILL。
+        struct StubbornScanProbe(FakeProbe);
+        impl ProcessProbe for StubbornScanProbe {
+            fn is_alive(&self, pid: u32) -> bool {
+                self.0.alive.lock().unwrap().contains(&pid)
+            }
+            fn parent_pid(&self, pid: u32) -> Option<u32> {
+                self.0.parent_pid(pid)
+            }
+            fn command_line(&self, pid: u32) -> Option<String> {
+                self.0.command_line(pid)
+            }
+            fn terminate(&self, pid: u32) {
+                self.0.terminated.lock().unwrap().push(pid);
+            }
+            fn force_kill(&self, pid: u32) {
+                self.0.force_kill(pid);
+            }
+        }
+
+        let path = temp_registry("migration-escalate");
+        let probe = StubbornScanProbe(
+            FakeProbe::new()
+                .with_alive(&[300])
+                .with_parent(300, 1)
+                .with_command(300, &sidecar_command(50001)),
+        );
+        let scanner = FakeScanner::new(vec![(300, 1, sidecar_command(50001))]);
+
+        reap_unrecorded_orphans_at(&path, &probe, &scanner);
+
+        assert_eq!(*probe.0.terminated.lock().unwrap(), vec![300]);
+        assert_eq!(*probe.0.force_killed.lock().unwrap(), vec![300]);
+        assert!(migration_marker_path(&path).exists());
     }
 
     /// SystemProbe の実バインディング（signal 0 / ps 読み）を実 process で検証する。
@@ -1018,6 +1528,7 @@ mod tests {
         let pid = child.id();
         assert!(probe.is_alive(pid));
         assert_eq!(probe.parent_pid(pid), Some(me));
+        assert!(probe.start_time(pid).is_some());
         assert!(probe
             .command_line(pid)
             .is_some_and(|command| command.contains("sleep")));

--- a/src-tauri/src/sessions/codex_tui_proxy.rs
+++ b/src-tauri/src/sessions/codex_tui_proxy.rs
@@ -1,6 +1,6 @@
 use futures_util::{SinkExt, StreamExt};
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -134,6 +134,7 @@ async fn proxy_connection(
     let (mut client_sink, mut client_stream) = client.split();
     let (mut upstream_sink, mut upstream_stream) = upstream.split();
     let mut thread_selection_requests = HashSet::new();
+    let mut resume_fallback_requests = HashMap::new();
 
     loop {
         tokio::select! {
@@ -142,6 +143,7 @@ async fn proxy_connection(
                 let message = message.map_err(|error| format!("TUI receive failed: {error}"))?;
                 if let Message::Text(text) = &message {
                     track_thread_selection_request(text.as_ref(), &mut thread_selection_requests);
+                    track_resume_fallback_request(text.as_ref(), &mut resume_fallback_requests);
                 }
                 upstream_sink.send(message).await
                     .map_err(|error| format!("upstream send failed: {error}"))?;
@@ -150,6 +152,19 @@ async fn proxy_connection(
                 let Some(message) = message else { break };
                 let message = message.map_err(|error| format!("upstream receive failed: {error}"))?;
                 if let Message::Text(text) = &message {
+                    if let Some(fallback) = take_active_writer_fallback_request(
+                        text.as_ref(),
+                        &mut resume_fallback_requests,
+                    ) {
+                        eprintln!(
+                            "[codex-tui-proxy] resume target has an active writer; forking it instead"
+                        );
+                        upstream_sink
+                            .send(Message::Text(fallback.to_string().into()))
+                            .await
+                            .map_err(|error| format!("upstream fallback send failed: {error}"))?;
+                        continue;
+                    }
                     if let Some(thread_id) = take_selected_thread_response(
                         text.as_ref(),
                         &mut thread_selection_requests,
@@ -193,6 +208,73 @@ fn track_thread_selection_request(raw: &str, pending: &mut HashSet<String>) {
     if let Some(key) = message.get("id").and_then(request_id_key) {
         pending.insert(key);
     }
+}
+
+/// Keep a `thread/fork` equivalent of each resume request until its response arrives.
+/// If Codex rejects the resume because another process still owns the thread writer
+/// lock, the proxy can retry the same selection as a fork without restarting the TUI.
+fn track_resume_fallback_request(raw: &str, pending: &mut HashMap<String, Value>) {
+    const FORK_COMPATIBLE_RESUME_FIELDS: &[&str] = &[
+        "approvalPolicy",
+        "approvalsReviewer",
+        "baseInstructions",
+        "config",
+        "cwd",
+        "developerInstructions",
+        "excludeTurns",
+        "model",
+        "modelProvider",
+        "path",
+        "permissions",
+        "runtimeWorkspaceRoots",
+        "sandbox",
+        "serviceTier",
+        "threadId",
+    ];
+
+    let Ok(mut message) = serde_json::from_str::<Value>(raw) else {
+        return;
+    };
+    if message.get("method").and_then(Value::as_str) != Some("thread/resume") {
+        return;
+    }
+    let Some(key) = message.get("id").and_then(request_id_key) else {
+        return;
+    };
+
+    message["method"] = Value::String("thread/fork".to_string());
+    if let Some(params) = message.get_mut("params").and_then(Value::as_object_mut) {
+        // Forward only fields accepted by both ThreadResumeParams and
+        // ThreadForkParams. A future resume-only field must not make the fallback
+        // fail with invalid params merely because the proxy did not know to drop it.
+        params.retain(|key, _| FORK_COMPATIBLE_RESUME_FIELDS.contains(&key.as_str()));
+    }
+    pending.insert(key, message);
+}
+
+fn take_active_writer_fallback_request(
+    raw: &str,
+    pending: &mut HashMap<String, Value>,
+) -> Option<Value> {
+    let message = serde_json::from_str::<Value>(raw).ok()?;
+    let object = message.as_object()?;
+    if object.contains_key("method") {
+        return None;
+    }
+    let has_result = object.contains_key("result");
+    let has_error = object.contains_key("error");
+    if has_result == has_error {
+        return None;
+    }
+    let key = message.get("id").and_then(request_id_key)?;
+    let fallback = pending.remove(&key)?;
+    let error = message.get("error")?;
+    let is_active_writer = error.get("code").and_then(Value::as_i64) == Some(-32600)
+        && error
+            .get("message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.contains("already has an active writer"));
+    is_active_writer.then_some(fallback)
 }
 
 fn take_selected_thread_response(raw: &str, pending: &mut HashSet<String>) -> Option<String> {
@@ -302,6 +384,95 @@ mod tests {
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
+    #[tokio::test]
+    async fn retries_active_writer_resume_as_fork_without_forwarding_the_error() {
+        let upstream_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("upstream listener");
+        let upstream_address = upstream_listener.local_addr().expect("upstream address");
+        let upstream_task = tokio::spawn(async move {
+            let (stream, _) = upstream_listener.accept().await.expect("upstream accept");
+            let mut socket = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("upstream handshake");
+
+            let resume = socket
+                .next()
+                .await
+                .expect("resume request")
+                .expect("valid resume request");
+            let Message::Text(resume) = resume else {
+                panic!("expected text resume request");
+            };
+            let resume: Value = serde_json::from_str(resume.as_ref()).expect("resume json");
+            assert_eq!(resume["method"], "thread/resume");
+
+            socket
+                .send(Message::Text(
+                    r#"{"id":7,"error":{"code":-32600,"message":"thread old already has an active writer"}}"#
+                        .into(),
+                ))
+                .await
+                .expect("active writer response");
+
+            let fork = socket
+                .next()
+                .await
+                .expect("fork request")
+                .expect("valid fork request");
+            let Message::Text(fork) = fork else {
+                panic!("expected text fork request");
+            };
+            let fork: Value = serde_json::from_str(fork.as_ref()).expect("fork json");
+            assert_eq!(fork["id"], 7);
+            assert_eq!(fork["method"], "thread/fork");
+            assert_eq!(fork["params"]["threadId"], "old");
+            assert_eq!(fork["params"]["cwd"], "/workspace");
+            assert!(fork["params"].get("history").is_none());
+            assert!(fork["params"].get("initialTurnsPage").is_none());
+            assert!(fork["params"].get("personality").is_none());
+
+            socket
+                .send(Message::Text(
+                    r#"{"id":7,"result":{"thread":{"id":"forked"}}}"#.into(),
+                ))
+                .await
+                .expect("fork response");
+        });
+
+        let proxy =
+            CodexTuiProxy::spawn(format!("ws://{upstream_address}")).expect("proxy should start");
+        let (mut client, _) = tokio_tungstenite::connect_async(proxy.endpoint())
+            .await
+            .expect("proxy handshake");
+        client
+            .send(Message::Text(
+                r#"{"method":"thread/resume","id":7,"params":{"threadId":"old","cwd":"/workspace","history":[],"initialTurnsPage":null,"personality":"friendly","futureResumeOnly":true}}"#
+                    .into(),
+            ))
+            .await
+            .expect("proxy request");
+        let response = client
+            .next()
+            .await
+            .expect("response")
+            .expect("valid response");
+        let Message::Text(response) = response else {
+            panic!("expected text response");
+        };
+        let response: Value = serde_json::from_str(response.as_ref()).expect("response json");
+        assert_eq!(response["result"]["thread"]["id"], "forked");
+
+        for _ in 0..20 {
+            if proxy.selected_thread_id().as_deref() == Some("forked") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(proxy.selected_thread_id().as_deref(), Some("forked"));
+        upstream_task.await.expect("upstream task");
+    }
+
     #[test]
     fn observes_only_successful_thread_selection_responses() {
         let mut pending = HashSet::new();
@@ -349,6 +520,41 @@ mod tests {
             None
         );
         assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn does_not_fallback_for_other_resume_failures() {
+        let mut pending = HashMap::new();
+        track_resume_fallback_request(
+            r#"{"method":"thread/resume","id":7,"params":{"threadId":"old"}}"#,
+            &mut pending,
+        );
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            take_active_writer_fallback_request(
+                r#"{"id":7,"error":{"code":-32600,"message":"invalid thread"}}"#,
+                &mut pending,
+            ),
+            None
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn malformed_resume_response_does_not_trigger_fallback_or_consume_it() {
+        let mut pending = HashMap::new();
+        track_resume_fallback_request(
+            r#"{"method":"thread/resume","id":7,"params":{"threadId":"old"}}"#,
+            &mut pending,
+        );
+        assert_eq!(
+            take_active_writer_fallback_request(
+                r#"{"id":7,"result":{},"error":{"code":-32600,"message":"thread old already has an active writer"}}"#,
+                &mut pending,
+            ),
+            None
+        );
+        assert_eq!(pending.len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/sessions/pty_session.rs
+++ b/src-tauri/src/sessions/pty_session.rs
@@ -352,15 +352,15 @@ impl CodexAppServerProcess {
             command.current_dir(dir);
         }
 
-        let child = command.spawn().map_err(|e| {
+        let mut child = command.spawn().map_err(|e| {
             format!(
                 "Failed to spawn Codex app-server ({binary}). Codex 0.145.0 or newer is required: {e}"
             )
         })?;
         // app が Drop を経ずに死んだ場合の startup reaper 用（issue #109）。
-        // 以降どの失敗経路でも Self が Drop され、registry の entry ごと回収される。
-        // 記録失敗でも session は起動させる（可用性優先）が、その sidecar は
-        // crash 時に reap 不能になるため警告を残す。
+        // 記録成功後はどの失敗経路でも Self が Drop され、entry ごと回収される。
+        // registry に記録できない sidecar は crash 後に安全な provenance 判定が
+        // できない。未記録 orphan を新たに作らないよう、起動を成立させず即回収する。
         let recorded = crate::yorishiro_home_path().is_ok_and(|home| {
             super::codex_sidecar_registry::record_spawn(
                 &super::codex_sidecar_registry::registry_path_under(&home),
@@ -372,10 +372,12 @@ impl CodexAppServerProcess {
             )
         });
         if !recorded {
-            eprintln!(
-                "[codex-sidecar] failed to record sidecar pid {}; it cannot be reaped after a crash",
-                child.id()
-            );
+            let sidecar_pid = child.id();
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!(
+                "Failed to record Codex app-server sidecar pid {sidecar_pid}; the process was stopped to avoid an untracked orphan"
+            ));
         }
         let mut process = Self {
             child,


### PR DESCRIPTION
## Summary

Fixes the known Codex startup failure tracked in #115, following the lifecycle work in #109.

When a pre-registry source/pre-release build leaves a `codex app-server` sidecar behind, v0.7.0 has no registry entry for it. The process can keep the most recent thread's writer lock, causing `resume --last` to fail with `-32600 already has an active writer` on every retry. The same error is legitimate when another Codex client is actively using the thread; Yorishiro must recover without killing that client.

Released v0.6.2 and earlier did not spawn this sidecar, so normal v0.6.2 → v0.7.0 release-channel updates are not affected. The confirmed migration case is limited to pre-release/source builds that contained the sidecar before the registry was added.

## Changes

- run a one-time migration sweep for unrecorded pre-registry sidecars
- require the exact Yorishiro command shape, `PPID=1`, no registry entry, and no client connection on that process's listen socket
- scope socket inspection by PID and port, preserving active or unrelated Codex integrations
- re-check process start time, PPID, command, client state, and the latest registry around TERM and KILL delivery
- re-read the registry for each target so a concurrent session registration cannot be signalled from a stale snapshot
- keep retrying when process enumeration fails, a client is present, a matching pre-registry parent is still alive, or a target becomes unsafe to signal
- write a completion marker after a clean migration pass so heuristic cleanup does not become a permanent process reaper
- fail closed when a new sidecar cannot be recorded: stop and wait for the child instead of allowing a future untracked orphan
- document the remaining raw-PID syscall window on macOS, where no pidfd-equivalent signal API is available
- keep the normal Codex startup path resume-first, preserving the same thread whenever its writer is available
- when and only when `thread/resume` returns the active-writer error, transparently retry the same thread selection as `thread/fork`
- forward all other resume errors unchanged, and allowlist only Resume/Fork-compatible protocol fields in the fallback request

## Safety review

An independent second-agent review found and then verified fixes for two races:

- PID reuse while `lsof` is running
- another instance recording a later target between target signals

The follow-up protocol review also checked request-ID handling, server request collisions, Resume/Fork schema compatibility, malformed responses, and non-active-writer errors. After the follow-up changes, the reviewer reported no remaining blocking findings and approved the branch for push.

## Validation

- `cargo test`: 302 passed
- `npm run test:run`: 2,287 passed
- focused `codex_sidecar_registry` tests: 31 passed
- focused `codex_tui_proxy` tests: 9 passed
- `npm run check`: passed
- pre-push checks: TypeScript, Biome, Rust format, Clippy, and TypeDoc all passed
- `git diff --check`: passed
- dev-build smoke test: with the original thread still locked by another Codex process, Yorishiro created a new rollout with the expected `forked_from_id` and kept the TUI running

## Operational note

Do not kill all Codex processes as a workaround. A different terminal, editor, or Codex integration may legitimately own the active thread. This migration only reaps the narrow orphan shape above; a legitimate active writer remains alive and Yorishiro forks its thread history instead.
