### PR TITLE
Add Back and Forward navigation for Main Agent sessions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -913,6 +913,22 @@ fn prepare_localized_plugin_dir(app: AppHandle, language: String) -> Result<Stri
 /// 任意 session id で PTY を spawn する。session_id を省略した legacy 呼び出し
 /// （旧 single-pane flow）は default-session を作る。caller が明示的に id を
 /// 渡せば multi-pane で session を並列に持てる。
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionSpawnResult {
+    /// replace 直前のbackendが保持していたprovider-confirmed session ID。
+    /// frontend pollingの成否に依存せず、NewのBack originを確実に保持するために返す。
+    replaced_confirmed_session_id: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionSpawnError {
+    message: String,
+    /// spawn失敗時も、既に置換されたsessionをcallerがexact restoreできるよう返す。
+    replaced_confirmed_session_id: Option<String>,
+}
+
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 async fn session_spawn(
@@ -924,7 +940,7 @@ async fn session_spawn(
     rows: u16,
     cwd: Option<String>,
     on_output: Channel,
-) -> Result<(), String> {
+) -> Result<SessionSpawnResult, SessionSpawnError> {
     // Agent variant のときだけ Tauri resource path から plugin_dir を差し込む。
     // Claude Code では --plugin-dir、Codex では local marketplace root として使う。
     let final_spec = match spec {
@@ -934,6 +950,7 @@ async fn session_spawn(
             system_prompt,
             plugin_dir,
             resume,
+            resume_session_id,
             ..
         } => {
             let plugin_dir = plugin_dir.or_else(|| {
@@ -948,12 +965,27 @@ async fn session_spawn(
                 system_prompt,
                 plugin_dir,
                 resume,
+                resume_session_id,
             }
         }
         shell @ SpawnSpec::Shell { .. } => shell,
     };
     let id = session_id.unwrap_or_else(|| sessions::DEFAULT_SESSION_ID.to_string());
-    state.spawn(app, &id, cols, rows, cwd, &final_spec, on_output)
+    // 読み取りとreplaceの間にawaitを挟まない。frontend側も同sessionのspawn invokeを
+    // 直列化するため、これは実際に置換されるPTYのatomicなorigin snapshotになる。
+    let replaced_confirmed_session_id = state
+        .realtime_selected_thread(&id)
+        .filter(|selected| selected.confirmed)
+        .map(|selected| selected.session_id);
+    match state.spawn(app, &id, cols, rows, cwd, &final_spec, on_output) {
+        Ok(()) => Ok(SessionSpawnResult {
+            replaced_confirmed_session_id,
+        }),
+        Err(message) => Err(SessionSpawnError {
+            message,
+            replaced_confirmed_session_id,
+        }),
+    }
 }
 
 #[tauri::command]
@@ -1035,6 +1067,14 @@ async fn session_realtime_selected_thread(
     session_id: String,
 ) -> Result<Option<String>, String> {
     Ok(pty_state.realtime_selected_thread_id(&session_id))
+}
+
+#[tauri::command]
+async fn session_realtime_selected_thread_state(
+    pty_state: State<'_, PtyState>,
+    session_id: String,
+) -> Result<Option<crate::sessions::pty_session::CodexSelectedThread>, String> {
+    Ok(pty_state.realtime_selected_thread(&session_id))
 }
 
 #[tauri::command]
@@ -2416,6 +2456,7 @@ pub fn run() {
             session_realtime_connect,
             session_realtime_capabilities,
             session_realtime_selected_thread,
+            session_realtime_selected_thread_state,
             session_realtime_send,
             session_realtime_disconnect,
             session_list,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -509,6 +509,14 @@ impl PtyState {
             .and_then(|session| session.realtime_selected_thread_id())
     }
 
+    pub fn realtime_selected_thread(
+        &self,
+        session_id: &str,
+    ) -> Option<crate::sessions::pty_session::CodexSelectedThread> {
+        self.session_or_default(session_id)
+            .and_then(|session| session.realtime_selected_thread())
+    }
+
     pub fn write_data(&self, session_id: &str, data: &str) -> Result<(), String> {
         let Some(session) = self.session_or_default(session_id) else {
             return Ok(());

--- a/src-tauri/src/sessions/agent_adapter/codex.rs
+++ b/src-tauri/src/sessions/agent_adapter/codex.rs
@@ -45,7 +45,10 @@ impl TerminalAgent for CodexAgent {
             args.push(endpoint.to_string());
         }
 
-        if ctx.resume && self.has_existing_session(ctx.cwd) {
+        if let Some(session_id) = ctx.resume_session_id.filter(|id| !id.is_empty()) {
+            args.push("resume".to_string());
+            args.push(session_id.to_string());
+        } else if ctx.resume && self.has_existing_session(ctx.cwd) {
             args.push("resume".to_string());
             args.push("--last".to_string());
         }
@@ -186,6 +189,7 @@ mod tests {
             mcp_port: 18743,
             hook_port: 19001,
             resume: true,
+            resume_session_id: None,
             realtime_endpoint: None,
         }
     }
@@ -204,6 +208,7 @@ mod tests {
             mcp_port: 18743,
             hook_port: 19001,
             resume,
+            resume_session_id: None,
             realtime_endpoint: None,
         }
     }
@@ -311,6 +316,16 @@ mod tests {
             .args
             .iter()
             .any(|arg| arg == &codex_yorishiro_mcp_config_arg(18743)));
+    }
+
+    #[test]
+    fn codex_resumes_an_exact_session_id() {
+        let mut ctx = make_ctx_with_resume(None, None, None, false);
+        ctx.resume_session_id = Some("0198-exact-session-id");
+        let result = CODEX.build_launch_args(&ctx).expect("build_launch_args");
+
+        assert_eq!(&result.args[..2], ["resume", "0198-exact-session-id"]);
+        assert!(!result.args.iter().any(|arg| arg == "--last"));
     }
 
     #[test]

--- a/src-tauri/src/sessions/agent_adapter/mod.rs
+++ b/src-tauri/src/sessions/agent_adapter/mod.rs
@@ -69,6 +69,8 @@ pub struct LaunchContext<'a> {
     pub mcp_port: u16,
     pub hook_port: u16,
     pub resume: bool,
+    /// provider 固有の会話 ID を指定した exact resume。未指定時は従来の resume policy。
+    pub resume_session_id: Option<&'a str>,
     /// 同じ conversation を共有する agent app-server の WebSocket endpoint。
     pub realtime_endpoint: Option<&'a str>,
 }

--- a/src-tauri/src/sessions/agent_adapter/opencode.rs
+++ b/src-tauri/src/sessions/agent_adapter/opencode.rs
@@ -255,6 +255,7 @@ mod tests {
             mcp_port: 18743,
             hook_port: 19001,
             resume: true,
+            resume_session_id: None,
             realtime_endpoint: None,
         }
     }
@@ -271,6 +272,7 @@ mod tests {
             mcp_port: 18743,
             hook_port: 19001,
             resume: true,
+            resume_session_id: None,
             realtime_endpoint: None,
         }
     }

--- a/src-tauri/src/sessions/codex_tui_proxy.rs
+++ b/src-tauri/src/sessions/codex_tui_proxy.rs
@@ -1,6 +1,6 @@
 use futures_util::{SinkExt, StreamExt};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -15,9 +15,19 @@ use tokio_tungstenite::tungstenite::{
 /// transcript や turn payload は保存しない。
 pub(super) struct CodexTuiProxy {
     endpoint: String,
-    selected_thread_id: Arc<Mutex<Option<String>>>,
+    selected_thread: Arc<Mutex<Option<SelectedThread>>>,
     shutdown: Option<oneshot::Sender<()>>,
     thread: Option<JoinHandle<()>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct SelectedThread {
+    pub(super) id: String,
+    /// resume / fork response、または最初の turn/start 済みなら true。
+    /// thread/start response だけなら未確定。
+    pub(super) confirmed: bool,
+    /// proxy が観測した top-level selection / turn-start ごとに増える。
+    pub(super) revision: u64,
 }
 
 impl CodexTuiProxy {
@@ -31,8 +41,8 @@ impl CodexTuiProxy {
             .set_nonblocking(true)
             .map_err(|error| format!("Codex TUI proxy nonblocking setup failed: {error}"))?;
         let endpoint = format!("ws://{address}");
-        let selected_thread_id = Arc::new(Mutex::new(None));
-        let task_selected_thread_id = Arc::clone(&selected_thread_id);
+        let selected_thread = Arc::new(Mutex::new(None));
+        let task_selected_thread = Arc::clone(&selected_thread);
         let (shutdown, mut shutdown_rx) = oneshot::channel();
 
         let thread = std::thread::Builder::new()
@@ -62,7 +72,7 @@ impl CodexTuiProxy {
                             accepted = listener.accept() => {
                                 let Ok((stream, _)) = accepted else { continue };
                                 let upstream = upstream_endpoint.clone();
-                                let selected = Arc::clone(&task_selected_thread_id);
+                                let selected = Arc::clone(&task_selected_thread);
                                 tokio::spawn(async move {
                                     if let Err(error) = proxy_connection(stream, upstream, selected).await {
                                         eprintln!("[codex-tui-proxy] connection ended: {error}");
@@ -77,7 +87,7 @@ impl CodexTuiProxy {
 
         Ok(Self {
             endpoint,
-            selected_thread_id,
+            selected_thread,
             shutdown: Some(shutdown),
             thread: Some(thread),
         })
@@ -88,7 +98,15 @@ impl CodexTuiProxy {
     }
 
     pub(super) fn selected_thread_id(&self) -> Option<String> {
-        self.selected_thread_id
+        self.selected_thread
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .map(|selected| selected.id.clone())
+    }
+
+    pub(super) fn selected_thread(&self) -> Option<SelectedThread> {
+        self.selected_thread
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
@@ -123,7 +141,7 @@ impl Callback for RejectBrowserOrigin {
 async fn proxy_connection(
     client_stream: tokio::net::TcpStream,
     upstream_endpoint: String,
-    selected_thread_id: Arc<Mutex<Option<String>>>,
+    selected_thread: Arc<Mutex<Option<SelectedThread>>>,
 ) -> Result<(), String> {
     let client = tokio_tungstenite::accept_hdr_async(client_stream, RejectBrowserOrigin)
         .await
@@ -133,8 +151,9 @@ async fn proxy_connection(
         .map_err(|error| format!("upstream connection failed: {error}"))?;
     let (mut client_sink, mut client_stream) = client.split();
     let (mut upstream_sink, mut upstream_stream) = upstream.split();
-    let mut thread_selection_requests = HashSet::new();
+    let mut thread_selection_requests = HashMap::new();
     let mut resume_fallback_requests = HashMap::new();
+    let mut turn_start_requests = HashMap::new();
 
     loop {
         tokio::select! {
@@ -144,6 +163,7 @@ async fn proxy_connection(
                 if let Message::Text(text) = &message {
                     track_thread_selection_request(text.as_ref(), &mut thread_selection_requests);
                     track_resume_fallback_request(text.as_ref(), &mut resume_fallback_requests);
+                    track_turn_start_request(text.as_ref(), &mut turn_start_requests);
                 }
                 upstream_sink.send(message).await
                     .map_err(|error| format!("upstream send failed: {error}"))?;
@@ -152,6 +172,12 @@ async fn proxy_connection(
                 let Some(message) = message else { break };
                 let message = message.map_err(|error| format!("upstream receive failed: {error}"))?;
                 if let Message::Text(text) = &message {
+                    if let Some(thread_id) = take_successful_turn_start_response(
+                        text.as_ref(),
+                        &mut turn_start_requests,
+                    ) {
+                        mark_selected_thread_confirmed(&thread_id, &selected_thread);
+                    }
                     if let Some(fallback) = take_active_writer_fallback_request(
                         text.as_ref(),
                         &mut resume_fallback_requests,
@@ -165,13 +191,17 @@ async fn proxy_connection(
                             .map_err(|error| format!("upstream fallback send failed: {error}"))?;
                         continue;
                     }
-                    if let Some(thread_id) = take_selected_thread_response(
+                    if let Some(mut selection) = take_selected_thread_response(
                         text.as_ref(),
                         &mut thread_selection_requests,
                     ) {
-                        *selected_thread_id
+                        let mut selected = selected_thread
                             .lock()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(thread_id);
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        selection.revision = selected
+                            .as_ref()
+                            .map_or(1, |current| current.revision.saturating_add(1));
+                        *selected = Some(selection);
                     }
                 }
                 client_sink.send(message).await
@@ -186,27 +216,78 @@ fn request_id_key(value: &Value) -> Option<String> {
     serde_json::to_string(value).ok()
 }
 
-fn track_thread_selection_request(raw: &str, pending: &mut HashSet<String>) {
+fn track_thread_selection_request(raw: &str, pending: &mut HashMap<String, bool>) {
     let Ok(message) = serde_json::from_str::<Value>(raw) else {
         return;
     };
     let method = message.get("method").and_then(Value::as_str);
-    let selects_main_thread = match method {
-        Some("thread/start" | "thread/resume") => true,
-        Some("thread/fork") => {
-            message
-                .get("params")
-                .and_then(|params| params.get("excludeTurns"))
-                .and_then(Value::as_bool)
-                != Some(true)
-        }
-        _ => false,
+    let confirmed = match method {
+        Some("thread/start") => Some(false),
+        Some("thread/resume") => Some(true),
+        Some("thread/fork") => (message
+            .get("params")
+            .and_then(|params| params.get("excludeTurns"))
+            .and_then(Value::as_bool)
+            != Some(true))
+        .then_some(true),
+        _ => None,
     };
-    if !selects_main_thread {
+    if let (Some(key), Some(confirmed)) = (message.get("id").and_then(request_id_key), confirmed) {
+        pending.insert(key, confirmed);
+    }
+}
+
+fn track_turn_start_request(raw: &str, pending: &mut HashMap<String, String>) {
+    let Ok(message) = serde_json::from_str::<Value>(raw) else {
+        return;
+    };
+    if message.get("method").and_then(Value::as_str) != Some("turn/start") {
         return;
     }
+    let Some(thread_id) = message
+        .get("params")
+        .and_then(|params| params.get("threadId"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
     if let Some(key) = message.get("id").and_then(request_id_key) {
-        pending.insert(key);
+        pending.insert(key, thread_id.to_string());
+    }
+}
+
+fn take_successful_turn_start_response(
+    raw: &str,
+    pending: &mut HashMap<String, String>,
+) -> Option<String> {
+    let message = serde_json::from_str::<Value>(raw).ok()?;
+    let object = message.as_object()?;
+    if object.contains_key("method") {
+        return None;
+    }
+    let has_result = object.contains_key("result");
+    let has_error = object.contains_key("error");
+    if has_result == has_error {
+        return None;
+    }
+    let key = message.get("id").and_then(request_id_key)?;
+    let thread_id = pending.remove(&key)?;
+    has_result.then_some(thread_id)
+}
+
+fn mark_selected_thread_confirmed(
+    thread_id: &str,
+    selected_thread: &Arc<Mutex<Option<SelectedThread>>>,
+) {
+    let mut selected = selected_thread
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(selected) = selected
+        .as_mut()
+        .filter(|selected| selected.id == thread_id)
+    {
+        selected.confirmed = true;
+        selected.revision = selected.revision.saturating_add(1);
     }
 }
 
@@ -277,7 +358,10 @@ fn take_active_writer_fallback_request(
     is_active_writer.then_some(fallback)
 }
 
-fn take_selected_thread_response(raw: &str, pending: &mut HashSet<String>) -> Option<String> {
+fn take_selected_thread_response(
+    raw: &str,
+    pending: &mut HashMap<String, bool>,
+) -> Option<SelectedThread> {
     let message = serde_json::from_str::<Value>(raw).ok()?;
     let object = message.as_object()?;
     if object.contains_key("method") {
@@ -289,16 +373,19 @@ fn take_selected_thread_response(raw: &str, pending: &mut HashSet<String>) -> Op
         return None;
     }
     let key = message.get("id").and_then(request_id_key)?;
-    if !pending.remove(&key) {
-        return None;
-    }
-    message
+    let confirmed = pending.remove(&key)?;
+    let id = message
         .get("result")?
         .get("thread")?
         .get("id")?
         .as_str()
-        .filter(|thread_id| !thread_id.is_empty())
-        .map(str::to_string)
+        .filter(|thread_id| !thread_id.is_empty())?;
+    Some(SelectedThread {
+        id: id.to_string(),
+        confirmed,
+        // proxy_connection が共有 state へ格納するとき単調 revision を割り当てる。
+        revision: 0,
+    })
 }
 
 #[cfg(test)]
@@ -359,6 +446,14 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         assert_eq!(proxy.selected_thread_id().as_deref(), Some("resumed"));
+        assert_eq!(
+            proxy.selected_thread(),
+            Some(SelectedThread {
+                id: "resumed".to_string(),
+                confirmed: true,
+                revision: 1,
+            })
+        );
         upstream_task.await.expect("upstream task");
     }
 
@@ -475,7 +570,7 @@ mod tests {
 
     #[test]
     fn observes_only_successful_thread_selection_responses() {
-        let mut pending = HashSet::new();
+        let mut pending = HashMap::new();
         track_thread_selection_request(
             r#"{"method":"thread/resume","id":7,"params":{"threadId":"old"}}"#,
             &mut pending,
@@ -485,14 +580,96 @@ mod tests {
                 r#"{"id":7,"result":{"thread":{"id":"resumed"}}}"#,
                 &mut pending,
             ),
-            Some("resumed".to_string())
+            Some(SelectedThread {
+                id: "resumed".to_string(),
+                confirmed: true,
+                revision: 0,
+            })
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn marks_thread_start_unconfirmed_until_the_provider_starts_a_turn() {
+        let mut pending = HashMap::new();
+        track_thread_selection_request(
+            r#"{"method":"thread/start","id":8,"params":{}}"#,
+            &mut pending,
+        );
+        assert_eq!(
+            take_selected_thread_response(
+                r#"{"id":8,"result":{"thread":{"id":"blank"}}}"#,
+                &mut pending,
+            ),
+            Some(SelectedThread {
+                id: "blank".to_string(),
+                confirmed: false,
+                revision: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn marks_started_thread_confirmed_when_its_first_turn_starts() {
+        let selected = Arc::new(Mutex::new(Some(SelectedThread {
+            id: "new-thread".to_string(),
+            confirmed: false,
+            revision: 1,
+        })));
+        let mut pending = HashMap::new();
+        track_turn_start_request(
+            r#"{"method":"turn/start","id":10,"params":{"threadId":"new-thread","input":[]}}"#,
+            &mut pending,
+        );
+        let thread_id = take_successful_turn_start_response(
+            r#"{"id":10,"result":{"turn":{"id":"turn-1"}}}"#,
+            &mut pending,
+        )
+        .expect("accepted turn");
+        mark_selected_thread_confirmed(&thread_id, &selected);
+        assert_eq!(
+            selected
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .as_ref()
+                .map(|selected| (selected.confirmed, selected.revision)),
+            Some((true, 2))
+        );
+    }
+
+    #[test]
+    fn rejected_turn_start_does_not_confirm_the_selected_thread() {
+        let selected = Arc::new(Mutex::new(Some(SelectedThread {
+            id: "new-thread".to_string(),
+            confirmed: false,
+            revision: 1,
+        })));
+        let mut pending = HashMap::new();
+        track_turn_start_request(
+            r#"{"method":"turn/start","id":10,"params":{"threadId":"new-thread","input":[]}}"#,
+            &mut pending,
+        );
+        assert_eq!(
+            take_successful_turn_start_response(
+                r#"{"id":10,"error":{"code":-32600,"message":"rejected"}}"#,
+                &mut pending,
+            ),
+            None
+        );
+        assert_eq!(
+            selected
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .as_ref()
+                .map(|selected| (selected.confirmed, selected.revision)),
+            Some((false, 1))
         );
         assert!(pending.is_empty());
     }
 
     #[test]
     fn ignores_unrelated_and_failed_responses() {
-        let mut pending = HashSet::new();
+        let mut pending = HashMap::new();
         track_thread_selection_request(
             r#"{"method":"thread/read","id":1,"params":{}}"#,
             &mut pending,
@@ -559,7 +736,7 @@ mod tests {
 
     #[test]
     fn server_request_id_collision_does_not_consume_pending_selection() {
-        let mut pending = HashSet::new();
+        let mut pending = HashMap::new();
         track_thread_selection_request(
             r#"{"method":"thread/resume","id":7,"params":{"threadId":"old"}}"#,
             &mut pending,
@@ -572,20 +749,24 @@ mod tests {
             ),
             None
         );
-        assert!(pending.contains("7"));
+        assert!(pending.contains_key("7"));
         assert_eq!(
             take_selected_thread_response(
                 r#"{"id":7,"result":{"thread":{"id":"resumed"}}}"#,
                 &mut pending,
             ),
-            Some("resumed".to_string())
+            Some(SelectedThread {
+                id: "resumed".to_string(),
+                confirmed: true,
+                revision: 0,
+            })
         );
         assert!(pending.is_empty());
     }
 
     #[test]
     fn malformed_response_does_not_consume_pending_selection() {
-        let mut pending = HashSet::new();
+        let mut pending = HashMap::new();
         track_thread_selection_request(
             r#"{"method":"thread/start","id":9,"params":{}}"#,
             &mut pending,
@@ -598,6 +779,6 @@ mod tests {
             ),
             None
         );
-        assert!(pending.contains("9"));
+        assert!(pending.contains_key("9"));
     }
 }

--- a/src-tauri/src/sessions/pty_session.rs
+++ b/src-tauri/src/sessions/pty_session.rs
@@ -57,6 +57,9 @@ pub enum SpawnSpec {
         /// false のとき agent adapter の既存会話 resume を禁止して完全新規 session を起動する。
         #[serde(default = "default_true")]
         resume: bool,
+        /// provider 固有の会話 ID を指定して再開する。現在は Codex adapter のみ使用する。
+        #[serde(default)]
+        resume_session_id: Option<String>,
     },
     Shell {
         /// Shell binary path を override したい場合のみ Some。None なら `$SHELL`、
@@ -254,6 +257,16 @@ pub struct CodexRealtimeCapabilities {
     pub persona_initial_items: bool,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexSelectedThread {
+    pub session_id: String,
+    /// resume / fork、または最初の turn/start 済みなら true。thread/start だけなら false。
+    pub confirmed: bool,
+    /// 同じ app-server process 内の top-level selection / turn-start revision。
+    pub revision: u64,
+}
+
 fn parse_codex_cli_version(output: &str) -> Option<String> {
     let version =
         output.split_whitespace().find(|part| {
@@ -400,6 +413,17 @@ impl CodexAppServerProcess {
             .and_then(CodexTuiProxy::selected_thread_id)
     }
 
+    fn selected_thread(&self) -> Option<CodexSelectedThread> {
+        self.tui_proxy
+            .as_ref()
+            .and_then(CodexTuiProxy::selected_thread)
+            .map(|selected| CodexSelectedThread {
+                session_id: selected.id,
+                confirmed: selected.confirmed,
+                revision: selected.revision,
+            })
+    }
+
     fn wait_until_ready(&mut self, address: SocketAddr) -> Result<(), String> {
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline {
@@ -528,6 +552,7 @@ impl PtySession {
                 system_prompt,
                 plugin_dir,
                 resume,
+                resume_session_id,
             } => {
                 let adapter = crate::sessions::agent_adapter::lookup(agent_id.as_str())
                     .ok_or_else(|| format!("Unknown agent id: {}", agent_id))?;
@@ -561,6 +586,7 @@ impl PtySession {
                     mcp_port: crate::mcp::server::resolve_port(),
                     hook_port: crate::pty::HOOK_SERVER_PORT,
                     resume: *resume,
+                    resume_session_id: resume_session_id.as_deref(),
                     realtime_endpoint: pending_app_server
                         .as_ref()
                         .and_then(CodexAppServerProcess::tui_endpoint),
@@ -766,6 +792,12 @@ impl PtySession {
         lock_or_recover(&self.codex_app_server)
             .as_ref()
             .and_then(CodexAppServerProcess::selected_thread_id)
+    }
+
+    pub fn realtime_selected_thread(&self) -> Option<CodexSelectedThread> {
+        lock_or_recover(&self.codex_app_server)
+            .as_ref()
+            .and_then(CodexAppServerProcess::selected_thread)
     }
 
     pub fn write_data(&self, data: &str) -> Result<(), String> {

--- a/src/App.css
+++ b/src/App.css
@@ -191,6 +191,15 @@ body,
   color: #ffd2d2;
 }
 
+.title-bar-voice-button:disabled {
+  color: #737373;
+  cursor: default;
+}
+
+.title-bar-voice-button:disabled svg {
+  opacity: 0.34;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .title-bar-voice-button[data-voice-state="connecting"] svg {
     animation: none;
@@ -1125,11 +1134,17 @@ body,
 }
 
 .tab-indicator-item.is-main {
+  width: 210px;
+  min-width: 200px;
+  max-width: 210px;
+  flex-basis: 210px;
   background: rgba(255, 255, 255, 0.075);
   color: #d6d6d6;
 }
 
 .tab-indicator-tab,
+.tab-indicator-conversation-back,
+.tab-indicator-conversation-forward,
 .tab-indicator-new-conversation,
 .tab-indicator-close,
 .tab-indicator-add {
@@ -1200,6 +1215,8 @@ body,
   opacity: 0;
 }
 
+.tab-indicator-conversation-back,
+.tab-indicator-conversation-forward,
 .tab-indicator-new-conversation {
   width: 22px;
   height: 19px;
@@ -1207,6 +1224,28 @@ body,
   margin-left: 2px;
   border-radius: 4px;
   color: #b8b8b8;
+}
+
+.tab-indicator-conversation-navigation {
+  height: 19px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0;
+  margin-left: 2px;
+}
+
+.tab-indicator-conversation-navigation .tab-indicator-conversation-back,
+.tab-indicator-conversation-navigation .tab-indicator-conversation-forward {
+  width: 19px;
+  height: 19px;
+  flex-basis: 19px;
+  margin-left: 0;
+  border-radius: 4px;
+}
+
+.tab-indicator-new-conversation {
+  margin-left: 6px;
 }
 
 .tab-indicator-add {
@@ -1233,14 +1272,20 @@ body,
   outline: none;
 }
 
+.tab-indicator-conversation-back svg,
+.tab-indicator-conversation-forward svg,
 .tab-indicator-new-conversation svg,
 .tab-indicator-add svg {
   opacity: 0.68;
   transition: opacity 0.15s;
 }
 
-.tab-indicator-new-conversation:hover,
-.tab-indicator-new-conversation:focus-visible,
+.tab-indicator-conversation-back:hover:not(:disabled),
+.tab-indicator-conversation-back:focus-visible:not(:disabled),
+.tab-indicator-conversation-forward:hover:not(:disabled),
+.tab-indicator-conversation-forward:focus-visible:not(:disabled),
+.tab-indicator-new-conversation:hover:not(:disabled),
+.tab-indicator-new-conversation:focus-visible:not(:disabled),
 .tab-indicator-add:hover,
 .tab-indicator-add:focus-visible {
   background: transparent;
@@ -1248,11 +1293,46 @@ body,
   outline: none;
 }
 
-.tab-indicator-new-conversation:hover svg,
-.tab-indicator-new-conversation:focus-visible svg,
+.tab-indicator-conversation-back:hover:not(:disabled) svg,
+.tab-indicator-conversation-back:focus-visible:not(:disabled) svg,
+.tab-indicator-conversation-forward:hover:not(:disabled) svg,
+.tab-indicator-conversation-forward:focus-visible:not(:disabled) svg,
+.tab-indicator-new-conversation:hover:not(:disabled) svg,
+.tab-indicator-new-conversation:focus-visible:not(:disabled) svg,
 .tab-indicator-add:hover svg,
 .tab-indicator-add:focus-visible svg {
   opacity: 1;
+}
+
+.tab-indicator-conversation-navigation .tab-indicator-conversation-back:hover:not(:disabled),
+.tab-indicator-conversation-navigation .tab-indicator-conversation-forward:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.tab-indicator-conversation-navigation .tab-indicator-conversation-back:active:not(:disabled),
+.tab-indicator-conversation-navigation .tab-indicator-conversation-forward:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.tab-indicator-conversation-navigation
+  .tab-indicator-conversation-back:focus-visible:not(:disabled),
+.tab-indicator-conversation-navigation
+  .tab-indicator-conversation-forward:focus-visible:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(225, 225, 230, 0.44);
+}
+
+.tab-indicator-conversation-back:disabled,
+.tab-indicator-conversation-forward:disabled,
+.tab-indicator-new-conversation:disabled {
+  color: #737373;
+  cursor: default;
+}
+
+.tab-indicator-conversation-back:disabled svg,
+.tab-indicator-conversation-forward:disabled svg,
+.tab-indicator-new-conversation:disabled svg {
+  opacity: 0.34;
 }
 
 .tab-indicator-item.active {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,9 +30,12 @@ import {
   prepareLocalizedPluginDir,
   ptyWrite,
   resolveCommandPath,
+  type SessionRealtimeSelectedThreadState,
+  SessionSpawnError,
   type SpawnSpec,
   sessionDestroy,
   sessionList,
+  sessionRealtimeSelectedThreadState,
   sessionRefreshTheme,
   snapshotCreate,
   snapshotList,
@@ -235,10 +238,38 @@ import {
   withSessionPersonaRecord,
 } from "./runtime/sessions";
 import {
+  type ActiveConversationEntry,
+  beginConversationTransition,
+  type ConversationEntryLaunch,
+  type ConversationNavigationAction,
+  type ConversationNavigationDirection,
+  type ConversationNavigationTrail,
+  type ConversationTransitionKind,
+  type ConversationTransitionLease,
+  canNavigateConversation,
+  conversationEntriesEqual,
+  conversationEntryLaunch,
+  conversationNavigationReducer,
+  conversationNavigationTarget,
+  createConversationTransitionGate,
+  currentConversationEntry,
+  EMPTY_CONVERSATION_NAVIGATION_TRAIL,
+  finishConversationTransition,
+  isConversationTransitionActive,
+  prepareConversationDraftForReplacement,
+  prepareFreshConversationRequest,
+} from "./runtime/sessions/conversation-navigation";
+import {
   spawnSpecFromDefaultProfile,
   withAgentResumePolicy,
+  withAgentResumeSessionId,
   withAgentRuntimeFields,
 } from "./runtime/sessions/default-spawn-spec";
+import {
+  readConversationSelectionWithin,
+  waitForConversationSelectionAfterSubmit,
+  waitForObservedSessionId,
+} from "./runtime/sessions/observed-session";
 import { getSurfaceRegistry, type SurfaceName } from "./runtime/surface-registry";
 import {
   getAgentToolRunStore,
@@ -2448,10 +2479,53 @@ function App() {
   const [mainSessionResumeEnabled, setMainSessionResumeEnabled] = useState(true);
   const [mainFreshRequestSeq, setMainFreshRequestSeq] = useState(0);
   const [mainSessionReplacing, setMainSessionReplacing] = useState(false);
+  const [mainConversationTrail, reactDispatchMainConversationTrail] = React.useReducer(
+    conversationNavigationReducer,
+    EMPTY_CONVERSATION_NAVIGATION_TRAIL,
+  );
   const [voiceReconnectPending, setVoiceReconnectPending] = useState(false);
+  const mainConversationTransitionGateRef = useRef(createConversationTransitionGate());
+  const mainConversationTrailRef = useRef<ConversationNavigationTrail>(
+    EMPTY_CONVERSATION_NAVIGATION_TRAIL,
+  );
+  const pendingFreshRollbackLaunchRef = useRef<ConversationEntryLaunch | null>(null);
+  const pendingFreshDraftLeaseRef = useRef("");
+  const pendingFreshTransitionLeaseRef = useRef<ConversationTransitionLease | null>(null);
+  const mainConversationGenerationRef = useRef(0);
+  const draftHydrationInFlightRef = useRef<Map<number, Promise<string | null>>>(new Map());
+  const confirmedObservationInFlightRef = useRef<Map<number, Promise<void>>>(new Map());
+  const mainConversationSubmitSequenceRef = useRef(0);
+  const latestMainConversationSelectionRef = useRef<{
+    readonly generation: number;
+    readonly selection: SessionRealtimeSelectedThreadState | null;
+  } | null>(null);
+  const mainDraftSequenceRef = useRef(0);
   const mainFreshLatestSeqRef = useRef(0);
   const mainFreshEnqueuedSeqRef = useRef(0);
   const mainFreshSpawnQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const dispatchMainConversationTrail = useCallback((action: ConversationNavigationAction) => {
+    mainConversationTrailRef.current = conversationNavigationReducer(
+      mainConversationTrailRef.current,
+      action,
+    );
+    reactDispatchMainConversationTrail(action);
+  }, []);
+  const beginMainConversationTransition = useCallback(
+    (kind: ConversationTransitionKind): ConversationTransitionLease | null => {
+      const lease = beginConversationTransition(mainConversationTransitionGateRef.current, kind);
+      if (lease !== null) setMainSessionReplacing(true);
+      return lease;
+    },
+    [],
+  );
+  const finishMainConversationTransition = useCallback(
+    (lease: ConversationTransitionLease): void => {
+      if (finishConversationTransition(mainConversationTransitionGateRef.current, lease)) {
+        setMainSessionReplacing(false);
+      }
+    },
+    [],
+  );
   // undefined = まだ未解決、null = 空（非注入）、string = 注入する内容。
   const [resolvedSystemPrompt, setResolvedSystemPrompt] = useState<string | null | undefined>(
     undefined,
@@ -3757,6 +3831,7 @@ function App() {
   }, [codexRealtimeState.status, mainSessionReplacing, voiceReconnectPending]);
 
   const handleToggleVoice = useCallback(async () => {
+    if (isConversationTransitionActive(mainConversationTransitionGateRef.current)) return;
     if (voiceReconnectPending) {
       stopCodexRealtime();
       setVoiceReconnectPending(false);
@@ -4382,44 +4457,563 @@ function App() {
     return labels;
   }, [cwd, homeDir, tabManager, tabState.mainSessionId, tabState.sessions]);
 
-  const handleNewMainConversation = useCallback(() => {
+  const readCurrentMainConversationSelection = useCallback(async () => {
+    if (terminalAgent !== "codex") return null;
     const mainSessionId = tabManager.getState().mainSessionId;
-    tabManager.switchTo(mainSessionId);
-    localStorage.setItem(ACTIVE_SESSION_STORAGE_KEY, mainSessionId);
-    setVoiceReconnectPending(
-      (pending) =>
-        pending ||
-        codexRealtimeState.status === "active" ||
-        codexRealtimeState.status === "connecting",
+    const generation = mainConversationGenerationRef.current;
+    try {
+      const selection = await sessionRealtimeSelectedThreadState({ sessionId: mainSessionId });
+      if (mainConversationGenerationRef.current === generation) {
+        latestMainConversationSelectionRef.current = { generation, selection };
+      }
+      return selection;
+    } catch (error) {
+      console.warn("[session-navigation] failed to read Codex thread state", error);
+      return null;
+    }
+  }, [tabManager, terminalAgent]);
+
+  const readConfirmedMainConversationId = useCallback(async (): Promise<string | null> => {
+    const selected = await readConversationSelectionWithin(
+      readCurrentMainConversationSelection,
+      250,
     );
-    setMainSessionReplacing(true);
-    const requestSeq = mainFreshLatestSeqRef.current + 1;
-    mainFreshLatestSeqRef.current = requestSeq;
-    setMainFreshRequestSeq(requestSeq);
-  }, [codexRealtimeState.status, tabManager]);
+    return selected?.confirmed === true && selected.sessionId.length > 0
+      ? selected.sessionId
+      : null;
+  }, [readCurrentMainConversationSelection]);
 
-  useEffect(() => {
-    if (!canMountTerminals || mainFreshRequestSeq === 0) return;
-    if (mainFreshEnqueuedSeqRef.current >= mainFreshRequestSeq) return;
-    mainFreshEnqueuedSeqRef.current = mainFreshRequestSeq;
+  const refreshCachedConversationSelectionImmediately = useCallback(async (): Promise<void> => {
+    await readConversationSelectionWithin(readCurrentMainConversationSelection, 40);
+  }, [readCurrentMainConversationSelection]);
 
-    const requestSeq = mainFreshRequestSeq;
+  const spawnFreshMainConversation = useCallback(async (): Promise<string | null> => {
     const mainSessionId = tabManager.getState().mainSessionId;
     const sessionCwd = getSessionCwd(mainSessionId);
     const params = {
       spec: withAgentResumePolicy(getTerminalSpec(mainSessionId), false),
       cwd: sessionCwd === undefined ? cwd : sessionCwd,
     };
-    const spawn = mainFreshSpawnQueueRef.current
-      .catch(() => {})
-      .then(() => getTerminalRuntime(mainSessionId).forceRespawnWithParams(params));
-    mainFreshSpawnQueueRef.current = spawn;
-    void spawn.finally(() => {
-      if (mainFreshLatestSeqRef.current === requestSeq) {
-        setMainSessionReplacing(false);
+    mainConversationGenerationRef.current += 1;
+    const result = await getTerminalRuntime(mainSessionId).forceRespawnWithParams(params);
+    return result?.replacedConfirmedSessionId ?? null;
+  }, [cwd, getSessionCwd, getTerminalSpec, tabManager]);
+
+  const resumeMainConversationExactly = useCallback(
+    async (sessionId: string): Promise<string> => {
+      const mainSessionId = tabManager.getState().mainSessionId;
+      const sessionCwd = getSessionCwd(mainSessionId);
+      const params = {
+        spec: withAgentResumeSessionId(getTerminalSpec(mainSessionId), sessionId),
+        cwd: sessionCwd === undefined ? cwd : sessionCwd,
+      };
+      const generation = mainConversationGenerationRef.current + 1;
+      mainConversationGenerationRef.current = generation;
+      await getTerminalRuntime(mainSessionId).forceRespawnWithParams(params);
+      const observedSessionId = await waitForObservedSessionId(
+        async () => {
+          const selected = await readConversationSelectionWithin(
+            readCurrentMainConversationSelection,
+            100,
+          );
+          return selected?.confirmed === true ? selected.sessionId : null;
+        },
+        {
+          timeoutMs: 2_000,
+          pollIntervalMs: 50,
+          shouldContinue: () => mainConversationGenerationRef.current === generation,
+        },
+      );
+      if (observedSessionId === null) {
+        throw new Error(`Timed out waiting for Codex session ${sessionId}`);
+      }
+      return observedSessionId;
+    },
+    [cwd, getSessionCwd, getTerminalSpec, readCurrentMainConversationSelection, tabManager],
+  );
+
+  const restoreMainConversationLaunch = useCallback(
+    async (launch: ConversationEntryLaunch): Promise<string | null> => {
+      if (launch.kind === "exact-resume") {
+        return resumeMainConversationExactly(launch.sessionId);
+      }
+      await spawnFreshMainConversation();
+      return null;
+    },
+    [resumeMainConversationExactly, spawnFreshMainConversation],
+  );
+
+  const restoreMainConversationEntry = useCallback(
+    async (entry: ActiveConversationEntry): Promise<string | null> => {
+      return restoreMainConversationLaunch(conversationEntryLaunch(entry));
+    },
+    [restoreMainConversationLaunch],
+  );
+
+  const tryHydrateActiveDraft = useCallback(
+    async (timeoutMs: number, coalesceByGeneration: boolean): Promise<string | null> => {
+      if (terminalAgent !== "codex") return null;
+      const trail = mainConversationTrailRef.current;
+      const entry = currentConversationEntry(trail);
+      if (entry?.kind !== "new-draft") return null;
+      const generation = mainConversationGenerationRef.current;
+      const hydrate = async (): Promise<string | null> => {
+        const readConfirmedSessionId =
+          timeoutMs === 0
+            ? async (): Promise<string | null> => {
+                const selected = await readConversationSelectionWithin(
+                  readCurrentMainConversationSelection,
+                  40,
+                );
+                return selected?.confirmed === true ? selected.sessionId : null;
+              }
+            : readConfirmedMainConversationId;
+        const observedSessionId = await waitForObservedSessionId(readConfirmedSessionId, {
+          timeoutMs,
+          pollIntervalMs: 50,
+          shouldContinue: () => {
+            if (mainConversationGenerationRef.current !== generation) return false;
+            if (
+              coalesceByGeneration &&
+              isConversationTransitionActive(mainConversationTransitionGateRef.current)
+            ) {
+              return false;
+            }
+            const current = currentConversationEntry(mainConversationTrailRef.current);
+            return current?.kind === "new-draft" && current.lease === entry.lease;
+          },
+        });
+        if (observedSessionId === null) return null;
+        const current = currentConversationEntry(mainConversationTrailRef.current);
+        if (current?.kind !== "new-draft" || current.lease !== entry.lease) return null;
+        dispatchMainConversationTrail({
+          type: "draft-hydrated",
+          draftLease: entry.lease,
+          sessionId: observedSessionId,
+        });
+        return observedSessionId;
+      };
+
+      if (!coalesceByGeneration) return hydrate();
+      const existing = draftHydrationInFlightRef.current.get(generation);
+      if (existing) return existing;
+      const operation = hydrate().finally(() => {
+        if (draftHydrationInFlightRef.current.get(generation) === operation) {
+          draftHydrationInFlightRef.current.delete(generation);
+        }
+      });
+      draftHydrationInFlightRef.current.set(generation, operation);
+      return operation;
+    },
+    [
+      dispatchMainConversationTrail,
+      readConfirmedMainConversationId,
+      readCurrentMainConversationSelection,
+      terminalAgent,
+    ],
+  );
+
+  const prepareActiveDraftForReplacement = useCallback(async (): Promise<void> => {
+    await prepareConversationDraftForReplacement({
+      getCurrentEntry: () => currentConversationEntry(mainConversationTrailRef.current),
+      // UI transitionでは長いprovider観測を待たない。現在値を一度だけ読み、
+      // 未確定なら置換を即座に中止してbackground hydrationへ任せる。
+      hydrate: () => tryHydrateActiveDraft(0, false),
+    });
+  }, [tryHydrateActiveDraft]);
+
+  const observeConversationSelectionAfterSubmit = useCallback(
+    async (baselineRevision: number | null, submitSequence: number): Promise<void> => {
+      const trail = mainConversationTrailRef.current;
+      if (trail.transient !== null) return;
+      const generation = mainConversationGenerationRef.current;
+      const existing = confirmedObservationInFlightRef.current.get(generation);
+      if (existing) return existing;
+      const modeledSessionId = trail.entries[trail.cursor]?.id ?? null;
+      const shouldContinue = (): boolean => {
+        if (mainConversationGenerationRef.current !== generation) return false;
+        if (isConversationTransitionActive(mainConversationTransitionGateRef.current)) return false;
+        const current = mainConversationTrailRef.current;
+        if (current.transient !== null) return false;
+        return (current.entries[current.cursor]?.id ?? null) === modeledSessionId;
+      };
+      const operation = (async () => {
+        const selection = await waitForConversationSelectionAfterSubmit({
+          readSelection: readCurrentMainConversationSelection,
+          baselineRevision,
+          modeledSessionId,
+          submitSequence,
+          getCurrentSubmitSequence: () => mainConversationSubmitSequenceRef.current,
+          shouldContinue,
+        });
+        if (selection === null || mainConversationGenerationRef.current !== generation) return;
+        const current = mainConversationTrailRef.current;
+        if (
+          current.transient !== null ||
+          (current.entries[current.cursor]?.id ?? null) !== modeledSessionId
+        ) {
+          return;
+        }
+        if (selection.confirmed) {
+          dispatchMainConversationTrail({
+            type: "confirmed-session-observed",
+            sessionId: selection.sessionId,
+          });
+        } else if (modeledSessionId !== null && selection.sessionId !== modeledSessionId) {
+          // provider-native `/new` も toolbar New と同じ ephemeral draft として表現する。
+          mainDraftSequenceRef.current += 1;
+          dispatchMainConversationTrail({
+            type: "fresh-session-succeeded",
+            draftLease: `native-draft-${mainDraftSequenceRef.current}`,
+          });
+        }
+      })().finally(() => {
+        if (confirmedObservationInFlightRef.current.get(generation) === operation) {
+          confirmedObservationInFlightRef.current.delete(generation);
+        }
+      });
+      confirmedObservationInFlightRef.current.set(generation, operation);
+      return operation;
+    },
+    [dispatchMainConversationTrail, readCurrentMainConversationSelection],
+  );
+
+  const reconcileCachedConversationSelectionBeforeTransition = useCallback((): void => {
+    const generation = mainConversationGenerationRef.current;
+    const cached = latestMainConversationSelectionRef.current;
+    const selection = cached?.generation === generation ? cached.selection : null;
+    if (selection === null) return;
+    const trail = mainConversationTrailRef.current;
+    if (trail.transient !== null) return;
+    const modeledSessionId = trail.entries[trail.cursor]?.id ?? null;
+    if (selection.confirmed) {
+      dispatchMainConversationTrail({
+        type: "confirmed-session-observed",
+        sessionId: selection.sessionId,
+      });
+    } else if (modeledSessionId !== null && selection.sessionId !== modeledSessionId) {
+      mainDraftSequenceRef.current += 1;
+      dispatchMainConversationTrail({
+        type: "fresh-session-succeeded",
+        draftLease: `native-draft-${mainDraftSequenceRef.current}`,
+      });
+    }
+  }, [dispatchMainConversationTrail]);
+
+  const reconcileReplacedConfirmedSession = useCallback(
+    (sessionId: string): void => {
+      if (sessionId.length === 0) return;
+      dispatchMainConversationTrail({ type: "outgoing-session-confirmed", sessionId });
+    },
+    [dispatchMainConversationTrail],
+  );
+
+  useEffect(() => {
+    if (terminalAgent !== "codex") dispatchMainConversationTrail({ type: "reset" });
+  }, [dispatchMainConversationTrail, terminalAgent]);
+
+  useEffect(() => {
+    if (
+      !canMountTerminals ||
+      terminalAgent !== "codex" ||
+      mainConversationTrail.entries.length > 0 ||
+      mainConversationTrail.transient !== null
+    ) {
+      return;
+    }
+    const generation = mainConversationGenerationRef.current;
+    let cancelled = false;
+    void waitForObservedSessionId(readConfirmedMainConversationId, {
+      timeoutMs: 15_000,
+      pollIntervalMs: 100,
+      shouldContinue: () =>
+        !cancelled &&
+        mainConversationGenerationRef.current === generation &&
+        !isConversationTransitionActive(mainConversationTransitionGateRef.current) &&
+        mainConversationTrailRef.current.entries.length === 0 &&
+        mainConversationTrailRef.current.transient === null,
+    }).then((sessionId) => {
+      if (!cancelled && sessionId) {
+        dispatchMainConversationTrail({ type: "confirmed-session-observed", sessionId });
       }
     });
-  }, [canMountTerminals, cwd, getSessionCwd, getTerminalSpec, mainFreshRequestSeq, tabManager]);
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    canMountTerminals,
+    dispatchMainConversationTrail,
+    mainConversationTrail.entries.length,
+    mainConversationTrail.transient,
+    readConfirmedMainConversationId,
+    terminalAgent,
+  ]);
+
+  const handleNewMainConversation = useCallback(async () => {
+    if (!canMountTerminals) return;
+    const transitionLease = beginMainConversationTransition("new");
+    if (transitionLease === null) return;
+    let handedOffToSpawnEffect = false;
+
+    try {
+      // provider ID が通常時のbackground観測で確認済みならexact rollbackを保持する。
+      // 未取得でもNew自体は止めず、履歴/rollbackなしのfresh draftへ即時degradeする。
+      mainDraftSequenceRef.current += 1;
+      const request = await prepareFreshConversationRequest({
+        draftLease: `draft-${mainDraftSequenceRef.current}`,
+        prepareActiveDraft: async () => {
+          await prepareActiveDraftForReplacement();
+          // background cacheを優先しつつ、click時のprovider stateを最大40msだけ拾う。
+          await refreshCachedConversationSelectionImmediately();
+        },
+        reconcileCachedSelection: reconcileCachedConversationSelectionBeforeTransition,
+        getTrail: () => mainConversationTrailRef.current,
+      });
+
+      const mainSessionId = tabManager.getState().mainSessionId;
+      tabManager.switchTo(mainSessionId);
+      localStorage.setItem(ACTIVE_SESSION_STORAGE_KEY, mainSessionId);
+      pendingFreshRollbackLaunchRef.current = request.rollbackLaunch;
+      pendingFreshDraftLeaseRef.current = request.draftLease;
+      pendingFreshTransitionLeaseRef.current = transitionLease;
+      setVoiceReconnectPending(
+        (pending) =>
+          pending ||
+          codexRealtimeState.status === "active" ||
+          codexRealtimeState.status === "connecting",
+      );
+      const requestSeq = mainFreshLatestSeqRef.current + 1;
+      mainFreshLatestSeqRef.current = requestSeq;
+      handedOffToSpawnEffect = true;
+      setMainFreshRequestSeq(requestSeq);
+    } catch (error) {
+      console.error("[session-navigation] failed to prepare a fresh Main Agent session", error);
+      dispatchMainConversationTrail({ type: "operation-failed" });
+    } finally {
+      if (!handedOffToSpawnEffect) finishMainConversationTransition(transitionLease);
+    }
+  }, [
+    beginMainConversationTransition,
+    canMountTerminals,
+    codexRealtimeState.status,
+    dispatchMainConversationTrail,
+    finishMainConversationTransition,
+    prepareActiveDraftForReplacement,
+    reconcileCachedConversationSelectionBeforeTransition,
+    refreshCachedConversationSelectionImmediately,
+    tabManager,
+  ]);
+
+  useEffect(() => {
+    if (!canMountTerminals || mainFreshRequestSeq === 0) return;
+    if (mainFreshEnqueuedSeqRef.current >= mainFreshRequestSeq) return;
+
+    const rollbackLaunch = pendingFreshRollbackLaunchRef.current;
+    const draftLease = pendingFreshDraftLeaseRef.current;
+    const transitionLease = pendingFreshTransitionLeaseRef.current;
+    if (transitionLease === null || transitionLease.kind !== "new") return;
+    mainFreshEnqueuedSeqRef.current = mainFreshRequestSeq;
+    const spawningAgent = terminalAgent;
+    const operation = mainFreshSpawnQueueRef.current
+      .catch(() => {})
+      .then(() => spawnFreshMainConversation())
+      .then((replacedConfirmedSessionId) => {
+        if (spawningAgent !== "codex") return;
+        // Rustのreplace境界で取得したoutgoing IDをsource of truthにする。
+        // click-time pollingがAを取り逃しても、Aを確定trailへ同期してからdraftを重ねる。
+        if (replacedConfirmedSessionId !== null) {
+          reconcileReplacedConfirmedSession(replacedConfirmedSessionId);
+        }
+        dispatchMainConversationTrail({
+          type: "fresh-session-succeeded",
+          draftLease,
+        });
+      });
+    mainFreshSpawnQueueRef.current = operation;
+    void operation
+      .catch(async (error) => {
+        console.error("[session-navigation] failed to start a fresh Main Agent session", error);
+        dispatchMainConversationTrail({ type: "operation-failed" });
+        const replacedConfirmedSessionId =
+          error instanceof SessionSpawnError ? error.replacedConfirmedSessionId : null;
+        const effectiveRollbackLaunch =
+          replacedConfirmedSessionId === null
+            ? rollbackLaunch
+            : ({
+                kind: "exact-resume",
+                sessionId: replacedConfirmedSessionId,
+              } satisfies ConversationEntryLaunch);
+        if (spawningAgent === "codex" && effectiveRollbackLaunch) {
+          try {
+            // State を非 commit のままにする場合、表示側も trail current へ戻して invariant を守る。
+            const actualSessionId = await restoreMainConversationLaunch(effectiveRollbackLaunch);
+            if (effectiveRollbackLaunch.kind === "exact-resume" && actualSessionId !== null) {
+              dispatchMainConversationTrail({
+                type: "current-session-replaced",
+                expectedSessionId: effectiveRollbackLaunch.sessionId,
+                actualSessionId,
+              });
+              // trailが未seed、またはtransientだった場合もactual runtimeへ同期する。
+              reconcileReplacedConfirmedSession(actualSessionId);
+            }
+          } catch (rollbackError) {
+            console.error(
+              "[session-navigation] failed to restore the prior Codex session",
+              rollbackError,
+            );
+            dispatchMainConversationTrail({ type: "reset" });
+          }
+        }
+      })
+      .finally(() => {
+        if (pendingFreshTransitionLeaseRef.current?.id === transitionLease.id) {
+          pendingFreshTransitionLeaseRef.current = null;
+        }
+        finishMainConversationTransition(transitionLease);
+      });
+  }, [
+    canMountTerminals,
+    dispatchMainConversationTrail,
+    finishMainConversationTransition,
+    mainFreshRequestSeq,
+    reconcileReplacedConfirmedSession,
+    restoreMainConversationLaunch,
+    spawnFreshMainConversation,
+    terminalAgent,
+  ]);
+
+  const handleMainConversationNavigation = useCallback(
+    async (direction: ConversationNavigationDirection) => {
+      if (terminalAgent !== "codex") return;
+      const transitionLease = beginMainConversationTransition(direction);
+      if (transitionLease === null) return;
+      let currentEntry: ActiveConversationEntry | null = null;
+
+      try {
+        await prepareActiveDraftForReplacement();
+        await refreshCachedConversationSelectionImmediately();
+        reconcileCachedConversationSelectionBeforeTransition();
+
+        const trail = mainConversationTrailRef.current;
+        currentEntry = currentConversationEntry(trail);
+        const targetEntry = conversationNavigationTarget(trail, direction);
+        if (!currentEntry || !targetEntry || conversationEntriesEqual(targetEntry, currentEntry)) {
+          return;
+        }
+
+        const mainSessionId = tabManager.getState().mainSessionId;
+        tabManager.switchTo(mainSessionId);
+        localStorage.setItem(ACTIVE_SESSION_STORAGE_KEY, mainSessionId);
+
+        setVoiceReconnectPending(
+          (pending) =>
+            pending ||
+            codexRealtimeState.status === "active" ||
+            codexRealtimeState.status === "connecting",
+        );
+
+        const launch = conversationEntryLaunch(targetEntry);
+        let actualSessionId: string | undefined;
+        if (launch.kind === "exact-resume") {
+          actualSessionId = await resumeMainConversationExactly(launch.sessionId);
+        } else {
+          await spawnFreshMainConversation();
+        }
+        dispatchMainConversationTrail({
+          type: "navigation-succeeded",
+          direction,
+          entry: targetEntry,
+          actualSessionId,
+        });
+      } catch (error) {
+        console.error(`[session-navigation] failed to navigate ${direction}`, error);
+        dispatchMainConversationTrail({ type: "operation-failed" });
+        if (currentEntry !== null) {
+          try {
+            const actualSessionId = await restoreMainConversationEntry(currentEntry);
+            if (currentEntry.kind === "session" && actualSessionId !== null) {
+              dispatchMainConversationTrail({
+                type: "current-session-replaced",
+                expectedSessionId: currentEntry.id,
+                actualSessionId,
+              });
+            }
+          } catch (rollbackError) {
+            console.error(
+              "[session-navigation] failed to restore the current Codex session",
+              rollbackError,
+            );
+            // 表示中 PTY と cursor の対応を復元できなければ、誤った ID への追加 navigation を止める。
+            dispatchMainConversationTrail({ type: "reset" });
+          }
+        }
+      } finally {
+        finishMainConversationTransition(transitionLease);
+      }
+    },
+    [
+      beginMainConversationTransition,
+      codexRealtimeState.status,
+      dispatchMainConversationTrail,
+      finishMainConversationTransition,
+      prepareActiveDraftForReplacement,
+      reconcileCachedConversationSelectionBeforeTransition,
+      refreshCachedConversationSelectionImmediately,
+      restoreMainConversationEntry,
+      resumeMainConversationExactly,
+      spawnFreshMainConversation,
+      tabManager,
+      terminalAgent,
+    ],
+  );
+
+  useEffect(() => {
+    if (!canMountTerminals || terminalAgent !== "codex") return;
+    const runtime = getTerminalRuntime(tabManager.getState().mainSessionId);
+    const subscription = runtime.subscribeUserInput((data) => {
+      if (!data || isConversationTransitionActive(mainConversationTransitionGateRef.current)) {
+        return;
+      }
+      const entry = currentConversationEntry(mainConversationTrailRef.current);
+      if (entry === null) {
+        if (data.includes("\r") || data.includes("\n")) {
+          const generation = mainConversationGenerationRef.current;
+          const cached = latestMainConversationSelectionRef.current;
+          const baselineRevision =
+            cached?.generation === generation ? cached.selection?.revision : null;
+          mainConversationSubmitSequenceRef.current += 1;
+          void observeConversationSelectionAfterSubmit(
+            baselineRevision ?? null,
+            mainConversationSubmitSequenceRef.current,
+          );
+        }
+        return;
+      }
+      if (entry.kind !== "new-draft") {
+        if (data.includes("\r") || data.includes("\n")) {
+          const generation = mainConversationGenerationRef.current;
+          const cached = latestMainConversationSelectionRef.current;
+          const baselineRevision =
+            cached?.generation === generation ? cached.selection?.revision : null;
+          mainConversationSubmitSequenceRef.current += 1;
+          void observeConversationSelectionAfterSubmit(
+            baselineRevision ?? null,
+            mainConversationSubmitSequenceRef.current,
+          );
+        }
+        return;
+      }
+      if (!data.includes("\r") && !data.includes("\n")) return;
+      void tryHydrateActiveDraft(15_000, true);
+    });
+    return () => subscription.dispose();
+  }, [
+    canMountTerminals,
+    observeConversationSelectionAfterSubmit,
+    tabManager,
+    terminalAgent,
+    tryHydrateActiveDraft,
+  ]);
 
   const titleBarVoiceState =
     voiceReconnectPending && codexRealtimeState.status === "idle"
@@ -4611,6 +5205,7 @@ function App() {
         onToggleSidebar={handleToggleSidebar}
         onOpenSettings={handleOpenSettings}
         voiceAvailable={voiceEntryAvailable}
+        voiceDisabled={mainSessionReplacing}
         voiceState={titleBarVoiceState}
         voiceMicrophoneActive={codexRealtimeState.microphoneActive === true}
         voiceLabel={
@@ -4631,8 +5226,41 @@ function App() {
             statuses={sessionStatusById}
             hookBadges={sessionHookBadges}
             onSelectSession={(sessionId) => tabManager.switchTo(sessionId)}
-            newConversationLabel={strings.newConversation}
-            onNewConversation={handleNewMainConversation}
+            backConversationLabel={
+              mainSessionReplacing
+                ? strings.switchingConversation
+                : canNavigateConversation(mainConversationTrail, "back")
+                  ? strings.backConversation
+                  : strings.noBackConversation
+            }
+            backConversationDisabled={
+              mainSessionReplacing || !canNavigateConversation(mainConversationTrail, "back")
+            }
+            onBackConversation={
+              terminalAgent === "codex"
+                ? () => void handleMainConversationNavigation("back")
+                : undefined
+            }
+            forwardConversationLabel={
+              mainSessionReplacing
+                ? strings.switchingConversation
+                : canNavigateConversation(mainConversationTrail, "forward")
+                  ? strings.forwardConversation
+                  : strings.noForwardConversation
+            }
+            forwardConversationDisabled={
+              mainSessionReplacing || !canNavigateConversation(mainConversationTrail, "forward")
+            }
+            onForwardConversation={
+              terminalAgent === "codex"
+                ? () => void handleMainConversationNavigation("forward")
+                : undefined
+            }
+            newConversationLabel={
+              mainSessionReplacing ? strings.switchingConversation : strings.newConversation
+            }
+            newConversationDisabled={mainSessionReplacing}
+            onNewConversation={() => void handleNewMainConversation()}
             onAddSession={() => tabManager.openShell(cwd)}
             onCloseSession={(sessionId) => tabManager.close(sessionId)}
           />

--- a/src/bindings/tauri-commands.test.ts
+++ b/src/bindings/tauri-commands.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInvoke = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: class MockChannel {},
+  invoke: mockInvoke,
+}));
+
+const { SessionSpawnError, sessionSpawn } = await import("./tauri-commands");
+
+const spawnArgs = {
+  sessionId: "main",
+  spec: { kind: "agent" as const, agent: "codex", resume: false },
+  cols: 80,
+  rows: 24,
+  cwd: "/workspace",
+  onOutput: {} as never,
+};
+
+describe("sessionSpawn", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  it("returns the backend's atomic pre-replacement confirmed session ID", async () => {
+    mockInvoke.mockResolvedValueOnce({ replacedConfirmedSessionId: "A" });
+
+    await expect(sessionSpawn(spawnArgs)).resolves.toEqual({
+      replacedConfirmedSessionId: "A",
+    });
+  });
+
+  it("preserves the pre-replacement ID on a structured spawn failure", async () => {
+    mockInvoke.mockRejectedValueOnce({
+      message: "spawn failed",
+      replacedConfirmedSessionId: "A",
+    });
+
+    const failure = await sessionSpawn(spawnArgs).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(SessionSpawnError);
+    expect(failure).toMatchObject({
+      message: "spawn failed",
+      replacedConfirmedSessionId: "A",
+    });
+  });
+});

--- a/src/bindings/tauri-commands.ts
+++ b/src/bindings/tauri-commands.ts
@@ -41,6 +41,8 @@ export type SpawnSpec =
       readonly pluginDir?: string | null;
       /** false のとき agent 側の既存会話 resume を禁止して完全新規 session を起動する。 */
       readonly resume?: boolean;
+      /** provider 固有の会話 ID を指定して再開する。現在は Codex のみ対応。 */
+      readonly resumeSessionId?: string | null;
     }
   | {
       readonly kind: "shell";
@@ -77,12 +79,51 @@ export interface SessionSpawnArgs {
   readonly onOutput: Channel<ArrayBuffer>;
 }
 
+export interface SessionSpawnResult {
+  /** PTY replace直前にbackendで確認済みだったprovider session ID。 */
+  readonly replacedConfirmedSessionId: string | null;
+}
+
+export class SessionSpawnError extends Error {
+  readonly replacedConfirmedSessionId: string | null;
+
+  constructor(message: string, replacedConfirmedSessionId: string | null) {
+    super(message);
+    this.name = "SessionSpawnError";
+    this.replacedConfirmedSessionId = replacedConfirmedSessionId;
+  }
+}
+
+function normalizeSessionSpawnError(error: unknown): never {
+  if (typeof error === "object" && error !== null) {
+    const candidate = error as {
+      readonly message?: unknown;
+      readonly replacedConfirmedSessionId?: unknown;
+    };
+    if (typeof candidate.message === "string") {
+      throw new SessionSpawnError(
+        candidate.message,
+        typeof candidate.replacedConfirmedSessionId === "string"
+          ? candidate.replacedConfirmedSessionId
+          : null,
+      );
+    }
+  }
+  throw error;
+}
+
 /**
  * Session を新規 spawn する。session_id が省略されると default-session を
  * 作る（Phase B-1 互換）。複数 session を持つときは caller が stable な
  * session_id を渡す。
  */
-export const sessionSpawn = (args: SessionSpawnArgs): Promise<void> => call("session_spawn", args);
+export const sessionSpawn = async (args: SessionSpawnArgs): Promise<SessionSpawnResult> => {
+  try {
+    return await call<SessionSpawnResult>("session_spawn", args);
+  } catch (error) {
+    normalizeSessionSpawnError(error);
+  }
+};
 
 export interface SessionWriteArgs {
   readonly sessionId: string;
@@ -165,6 +206,20 @@ export const sessionRealtimeCapabilities = (args: {
 export const sessionRealtimeSelectedThread = (args: {
   readonly sessionId: string;
 }): Promise<string | null> => call("session_realtime_selected_thread", args);
+
+export interface SessionRealtimeSelectedThreadState {
+  readonly sessionId: string;
+  /** resume / fork、または最初の turn/start 済み。thread/start だけなら未確定。 */
+  readonly confirmed: boolean;
+  /** 同じ app-server process 内の top-level selection / turn-start revision。 */
+  readonly revision: number;
+}
+
+/** Codex TUI proxy が選択したthreadと、会話として確定済みかを返す。 */
+export const sessionRealtimeSelectedThreadState = (args: {
+  readonly sessionId: string;
+}): Promise<SessionRealtimeSelectedThreadState | null> =>
+  call("session_realtime_selected_thread_state", args);
 
 /** Rust host が所有する realtime connection へ JSON-RPC text を送る。 */
 export const sessionRealtimeSend = (args: {

--- a/src/components/TabIndicator.test.tsx
+++ b/src/components/TabIndicator.test.tsx
@@ -310,6 +310,79 @@ describe("TabIndicator", () => {
     expect(onSelectSession).not.toHaveBeenCalled();
   });
 
+  it("keeps New visible but blocks it while a conversation transition is busy", () => {
+    const onNewConversation = vi.fn();
+
+    render(
+      <TabIndicator
+        state={state()}
+        labels={new Map([["default-session", "Main Agent"]])}
+        newConversationLabel="Switching conversation"
+        newConversationDisabled
+        onNewConversation={onNewConversation}
+      />,
+    );
+
+    const action = screen.getByRole("button", { name: "Switching conversation" });
+    expect(action.getAttribute("disabled")).not.toBeNull();
+    fireEvent.click(action);
+    expect(onNewConversation).not.toHaveBeenCalled();
+  });
+
+  it("navigates back and forward from separate Main Agent tab actions", () => {
+    const onBackConversation = vi.fn();
+    const onForwardConversation = vi.fn();
+
+    render(
+      <TabIndicator
+        state={state("shell-1")}
+        labels={
+          new Map([
+            ["default-session", "Main Agent"],
+            ["shell-1", "shell-1"],
+          ])
+        }
+        backConversationLabel="Back to previous session"
+        onBackConversation={onBackConversation}
+        forwardConversationLabel="Forward to next session"
+        onForwardConversation={onForwardConversation}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to previous session" }));
+    fireEvent.click(screen.getByRole("button", { name: "Forward to next session" }));
+
+    expect(onBackConversation).toHaveBeenCalledTimes(1);
+    expect(onForwardConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps both navigation actions visible while unavailable", () => {
+    const onBackConversation = vi.fn();
+    const onForwardConversation = vi.fn();
+
+    render(
+      <TabIndicator
+        state={state()}
+        labels={new Map([["default-session", "Main Agent"]])}
+        backConversationLabel="No previous session"
+        backConversationDisabled
+        onBackConversation={onBackConversation}
+        forwardConversationLabel="No next session"
+        forwardConversationDisabled
+        onForwardConversation={onForwardConversation}
+      />,
+    );
+
+    const back = screen.getByRole("button", { name: "No previous session" });
+    const forward = screen.getByRole("button", { name: "No next session" });
+    expect(back.getAttribute("disabled")).not.toBeNull();
+    expect(forward.getAttribute("disabled")).not.toBeNull();
+    fireEvent.click(back);
+    fireEvent.click(forward);
+    expect(onBackConversation).not.toHaveBeenCalled();
+    expect(onForwardConversation).not.toHaveBeenCalled();
+  });
+
   it("calls onAddSession from the add button", () => {
     const onAddSession = vi.fn();
 

--- a/src/components/TabIndicator.tsx
+++ b/src/components/TabIndicator.tsx
@@ -1,4 +1,4 @@
-import { Plus, SquarePen, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus, SquarePen, X } from "lucide-react";
 import { deriveSessionStatusBadge, type SessionStatus } from "../runtime/session-status";
 import type { SessionTabState } from "../runtime/session-tabs/types";
 import type { SessionId } from "../runtime/sessions/types";
@@ -20,7 +20,14 @@ interface TabIndicatorProps {
   readonly hookBadges?: ReadonlyMap<SessionId, TabIndicatorBadge>;
   /** タブ選択。未指定なら表示専用。 */
   readonly onSelectSession?: (sessionId: SessionId) => void;
+  readonly backConversationLabel?: string;
+  readonly backConversationDisabled?: boolean;
+  readonly onBackConversation?: () => void;
+  readonly forwardConversationLabel?: string;
+  readonly forwardConversationDisabled?: boolean;
+  readonly onForwardConversation?: () => void;
   readonly newConversationLabel?: string;
+  readonly newConversationDisabled?: boolean;
   readonly onNewConversation?: () => void;
   readonly onAddSession?: () => void;
   readonly onCloseSession?: (sessionId: SessionId) => void;
@@ -36,7 +43,14 @@ export default function TabIndicator({
   statuses,
   hookBadges,
   onSelectSession,
+  backConversationLabel = "Back",
+  backConversationDisabled = false,
+  onBackConversation,
+  forwardConversationLabel = "Forward",
+  forwardConversationDisabled = false,
+  onForwardConversation,
   newConversationLabel = "New session",
+  newConversationDisabled = false,
   onNewConversation,
   onAddSession,
   onCloseSession,
@@ -90,12 +104,37 @@ export default function TabIndicator({
                   </span>
                 ) : null}
               </button>
+              {isMain && (onBackConversation || onForwardConversation) ? (
+                <span className="tab-indicator-conversation-navigation">
+                  <button
+                    type="button"
+                    className="tab-indicator-conversation-back"
+                    aria-label={backConversationLabel}
+                    title={backConversationLabel}
+                    disabled={backConversationDisabled}
+                    onClick={onBackConversation}
+                  >
+                    <ChevronLeft size={14} strokeWidth={2} aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    className="tab-indicator-conversation-forward"
+                    aria-label={forwardConversationLabel}
+                    title={forwardConversationLabel}
+                    disabled={forwardConversationDisabled}
+                    onClick={onForwardConversation}
+                  >
+                    <ChevronRight size={14} strokeWidth={2} aria-hidden="true" />
+                  </button>
+                </span>
+              ) : null}
               {isMain && onNewConversation ? (
                 <button
                   type="button"
                   className="tab-indicator-new-conversation"
                   aria-label={newConversationLabel}
                   title={newConversationLabel}
+                  disabled={newConversationDisabled}
                   onClick={onNewConversation}
                 >
                   <SquarePen size={14} strokeWidth={1.9} aria-hidden="true" />

--- a/src/i18n/strings.test.ts
+++ b/src/i18n/strings.test.ts
@@ -133,6 +133,15 @@ describe("changeStrings", () => {
     expect(getStrings("ja").newConversation).toBe("新しいセッション");
   });
 
+  it("labels back/forward session navigation in both languages", () => {
+    expect(getStrings("en").backConversation).toBe("Back to previous session");
+    expect(getStrings("ja").backConversation).toBe("前のセッションに戻る");
+    expect(getStrings("en").forwardConversation).toBe("Forward to next session");
+    expect(getStrings("ja").forwardConversation).toBe("次のセッションに進む");
+    expect(getStrings("en").noBackConversation).toBe("No previous session");
+    expect(getStrings("en").noForwardConversation).toBe("No next session");
+  });
+
   it("labels the bundled Yori VRM reset action in both languages", () => {
     expect(getStrings("en").resetVrmToYori).toBe("Return to Yori");
     expect(getStrings("ja").resetVrmToYori).toBe("Yori に戻す");

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -32,6 +32,11 @@ export interface UiStrings {
   readonly selectProjectFolder: string;
   readonly defaultFolderName: string;
   readonly newConversation: string;
+  readonly backConversation: string;
+  readonly noBackConversation: string;
+  readonly forwardConversation: string;
+  readonly noForwardConversation: string;
+  readonly switchingConversation: string;
   readonly voiceFrequency: string;
   readonly voiceOn: string;
   readonly voiceOff: string;
@@ -163,6 +168,11 @@ const EN: UiStrings = {
   selectProjectFolder: "Select project folder",
   defaultFolderName: "~",
   newConversation: "New session",
+  backConversation: "Back to previous session",
+  noBackConversation: "No previous session",
+  forwardConversation: "Forward to next session",
+  noForwardConversation: "No next session",
+  switchingConversation: "Switching sessions…",
   voiceFrequency: "Voice Summary",
   voiceOn: "On",
   voiceOff: "Off",
@@ -289,6 +299,11 @@ const JA: UiStrings = {
   selectProjectFolder: "プロジェクトフォルダを選択",
   defaultFolderName: "~",
   newConversation: "新しいセッション",
+  backConversation: "前のセッションに戻る",
+  noBackConversation: "戻れるセッションはありません",
+  forwardConversation: "次のセッションに進む",
+  noForwardConversation: "進めるセッションはありません",
+  switchingConversation: "セッションを切り替え中…",
   voiceFrequency: "Voice Summary",
   voiceOn: "On",
   voiceOff: "Off",

--- a/src/runtime/sessions/conversation-navigation.test.ts
+++ b/src/runtime/sessions/conversation-navigation.test.ts
@@ -1,0 +1,607 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ActiveConversationEntry,
+  beginConversationTransition,
+  type ConversationNavigationEntry,
+  type ConversationNavigationTrail,
+  type ConversationTransitionKind,
+  canNavigateConversation,
+  conversationEntryLaunch,
+  conversationNavigationReducer,
+  conversationNavigationTarget,
+  createConversationTransitionGate,
+  currentConversationEntry,
+  EMPTY_CONVERSATION_NAVIGATION_TRAIL,
+  finishConversationTransition,
+  prepareConversationDraftForReplacement,
+  prepareFreshConversationRequest,
+} from "./conversation-navigation";
+import { readConversationSelectionWithin } from "./observed-session";
+
+const session = (id: string): ConversationNavigationEntry => ({ kind: "session", id });
+const confirmedTrail = (
+  ids: readonly string[],
+  cursor = ids.length - 1,
+): ConversationNavigationTrail => ({
+  entries: ids.map(session),
+  cursor,
+  transient: null,
+});
+
+describe("conversationNavigationReducer", () => {
+  it("seeds and advances the persistent trail only from observed confirmed provider sessions", () => {
+    const observed = conversationNavigationReducer(EMPTY_CONVERSATION_NAVIGATION_TRAIL, {
+      type: "confirmed-session-observed",
+      sessionId: "A",
+    });
+    expect(observed).toEqual(confirmedTrail(["A"]));
+
+    expect(
+      conversationNavigationReducer(observed, {
+        type: "confirmed-session-observed",
+        sessionId: "B",
+      }),
+    ).toEqual(confirmedTrail(["A", "B"]));
+  });
+
+  it("allows an initial blank to be replaced without inventing a confirmed origin", () => {
+    const blank = conversationNavigationReducer(EMPTY_CONVERSATION_NAVIGATION_TRAIL, {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    expect(blank).toEqual({
+      entries: [],
+      cursor: -1,
+      transient: { kind: "new-draft", originCursor: -1, lease: "draft-1" },
+    });
+    expect(canNavigateConversation(blank, "back")).toBe(false);
+    expect(canNavigateConversation(blank, "forward")).toBe(false);
+
+    expect(
+      conversationNavigationReducer(blank, {
+        type: "draft-hydrated",
+        draftLease: "draft-1",
+        sessionId: "B",
+      }),
+    ).toEqual(confirmedTrail(["B"]));
+  });
+
+  it("uses the backend's atomic outgoing ID to preserve A before committing a fresh draft", () => {
+    // New click時のfrontend pollingがnullでも、session_spawn successが返したAを先にseedする。
+    const outgoingConfirmed = conversationNavigationReducer(EMPTY_CONVERSATION_NAVIGATION_TRAIL, {
+      type: "outgoing-session-confirmed",
+      sessionId: "A",
+    });
+    const blank = conversationNavigationReducer(outgoingConfirmed, {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+
+    expect(conversationNavigationTarget(blank, "back")).toEqual(session("A"));
+  });
+
+  it("commits a confirmed outgoing draft before a later New replaces it", () => {
+    const draftB = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-B",
+    });
+
+    expect(
+      conversationNavigationReducer(draftB, {
+        type: "outgoing-session-confirmed",
+        sessionId: "B",
+      }),
+    ).toEqual(confirmedTrail(["A", "B"]));
+  });
+
+  it("keeps New blank outside entries and leaves the confirmed cursor unchanged", () => {
+    const atA = confirmedTrail(["A"]);
+    const blank = conversationNavigationReducer(atA, {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+
+    expect(blank).toEqual({
+      entries: [session("A")],
+      cursor: 0,
+      transient: { kind: "new-draft", originCursor: 0, lease: "draft-1" },
+    });
+    expect(currentConversationEntry(blank)).toEqual({
+      kind: "new-draft",
+      originCursor: 0,
+      lease: "draft-1",
+    });
+    const active = currentConversationEntry(blank);
+    if (active === null) throw new Error("expected active blank draft");
+    expect(conversationEntryLaunch(active)).toEqual({ kind: "fresh" });
+  });
+
+  it("A → blank → Back discards blank and leaves Forward disabled", () => {
+    const blank = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    expect(conversationNavigationTarget(blank, "back")).toEqual(session("A"));
+    expect(conversationNavigationTarget(blank, "forward")).toBeNull();
+
+    const atA = conversationNavigationReducer(blank, {
+      type: "navigation-succeeded",
+      direction: "back",
+      entry: session("A"),
+    });
+    expect(atA).toEqual(confirmedTrail(["A"]));
+    expect(canNavigateConversation(atA, "forward")).toBe(false);
+  });
+
+  it("records the provider's actual fork ID when exact Back falls back from an active writer", () => {
+    const blank = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    const atFork = conversationNavigationReducer(blank, {
+      type: "navigation-succeeded",
+      direction: "back",
+      entry: session("A"),
+      actualSessionId: "fork-A",
+    });
+
+    expect(atFork).toEqual(confirmedTrail(["fork-A"]));
+    expect(canNavigateConversation(atFork, "forward")).toBe(false);
+  });
+
+  it("replaces the rollback entry with the actual provider ID", () => {
+    expect(
+      conversationNavigationReducer(confirmedTrail(["A", "B"], 1), {
+        type: "current-session-replaced",
+        expectedSessionId: "B",
+        actualSessionId: "fork-B",
+      }),
+    ).toEqual(confirmedTrail(["A", "fork-B"], 1));
+  });
+
+  it("A → blank → Back → New starts another fresh blank without an old resume target", () => {
+    const firstBlank = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    const atA = conversationNavigationReducer(firstBlank, {
+      type: "navigation-succeeded",
+      direction: "back",
+      entry: session("A"),
+    });
+    const secondBlank = conversationNavigationReducer(atA, {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-2",
+    });
+
+    const active = currentConversationEntry(secondBlank);
+    if (active === null) throw new Error("expected second blank draft");
+    expect(conversationEntryLaunch(active)).toEqual({
+      kind: "fresh",
+    });
+    expect(secondBlank.entries).toEqual([session("A")]);
+    expect(secondBlank.transient?.lease).toBe("draft-2");
+  });
+
+  it("commits a new entry after the caller observes a provider-confirmed session ID", () => {
+    const blank = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    const committed = conversationNavigationReducer(blank, {
+      type: "draft-hydrated",
+      draftLease: "draft-1",
+      sessionId: "B",
+    });
+    expect(committed).toEqual(confirmedTrail(["A", "B"]));
+  });
+
+  it("discards a draft and selects an existing confirmed session after provider-native resume", () => {
+    const blank = conversationNavigationReducer(confirmedTrail(["A", "B"], 1), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+
+    expect(
+      conversationNavigationReducer(blank, {
+        type: "draft-hydrated",
+        draftLease: "draft-1",
+        sessionId: "A",
+      }),
+    ).toEqual(confirmedTrail(["A", "B"], 0));
+  });
+
+  it("does not truncate a forward branch until the draft becomes a confirmed session", () => {
+    const atB = confirmedTrail(["A", "B", "C"], 1);
+    const blank = conversationNavigationReducer(atB, {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-D",
+    });
+    expect(blank.entries).toEqual([session("A"), session("B"), session("C")]);
+    expect(blank.cursor).toBe(1);
+    expect(canNavigateConversation(blank, "forward")).toBe(false);
+
+    const committed = conversationNavigationReducer(blank, {
+      type: "draft-hydrated",
+      draftLease: "draft-D",
+      sessionId: "D",
+    });
+    expect(committed).toEqual(confirmedTrail(["A", "B", "D"]));
+  });
+
+  it("reconciles a provider-confirmed native resume and truncates only for a new branch", () => {
+    const atB = confirmedTrail(["A", "B", "C"], 1);
+    const resumedA = conversationNavigationReducer(atB, {
+      type: "confirmed-session-observed",
+      sessionId: "A",
+    });
+    expect(resumedA).toEqual(confirmedTrail(["A", "B", "C"], 0));
+
+    expect(
+      conversationNavigationReducer(resumedA, {
+        type: "confirmed-session-observed",
+        sessionId: "D",
+      }),
+    ).toEqual(confirmedTrail(["A", "D"]));
+  });
+
+  it("replaces one blank transient with another without appending a history entry", () => {
+    const first = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    const second = conversationNavigationReducer(first, {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-2",
+    });
+
+    expect(second.entries).toEqual([session("A")]);
+    expect(second.cursor).toBe(0);
+    expect(second.transient).toEqual({
+      kind: "new-draft",
+      originCursor: 0,
+      lease: "draft-2",
+    });
+  });
+
+  it("rejects stale hydration and failure commits without mutating state", () => {
+    const blank = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    expect(
+      conversationNavigationReducer(blank, {
+        type: "draft-hydrated",
+        draftLease: "stale-draft",
+        sessionId: "B",
+      }),
+    ).toBe(blank);
+    expect(conversationNavigationReducer(blank, { type: "operation-failed" })).toBe(blank);
+  });
+
+  it("ignores a late provider ID after Back has discarded the blank draft", () => {
+    const blank = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    const atA = conversationNavigationReducer(blank, {
+      type: "navigation-succeeded",
+      direction: "back",
+      entry: session("A"),
+    });
+
+    expect(
+      conversationNavigationReducer(atA, {
+        type: "draft-hydrated",
+        draftLease: "draft-1",
+        sessionId: "late-B",
+      }),
+    ).toBe(atA);
+  });
+
+  it("ignores a late provider ID from a blank replaced by a newer New", () => {
+    const first = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    const second = conversationNavigationReducer(first, {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-2",
+    });
+
+    expect(
+      conversationNavigationReducer(second, {
+        type: "draft-hydrated",
+        draftLease: "draft-1",
+        sessionId: "late-B",
+      }),
+    ).toBe(second);
+  });
+});
+
+describe("conversation transition gate", () => {
+  function deferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => {
+      resolve = done;
+    });
+    return { promise, resolve };
+  }
+
+  it.each([
+    ["Back", "back"],
+    ["Forward", "forward"],
+    ["New", "new"],
+  ] as const)("blocks repeated %s while its first transition is in flight", async (_, kind) => {
+    const gate = createConversationTransitionGate();
+    const pending = deferred();
+    let launches = 0;
+    let commits = 0;
+
+    const attempt = async (attemptKind: ConversationTransitionKind): Promise<boolean> => {
+      const lease = beginConversationTransition(gate, attemptKind);
+      if (lease === null) return false;
+      launches += 1;
+      try {
+        await pending.promise;
+        commits += 1;
+      } finally {
+        finishConversationTransition(gate, lease);
+      }
+      return true;
+    };
+
+    const first = attempt(kind);
+    await expect(attempt(kind)).resolves.toBe(false);
+    expect(launches).toBe(1);
+    expect(commits).toBe(0);
+    pending.resolve();
+    await expect(first).resolves.toBe(true);
+    expect(launches).toBe(1);
+    expect(commits).toBe(1);
+  });
+
+  it("blocks heterogeneous Back → New/Forward transitions under the same lease", () => {
+    const gate = createConversationTransitionGate();
+    const backLease = beginConversationTransition(gate, "back");
+    if (backLease === null) throw new Error("expected Back lease");
+    expect(beginConversationTransition(gate, "new")).toBeNull();
+    expect(beginConversationTransition(gate, "forward")).toBeNull();
+    expect(finishConversationTransition(gate, backLease)).toBe(true);
+  });
+
+  it("does not let a stale completion clear a newer transition", () => {
+    const gate = createConversationTransitionGate();
+    const first = beginConversationTransition(gate, "back");
+    if (first === null) throw new Error("expected first lease");
+    finishConversationTransition(gate, first);
+    const second = beginConversationTransition(gate, "new");
+    if (second === null) throw new Error("expected second lease");
+    expect(finishConversationTransition(gate, first)).toBe(false);
+    expect(beginConversationTransition(gate, "forward")).toBeNull();
+    expect(finishConversationTransition(gate, second)).toBe(true);
+  });
+
+  it("allows one Back exact resume and discards one blank transient", async () => {
+    const gate = createConversationTransitionGate();
+    const pending = deferred();
+    let resumes = 0;
+    let trail = conversationNavigationReducer(confirmedTrail(["A"]), {
+      type: "fresh-session-succeeded",
+      draftLease: "draft-1",
+    });
+    const back = async (): Promise<void> => {
+      const lease = beginConversationTransition(gate, "back");
+      if (lease === null) return;
+      try {
+        const target = conversationNavigationTarget(trail, "back");
+        if (target && conversationEntryLaunch(target).kind === "exact-resume") resumes += 1;
+        await pending.promise;
+        if (target) {
+          trail = conversationNavigationReducer(trail, {
+            type: "navigation-succeeded",
+            direction: "back",
+            entry: target,
+          });
+        }
+      } finally {
+        finishConversationTransition(gate, lease);
+      }
+    };
+
+    const first = back();
+    const repeated = back();
+    pending.resolve();
+    await Promise.all([first, repeated]);
+    expect(resumes).toBe(1);
+    expect(trail).toEqual(confirmedTrail(["A"]));
+    expect(canNavigateConversation(trail, "forward")).toBe(false);
+  });
+
+  it("allows only one confirmed Forward resume and cursor commit", async () => {
+    const gate = createConversationTransitionGate();
+    const pending = deferred();
+    let resumes = 0;
+    let trail = confirmedTrail(["A", "B"], 0);
+    const forward = async (): Promise<void> => {
+      const lease = beginConversationTransition(gate, "forward");
+      if (lease === null) return;
+      try {
+        const target = conversationNavigationTarget(trail, "forward");
+        if (target && conversationEntryLaunch(target).kind === "exact-resume") resumes += 1;
+        await pending.promise;
+        if (target) {
+          trail = conversationNavigationReducer(trail, {
+            type: "navigation-succeeded",
+            direction: "forward",
+            entry: target,
+          });
+        }
+      } finally {
+        finishConversationTransition(gate, lease);
+      }
+    };
+
+    const first = forward();
+    const repeated = forward();
+    pending.resolve();
+    await Promise.all([first, repeated]);
+    expect(resumes).toBe(1);
+    expect(trail.cursor).toBe(1);
+  });
+
+  it("allows only one New fresh spawn and no confirmed trail append", async () => {
+    const gate = createConversationTransitionGate();
+    const pending = deferred();
+    let freshSpawns = 0;
+    let trail = confirmedTrail(["A"]);
+    const startNew = async (): Promise<void> => {
+      const lease = beginConversationTransition(gate, "new");
+      if (lease === null) return;
+      try {
+        freshSpawns += 1;
+        await pending.promise;
+        trail = conversationNavigationReducer(trail, {
+          type: "fresh-session-succeeded",
+          draftLease: "draft-1",
+        });
+      } finally {
+        finishConversationTransition(gate, lease);
+      }
+    };
+
+    const first = startNew();
+    const repeated = startNew();
+    pending.resolve();
+    await Promise.all([first, repeated]);
+    expect(freshSpawns).toBe(1);
+    expect(trail.entries).toEqual([session("A")]);
+    expect(trail.transient?.lease).toBe("draft-1");
+  });
+
+  it("spawns New immediately and releases its lease while provider ID stays null for 15s", async () => {
+    vi.useFakeTimers();
+    try {
+      const gate = createConversationTransitionGate();
+      let trail = EMPTY_CONVERSATION_NAVIGATION_TRAIL;
+      let freshSpawns = 0;
+      let providerObservationSettled = false;
+      const providerObservation = new Promise<null>((resolve) => {
+        setTimeout(() => {
+          providerObservationSettled = true;
+          resolve(null);
+        }, 15_000);
+      });
+      const boundedClickRead = async (): Promise<void> => {
+        await readConversationSelectionWithin(() => providerObservation, 40);
+      };
+
+      const startNew = async (draftLease: string): Promise<void> => {
+        const lease = beginConversationTransition(gate, "new");
+        if (lease === null) throw new Error("expected New lease");
+        try {
+          const request = await prepareFreshConversationRequest({
+            draftLease,
+            prepareActiveDraft: boundedClickRead,
+            reconcileCachedSelection: () => {},
+            getTrail: () => trail,
+          });
+          expect(request.rollbackLaunch).toEqual(
+            draftLease === "draft-1" ? null : { kind: "fresh" },
+          );
+          freshSpawns += 1;
+          trail = conversationNavigationReducer(trail, {
+            type: "fresh-session-succeeded",
+            draftLease: request.draftLease,
+          });
+        } finally {
+          finishConversationTransition(gate, lease);
+        }
+      };
+
+      const first = startNew("draft-1");
+      await vi.advanceTimersByTimeAsync(40);
+      await first;
+      expect(providerObservationSettled).toBe(false);
+      expect(gate.active).toBeNull();
+      expect(freshSpawns).toBe(1);
+      expect(canNavigateConversation(trail, "back")).toBe(false);
+
+      const second = startNew("draft-2");
+      await vi.advanceTimersByTimeAsync(40);
+      await second;
+      expect(gate.active).toBeNull();
+      expect(freshSpawns).toBe(2);
+      expect(trail.transient?.lease).toBe("draft-2");
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      await providerObservation;
+      expect(providerObservationSettled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves an already-confirmed current ID as New rollback target", async () => {
+    const trail = confirmedTrail(["A"]);
+    const request = await prepareFreshConversationRequest({
+      draftLease: "draft-1",
+      prepareActiveDraft: async () => {},
+      reconcileCachedSelection: () => {},
+      getTrail: () => trail,
+    });
+
+    expect(request).toEqual({
+      draftLease: "draft-1",
+      rollbackLaunch: { kind: "exact-resume", sessionId: "A" },
+    });
+  });
+});
+
+describe("prepareConversationDraftForReplacement", () => {
+  const draft = (lease: string): ActiveConversationEntry => ({
+    kind: "new-draft",
+    originCursor: 0,
+    lease,
+  });
+
+  it("performs one caller-bounded hydration attempt for a draft", async () => {
+    const hydrate = vi.fn<() => Promise<void>>().mockResolvedValue();
+    await prepareConversationDraftForReplacement({
+      getCurrentEntry: () => draft("draft-1"),
+      hydrate,
+    });
+    expect(hydrate).toHaveBeenCalledOnce();
+  });
+
+  it("waits for an input draft to become a confirmed session", async () => {
+    let resolve!: () => void;
+    const pending = new Promise<void>((done) => {
+      resolve = done;
+    });
+    let current: ActiveConversationEntry = draft("draft-1");
+    let settled = false;
+    const preparation = prepareConversationDraftForReplacement({
+      getCurrentEntry: () => current,
+      hydrate: () => pending,
+    }).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    current = session("B");
+    resolve();
+    await preparation;
+  });
+
+  it("does not block replacement when provider session ID remains unconfirmed", async () => {
+    await expect(
+      prepareConversationDraftForReplacement({
+        getCurrentEntry: () => draft("draft-1"),
+        hydrate: () => Promise.resolve(null),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/runtime/sessions/conversation-navigation.ts
+++ b/src/runtime/sessions/conversation-navigation.ts
@@ -1,0 +1,359 @@
+export type ConversationNavigationDirection = "back" | "forward";
+export type ConversationTransitionKind = "new" | ConversationNavigationDirection;
+
+export interface ConversationTransitionLease {
+  readonly id: number;
+  readonly kind: ConversationTransitionKind;
+}
+
+/**
+ * New / Back / Forward が共有する排他 gate。React の disabled 更新より先に handler 側で
+ * lease を確保し、古い operation の finally が新しい operation を解除しないよう id も照合する。
+ */
+export interface ConversationTransitionGate {
+  active: ConversationTransitionLease | null;
+  nextId: number;
+}
+
+export function createConversationTransitionGate(): ConversationTransitionGate {
+  return { active: null, nextId: 1 };
+}
+
+export function beginConversationTransition(
+  gate: ConversationTransitionGate,
+  kind: ConversationTransitionKind,
+): ConversationTransitionLease | null {
+  if (gate.active !== null) return null;
+  const lease = { id: gate.nextId, kind };
+  gate.nextId += 1;
+  gate.active = lease;
+  return lease;
+}
+
+export function finishConversationTransition(
+  gate: ConversationTransitionGate,
+  lease: ConversationTransitionLease,
+): boolean {
+  if (gate.active?.id !== lease.id || gate.active.kind !== lease.kind) return false;
+  gate.active = null;
+  return true;
+}
+
+export function isConversationTransitionActive(gate: ConversationTransitionGate): boolean {
+  return gate.active !== null;
+}
+
+/** 永続的な navigation trail に入れてよい、provider ID 確定済みの会話。 */
+export interface ConversationNavigationEntry {
+  readonly kind: "session";
+  readonly id: string;
+}
+
+/**
+ * New 成功後から最初の入力で provider session ID が確定するまでだけ存在する状態。
+ * trail entry ではなく、originCursor 上に一時的に重なる。
+ */
+export interface NewConversationDraft {
+  readonly kind: "new-draft";
+  readonly originCursor: number;
+  readonly lease: string;
+}
+
+export type ActiveConversationEntry = ConversationNavigationEntry | NewConversationDraft;
+
+export interface PrepareConversationDraftOptions {
+  readonly getCurrentEntry: () => ActiveConversationEntry | null;
+  readonly hydrate: () => Promise<unknown>;
+}
+
+/**
+ * provider-confirmed ID が既にあれば短いpreflightでhydrateする。
+ * raw key/Enterはprovider turn成立の証拠にせず、未確定なら置換を妨げない。
+ */
+export async function prepareConversationDraftForReplacement(
+  options: PrepareConversationDraftOptions,
+): Promise<void> {
+  const entry = options.getCurrentEntry();
+  if (entry?.kind !== "new-draft") return;
+  await options.hydrate();
+}
+
+export type ConversationEntryLaunch =
+  | { readonly kind: "exact-resume"; readonly sessionId: string }
+  | { readonly kind: "fresh" };
+
+export interface PreparedFreshConversationRequest {
+  readonly draftLease: string;
+  readonly rollbackLaunch: ConversationEntryLaunch | null;
+}
+
+export interface PrepareFreshConversationRequestOptions {
+  readonly draftLease: string;
+  readonly prepareActiveDraft: () => Promise<void>;
+  readonly reconcileCachedSelection: () => void;
+  readonly getTrail: () => ConversationNavigationTrail;
+}
+
+/**
+ * New click の同期preflight。provider ID の取得は通常時のbackground観測が所有し、
+ * ここでは待たない。未観測ならrollbackなしでfresh spawnへ進む。
+ */
+export async function prepareFreshConversationRequest(
+  options: PrepareFreshConversationRequestOptions,
+): Promise<PreparedFreshConversationRequest> {
+  await options.prepareActiveDraft();
+  options.reconcileCachedSelection();
+  const current = currentConversationEntry(options.getTrail());
+  return {
+    draftLease: options.draftLease,
+    rollbackLaunch: current === null ? null : conversationEntryLaunch(current),
+  };
+}
+
+/**
+ * confirmed provider sessions だけを持つ線形 trail。New の blank は transient に置き、
+ * 初回入力で provider session ID が確定するまで entries / cursor を変えない。
+ * scope identity は caller が所有するため、将来 workspace / Main Agent / agent / persona ごとに
+ * この state を keying できる。
+ */
+export interface ConversationNavigationTrail {
+  readonly entries: readonly ConversationNavigationEntry[];
+  readonly cursor: number;
+  readonly transient: NewConversationDraft | null;
+}
+
+export type ConversationNavigationAction =
+  | {
+      readonly type: "fresh-session-succeeded";
+      readonly draftLease: string;
+    }
+  | { readonly type: "confirmed-session-observed"; readonly sessionId: string }
+  | {
+      readonly type: "current-session-replaced";
+      readonly expectedSessionId: string;
+      readonly actualSessionId: string;
+    }
+  | {
+      /** PTY replace境界でbackendがatomicに捕捉したoutgoing confirmed session。 */
+      readonly type: "outgoing-session-confirmed";
+      readonly sessionId: string;
+    }
+  | {
+      readonly type: "navigation-succeeded";
+      readonly direction: ConversationNavigationDirection;
+      readonly entry: ConversationNavigationEntry;
+      /** active-writer fallback等でproviderが実際に選んだID。 */
+      readonly actualSessionId?: string;
+    }
+  | {
+      readonly type: "draft-hydrated";
+      readonly draftLease: string;
+      readonly sessionId: string;
+    }
+  | { readonly type: "operation-failed" }
+  | { readonly type: "reset" };
+
+export const EMPTY_CONVERSATION_NAVIGATION_TRAIL: ConversationNavigationTrail = Object.freeze({
+  entries: Object.freeze([]),
+  cursor: -1,
+  transient: null,
+});
+
+function isNonEmpty(value: string | null): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function conversationEntriesEqual(
+  left: ActiveConversationEntry,
+  right: ActiveConversationEntry,
+): boolean {
+  if (left.kind === "session") return right.kind === "session" && left.id === right.id;
+  return right.kind === "new-draft" && left.lease === right.lease;
+}
+
+export function conversationEntryLaunch(entry: ActiveConversationEntry): ConversationEntryLaunch {
+  return entry.kind === "session"
+    ? { kind: "exact-resume", sessionId: entry.id }
+    : { kind: "fresh" };
+}
+
+export function currentConversationEntry(
+  trail: ConversationNavigationTrail,
+): ActiveConversationEntry | null {
+  if (trail.transient !== null) return trail.transient;
+  if (trail.cursor < 0 || trail.cursor >= trail.entries.length) return null;
+  return trail.entries[trail.cursor] ?? null;
+}
+
+export function currentConfirmedConversationEntry(
+  trail: ConversationNavigationTrail,
+): ConversationNavigationEntry | null {
+  if (trail.cursor < 0 || trail.cursor >= trail.entries.length) return null;
+  return trail.entries[trail.cursor] ?? null;
+}
+
+export function conversationNavigationTarget(
+  trail: ConversationNavigationTrail,
+  direction: ConversationNavigationDirection,
+): ConversationNavigationEntry | null {
+  if (trail.transient !== null) {
+    if (direction === "forward") return null;
+    return trail.entries[trail.transient.originCursor] ?? null;
+  }
+  const targetCursor = trail.cursor + (direction === "back" ? -1 : 1);
+  if (targetCursor < 0 || targetCursor >= trail.entries.length) return null;
+  const target = trail.entries[targetCursor] ?? null;
+  const current = currentConversationEntry(trail);
+  return target && current && conversationEntriesEqual(target, current) ? null : target;
+}
+
+export function canNavigateConversation(
+  trail: ConversationNavigationTrail,
+  direction: ConversationNavigationDirection,
+): boolean {
+  return conversationNavigationTarget(trail, direction) !== null;
+}
+
+function commitFreshSession(
+  trail: ConversationNavigationTrail,
+  draftLease: string,
+): ConversationNavigationTrail {
+  if (!isNonEmpty(draftLease)) return trail;
+  if (trail.transient?.lease === draftLease) return trail;
+  return {
+    entries: trail.entries,
+    cursor: trail.cursor,
+    transient: {
+      kind: "new-draft",
+      originCursor: trail.transient?.originCursor ?? trail.cursor,
+      lease: draftLease,
+    },
+  };
+}
+
+function observeConfirmedSession(
+  trail: ConversationNavigationTrail,
+  sessionId: string,
+): ConversationNavigationTrail {
+  if (!isNonEmpty(sessionId) || trail.transient !== null) return trail;
+  const current = currentConfirmedConversationEntry(trail);
+  if (current?.id === sessionId) return trail;
+  const existingIndex = trail.entries.findIndex((entry) => entry.id === sessionId);
+  if (existingIndex >= 0) {
+    return { entries: trail.entries, cursor: existingIndex, transient: null };
+  }
+  const prefix = trail.cursor >= 0 ? trail.entries.slice(0, trail.cursor + 1) : [];
+  const entries = [...prefix, { kind: "session" as const, id: sessionId }];
+  return {
+    entries,
+    cursor: entries.length - 1,
+    transient: null,
+  };
+}
+
+function replaceCurrentConfirmedSession(
+  trail: ConversationNavigationTrail,
+  expectedSessionId: string,
+  actualSessionId: string,
+): ConversationNavigationTrail {
+  if (!isNonEmpty(expectedSessionId) || !isNonEmpty(actualSessionId)) return trail;
+  if (trail.transient !== null) return trail;
+  const current = currentConfirmedConversationEntry(trail);
+  if (current?.id !== expectedSessionId) return trail;
+  if (expectedSessionId === actualSessionId) return trail;
+  const entries = trail.entries.map((entry, index) =>
+    index === trail.cursor ? { kind: "session" as const, id: actualSessionId } : entry,
+  );
+  return { entries, cursor: trail.cursor, transient: null };
+}
+
+function commitNavigation(
+  trail: ConversationNavigationTrail,
+  direction: ConversationNavigationDirection,
+  entry: ConversationNavigationEntry,
+  actualSessionId?: string,
+): ConversationNavigationTrail {
+  const target = conversationNavigationTarget(trail, direction);
+  if (target === null || !conversationEntriesEqual(target, entry)) return trail;
+  const actualEntry = {
+    kind: "session" as const,
+    id: isNonEmpty(actualSessionId ?? null) ? (actualSessionId as string) : entry.id,
+  };
+  if (trail.transient !== null) {
+    if (direction !== "back") return trail;
+    const entries = trail.entries.map((confirmed, index) =>
+      index === trail.transient?.originCursor ? actualEntry : confirmed,
+    );
+    return {
+      entries,
+      cursor: trail.transient.originCursor,
+      transient: null,
+    };
+  }
+  const cursor = trail.cursor + (direction === "back" ? -1 : 1);
+  const entries = trail.entries.map((confirmed, index) =>
+    index === cursor ? actualEntry : confirmed,
+  );
+  return {
+    entries,
+    cursor,
+    transient: null,
+  };
+}
+
+function hydrateDraft(
+  trail: ConversationNavigationTrail,
+  draftLease: string,
+  sessionId: string,
+): ConversationNavigationTrail {
+  if (!isNonEmpty(draftLease) || !isNonEmpty(sessionId)) return trail;
+  if (trail.transient?.lease !== draftLease) return trail;
+  const existingIndex = trail.entries.findIndex((entry) => entry.id === sessionId);
+  if (existingIndex >= 0) {
+    // draft 内の provider-native resume/fork selection は新規 entry にせず、
+    // ephemeral draft を破棄して既存の confirmed cursor へ同期する。
+    return { entries: trail.entries, cursor: existingIndex, transient: null };
+  }
+  const prefix = trail.entries.slice(0, trail.transient.originCursor + 1);
+  const entries = [...prefix, { kind: "session" as const, id: sessionId }];
+  return { entries, cursor: entries.length - 1, transient: null };
+}
+
+function confirmOutgoingSession(
+  trail: ConversationNavigationTrail,
+  sessionId: string,
+): ConversationNavigationTrail {
+  if (!isNonEmpty(sessionId)) return trail;
+  if (trail.transient !== null) {
+    return hydrateDraft(trail, trail.transient.lease, sessionId);
+  }
+  return observeConfirmedSession(trail, sessionId);
+}
+
+export function conversationNavigationReducer(
+  trail: ConversationNavigationTrail,
+  action: ConversationNavigationAction,
+): ConversationNavigationTrail {
+  switch (action.type) {
+    case "fresh-session-succeeded":
+      return commitFreshSession(trail, action.draftLease);
+    case "confirmed-session-observed":
+      return observeConfirmedSession(trail, action.sessionId);
+    case "current-session-replaced":
+      return replaceCurrentConfirmedSession(
+        trail,
+        action.expectedSessionId,
+        action.actualSessionId,
+      );
+    case "outgoing-session-confirmed":
+      return confirmOutgoingSession(trail, action.sessionId);
+    case "navigation-succeeded":
+      return commitNavigation(trail, action.direction, action.entry, action.actualSessionId);
+    case "draft-hydrated":
+      return hydrateDraft(trail, action.draftLease, action.sessionId);
+    case "operation-failed":
+      return trail;
+    case "reset":
+      return EMPTY_CONVERSATION_NAVIGATION_TRAIL;
+  }
+}

--- a/src/runtime/sessions/default-spawn-spec.test.ts
+++ b/src/runtime/sessions/default-spawn-spec.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   spawnSpecFromDefaultProfile,
   withAgentResumePolicy,
+  withAgentResumeSessionId,
   withAgentRuntimeFields,
 } from "./default-spawn-spec";
 import type { SessionProfile } from "./types";
@@ -83,13 +84,52 @@ describe("withAgentResumePolicy", () => {
         agent: "claude",
         command: null,
         resume: false,
+        resumeSessionId: null,
       },
     );
+  });
+
+  it("clears an exact resume target when preparing a fresh session", () => {
+    expect(
+      withAgentResumePolicy(
+        {
+          kind: "agent",
+          agent: "codex",
+          resume: true,
+          resumeSessionId: "old-session-id",
+        },
+        false,
+      ),
+    ).toEqual({
+      kind: "agent",
+      agent: "codex",
+      resume: false,
+      resumeSessionId: null,
+    });
   });
 
   it("does not add resume policy to shell specs", () => {
     expect(
       withAgentResumePolicy({ kind: "shell", command: null, integration: true }, false),
+    ).toEqual({ kind: "shell", command: null, integration: true });
+  });
+});
+
+describe("withAgentResumeSessionId", () => {
+  it("targets one exact agent conversation and enables resume", () => {
+    expect(
+      withAgentResumeSessionId({ kind: "agent", agent: "codex", resume: false }, "0198-session-id"),
+    ).toEqual({
+      kind: "agent",
+      agent: "codex",
+      resume: true,
+      resumeSessionId: "0198-session-id",
+    });
+  });
+
+  it("does not add provider resume fields to shell specs", () => {
+    expect(
+      withAgentResumeSessionId({ kind: "shell", command: null, integration: true }, "ignored"),
     ).toEqual({ kind: "shell", command: null, integration: true });
   });
 });

--- a/src/runtime/sessions/default-spawn-spec.ts
+++ b/src/runtime/sessions/default-spawn-spec.ts
@@ -33,5 +33,10 @@ export function withAgentRuntimeFields(
 
 export function withAgentResumePolicy(spec: SpawnSpec, resume: boolean): SpawnSpec {
   if (spec.kind !== "agent") return spec;
-  return { ...spec, resume };
+  return resume ? { ...spec, resume: true } : { ...spec, resume: false, resumeSessionId: null };
+}
+
+export function withAgentResumeSessionId(spec: SpawnSpec, sessionId: string): SpawnSpec {
+  if (spec.kind !== "agent") return spec;
+  return { ...spec, resume: true, resumeSessionId: sessionId };
 }

--- a/src/runtime/sessions/observed-session.test.ts
+++ b/src/runtime/sessions/observed-session.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  readConversationSelectionWithin,
+  waitForConversationSelectionAfterSubmit,
+  waitForObservedSessionId,
+} from "./observed-session";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("waitForObservedSessionId", () => {
+  it("polls until the initial current session ID becomes observable", async () => {
+    vi.useFakeTimers();
+    const read = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue("A");
+
+    const observed = waitForObservedSessionId(read, {
+      timeoutMs: 1_000,
+      pollIntervalMs: 10,
+    });
+    await vi.runAllTimersAsync();
+
+    await expect(observed).resolves.toBe("A");
+  });
+
+  it("ignores stale known IDs until a genuinely new session is observed", async () => {
+    vi.useFakeTimers();
+    const read = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce("B")
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce("C")
+      .mockResolvedValue("D");
+
+    const observed = waitForObservedSessionId(read, {
+      excludedSessionIds: new Set(["A", "B", "C"]),
+      timeoutMs: 1_000,
+      pollIntervalMs: 10,
+    });
+    await vi.runAllTimersAsync();
+
+    await expect(observed).resolves.toBe("D");
+  });
+
+  it("requires an exact ID before confirming back or forward navigation", async () => {
+    vi.useFakeTimers();
+    const read = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce("C")
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue("B");
+
+    const observed = waitForObservedSessionId(read, {
+      expectedSessionId: "B",
+      timeoutMs: 1_000,
+      pollIntervalMs: 10,
+    });
+    await vi.runAllTimersAsync();
+
+    await expect(observed).resolves.toBe("B");
+  });
+
+  it("stops observing when the owning terminal generation is replaced", async () => {
+    const read = vi.fn<() => Promise<string | null>>().mockResolvedValue("stale");
+
+    await expect(
+      waitForObservedSessionId(read, {
+        shouldContinue: () => false,
+      }),
+    ).resolves.toBeNull();
+    expect(read).not.toHaveBeenCalled();
+  });
+});
+
+describe("readConversationSelectionWithin", () => {
+  it("returns after the click-time budget even when provider ID remains null for 15 seconds", async () => {
+    vi.useFakeTimers();
+    const slowRead = new Promise<null>((resolve) => {
+      window.setTimeout(() => resolve(null), 15_000);
+    });
+    let settled = false;
+    const immediate = readConversationSelectionWithin(() => slowRead, 40).then((selection) => {
+      settled = true;
+      return selection;
+    });
+
+    await vi.advanceTimersByTimeAsync(39);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(immediate).resolves.toBeNull();
+    expect(settled).toBe(true);
+  });
+});
+
+describe("waitForConversationSelectionAfterSubmit", () => {
+  it("keeps a provider-native new thread provisional when no later prompt was submitted", async () => {
+    const provisional = { sessionId: "B", confirmed: false, revision: 2 };
+
+    await expect(
+      waitForConversationSelectionAfterSubmit({
+        readSelection: async () => provisional,
+        baselineRevision: 1,
+        modeledSessionId: "A",
+        submitSequence: 1,
+        getCurrentSubmitSequence: () => 1,
+        shouldContinue: () => true,
+        provisionalTimeoutMs: 0,
+        confirmationTimeoutMs: 0,
+        pollIntervalMs: 0,
+      }),
+    ).resolves.toEqual(provisional);
+  });
+
+  it("does not lose a prompt coalesced just before the provisional timeout", async () => {
+    const provisional = { sessionId: "B", confirmed: false, revision: 2 };
+    const confirmed = { sessionId: "B", confirmed: true, revision: 3 };
+    const readSelection = vi
+      .fn<() => Promise<typeof provisional>>()
+      .mockResolvedValueOnce(provisional)
+      .mockResolvedValue(confirmed);
+
+    await expect(
+      waitForConversationSelectionAfterSubmit({
+        readSelection,
+        baselineRevision: 1,
+        modeledSessionId: "A",
+        submitSequence: 1,
+        // sequence 2 はobserver coalescing中に届いた最初のprompt submit。
+        getCurrentSubmitSequence: () => 2,
+        shouldContinue: () => true,
+        provisionalTimeoutMs: 0,
+        confirmationTimeoutMs: 1_000,
+        pollIntervalMs: 0,
+      }),
+    ).resolves.toEqual(confirmed);
+    expect(readSelection).toHaveBeenCalledTimes(2);
+  });
+
+  it("observes a changed provider ID when an unmanaged PTY respawn reset the proxy revision", async () => {
+    const respawned = { sessionId: "B", confirmed: true, revision: 2 };
+
+    await expect(
+      waitForConversationSelectionAfterSubmit({
+        readSelection: async () => respawned,
+        // 前proxyのrevisionは高いが、provider ID差を優先して新processを検出する。
+        baselineRevision: 10,
+        modeledSessionId: "A",
+        submitSequence: 1,
+        getCurrentSubmitSequence: () => 1,
+        shouldContinue: () => true,
+        provisionalTimeoutMs: 0,
+        confirmationTimeoutMs: 0,
+        pollIntervalMs: 0,
+      }),
+    ).resolves.toEqual(respawned);
+  });
+
+  it("drops a late selection when the owning generation or modeled cursor changed", async () => {
+    let active = true;
+    const result = waitForConversationSelectionAfterSubmit({
+      readSelection: async () => {
+        active = false;
+        return { sessionId: "B", confirmed: true, revision: 2 };
+      },
+      baselineRevision: 1,
+      modeledSessionId: "A",
+      submitSequence: 1,
+      getCurrentSubmitSequence: () => 1,
+      shouldContinue: () => active,
+      provisionalTimeoutMs: 0,
+      confirmationTimeoutMs: 0,
+      pollIntervalMs: 0,
+    });
+
+    await expect(result).resolves.toBeNull();
+  });
+});

--- a/src/runtime/sessions/observed-session.ts
+++ b/src/runtime/sessions/observed-session.ts
@@ -1,0 +1,117 @@
+export interface WaitForObservedSessionOptions {
+  readonly expectedSessionId?: string;
+  readonly excludedSessionIds?: ReadonlySet<string>;
+  readonly timeoutMs?: number;
+  readonly pollIntervalMs?: number;
+  readonly shouldContinue?: () => boolean;
+}
+
+export interface ObservedConversationSelection {
+  readonly sessionId: string;
+  readonly confirmed: boolean;
+  readonly revision: number;
+}
+
+export interface WaitForConversationSelectionAfterSubmitOptions {
+  readonly readSelection: () => Promise<ObservedConversationSelection | null>;
+  readonly baselineRevision: number | null;
+  readonly modeledSessionId: string | null;
+  readonly submitSequence: number;
+  readonly getCurrentSubmitSequence: () => number;
+  readonly shouldContinue: () => boolean;
+  readonly provisionalTimeoutMs?: number;
+  readonly confirmationTimeoutMs?: number;
+  readonly pollIntervalMs?: number;
+}
+
+const delay = (durationMs: number): Promise<void> =>
+  new Promise((resolve) => window.setTimeout(resolve, durationMs));
+
+/** click transition向けのbest-effort read。provider応答を待ち続けず必ず期限内に返す。 */
+export async function readConversationSelectionWithin(
+  readSelection: () => Promise<ObservedConversationSelection | null>,
+  timeoutMs = 40,
+): Promise<ObservedConversationSelection | null> {
+  return Promise.race([readSelection(), delay(timeoutMs).then(() => null)]);
+}
+
+/**
+ * Codex TUI proxy が選択を確定した response だけを待つ。New では既知 ID を除外し、
+ * exact resume では目的 ID と一致するまで待つため、respawn 直後の stale 値を採用しない。
+ */
+export async function waitForObservedSessionId(
+  readSelectedSessionId: () => Promise<string | null>,
+  options: WaitForObservedSessionOptions = {},
+): Promise<string | null> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const pollIntervalMs = options.pollIntervalMs ?? 100;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    if (options.shouldContinue?.() === false) return null;
+    const sessionId = await readSelectedSessionId();
+    if (options.shouldContinue?.() === false) return null;
+    const matchesExpected =
+      options.expectedSessionId === undefined || sessionId === options.expectedSessionId;
+    const isExcluded = sessionId !== null && options.excludedSessionIds?.has(sessionId) === true;
+    if (sessionId && matchesExpected && !isExcluded) return sessionId;
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) return null;
+    await delay(Math.min(pollIntervalMs, remainingMs));
+  }
+}
+
+/**
+ * submit 後の provider selection 変化を観測する。native `/new` の provisional
+ * thread/start 中に次のpromptがsubmitされた場合は、そのsubmitをcoalescingで失わず、
+ * matching turn/start confirmationまで待つ。
+ */
+export async function waitForConversationSelectionAfterSubmit(
+  options: WaitForConversationSelectionAfterSubmitOptions,
+): Promise<ObservedConversationSelection | null> {
+  let observed: ObservedConversationSelection | null = null;
+  await waitForObservedSessionId(
+    async () => {
+      const selection = await options.readSelection();
+      if (selection === null) return null;
+      const advanced =
+        selection.sessionId !== options.modeledSessionId ||
+        (options.baselineRevision !== null && selection.revision > options.baselineRevision);
+      if (!advanced) return null;
+      observed = selection;
+      return selection.confirmed ? selection.sessionId : null;
+    },
+    {
+      timeoutMs: options.provisionalTimeoutMs ?? 2_000,
+      pollIntervalMs: options.pollIntervalMs ?? 50,
+      shouldContinue: options.shouldContinue,
+    },
+  );
+
+  let selection = observed as ObservedConversationSelection | null;
+  if (
+    selection !== null &&
+    !selection.confirmed &&
+    options.getCurrentSubmitSequence() > options.submitSequence &&
+    options.shouldContinue()
+  ) {
+    const provisionalRevision = selection.revision;
+    await waitForObservedSessionId(
+      async () => {
+        const next = await options.readSelection();
+        if (next === null || next.revision <= provisionalRevision) return null;
+        observed = next;
+        return next.confirmed ? next.sessionId : null;
+      },
+      {
+        timeoutMs: options.confirmationTimeoutMs ?? 15_000,
+        pollIntervalMs: options.pollIntervalMs ?? 50,
+        shouldContinue: options.shouldContinue,
+      },
+    );
+    selection = observed as ObservedConversationSelection | null;
+  }
+
+  return options.shouldContinue() ? selection : null;
+}

--- a/src/runtime/terminal-runtime/terminal-runtime.test.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.test.ts
@@ -308,7 +308,7 @@ describe("TerminalRuntime", () => {
     mockState.sessionResize.mockReset();
     mockState.sessionResize.mockResolvedValue(undefined);
     mockState.sessionSpawn.mockReset();
-    mockState.sessionSpawn.mockResolvedValue(undefined);
+    mockState.sessionSpawn.mockResolvedValue({ replacedConfirmedSessionId: null });
     mockState.sessionWrite.mockReset();
     mockState.sessionWrite.mockResolvedValue(undefined);
   });
@@ -465,6 +465,72 @@ describe("TerminalRuntime", () => {
     firstChannel.onmessage?.(new Uint8Array([65]).buffer);
     freshChannel.onmessage?.(new Uint8Array([66]).buffer);
     expect(terminal.writes).toEqual([new Uint8Array([66])]);
+  });
+
+  it("one-shot respawn はbackendがatomicに捕捉した置換前session IDを返す", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    mockState.sessionSpawn.mockResolvedValueOnce({ replacedConfirmedSessionId: "A" });
+
+    await expect(
+      runtime.forceRespawnWithParams({ spec: shellSpec, cwd: "/workspace" }),
+    ).resolves.toEqual({ replacedConfirmedSessionId: "A" });
+  });
+
+  it("one-shot respawn の spawn 失敗を caller に返す", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const failure = new Error("spawn failed");
+    mockState.sessionSpawn.mockRejectedValueOnce(failure);
+
+    await expect(
+      runtime.forceRespawnWithParams({ spec: shellSpec, cwd: "/workspace" }),
+    ).rejects.toBe(failure);
+  });
+
+  it("competing respawn はspawn invokeを直列化し、最新startだけをbackend winnerにする", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const firstSpawn = deferred<void>();
+    let backendCwd: string | null = null;
+    mockState.sessionSpawn
+      .mockImplementationOnce(async (args) => {
+        await firstSpawn.promise;
+        backendCwd = args.cwd;
+        return { replacedConfirmedSessionId: null };
+      })
+      .mockImplementationOnce(async (args) => {
+        backendCwd = args.cwd;
+        return { replacedConfirmedSessionId: null };
+      });
+
+    const first = runtime.forceRespawnWithParams({ spec: shellSpec, cwd: "/first" });
+    await flushMicrotasks();
+    const second = runtime.forceRespawnWithParams({ spec: shellSpec, cwd: "/second" });
+    await flushMicrotasks();
+
+    // start2 はstart1のbackend side effectが完了するまでinvokeされない。
+    expect(mockState.sessionSpawn).toHaveBeenCalledTimes(1);
+    firstSpawn.resolve();
+
+    await expect(first).rejects.toThrow("PTY start was superseded");
+    await second;
+    expect(mockState.sessionSpawn).toHaveBeenCalledTimes(2);
+    expect(backendCwd).toBe("/second");
+  });
+
+  it("superseded one-shot spawn が失敗してもsuccessとしてresolveしない", async () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const firstSpawn = deferred<{ readonly replacedConfirmedSessionId: string | null }>();
+    mockState.sessionSpawn
+      .mockReturnValueOnce(firstSpawn.promise)
+      .mockResolvedValueOnce({ replacedConfirmedSessionId: null });
+
+    const first = runtime.forceRespawnWithParams({ spec: shellSpec, cwd: "/first" });
+    await flushMicrotasks();
+    const second = runtime.forceRespawnWithParams({ spec: shellSpec, cwd: "/second" });
+    const firstRejected = expect(first).rejects.toThrow("PTY start was superseded");
+    firstSpawn.reject(new Error("first spawn failed"));
+
+    await firstRejected;
+    await expect(second).resolves.toEqual({ replacedConfirmedSessionId: null });
   });
 
   it("attach-first が見つからない場合は spawn に新しい Channel を渡す", async () => {

--- a/src/runtime/terminal-runtime/terminal-runtime.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.ts
@@ -4,6 +4,7 @@ import type { ITheme as XTermTheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
 import type { Disposable, TerminalCellData } from "@yorishiro/sdk";
 import {
+  type SessionSpawnResult,
   type SpawnSpec,
   sessionAttach,
   sessionDestroy,
@@ -103,6 +104,13 @@ export function hexToRgba(background: string, alpha: number): string {
   return `rgba(20,22,25,${clampedAlpha})`;
 }
 
+class SupersededPtyStartError extends Error {
+  constructor() {
+    super("PTY start was superseded by a newer replacement");
+    this.name = "SupersededPtyStartError";
+  }
+}
+
 /**
  * TerminalRuntime implementation. See types.ts for the contract.
  *
@@ -164,6 +172,15 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   /** 直近 setTheme で明示された背景色。背景 alpha の色元・不透明化時の復帰先。 */
   private currentThemeBackground: string | undefined;
   private startGeneration = 0;
+  /**
+   * 同じ session id に対する session_spawn invoke を発行順に直列化する。
+   *
+   * JS generation guard だけでは、古い invoke が Rust 側で遅れて完了したときに
+   * 新しい PTY を backend から上書きできてしまう。invoke 自体を直列化し、各
+   * dequeue 時に generation を再確認することで、backend の最終 winner も常に
+   * 最新 start と一致させる。
+   */
+  private ptySpawnQueue: Promise<void> = Promise.resolve();
   private ptyExitUnlisten: (() => void) | null = null;
   private regionDrag: {
     readonly pointerId: number;
@@ -423,11 +440,17 @@ class TerminalRuntimeImpl implements TerminalRuntime {
       return;
     }
     this.currentParams = params;
-    this.startPty(params, { attachFirst: options.attachFirst === true });
+    this.startPty(params, {
+      attachFirst: options.attachFirst === true,
+      rejectOnSpawnFailure: false,
+    });
   }
 
-  private startPty(params: PtyParams, opts: { attachFirst: boolean }): Promise<void> {
-    if (this.disposed) return Promise.resolve();
+  private startPty(
+    params: PtyParams,
+    opts: { attachFirst: boolean; rejectOnSpawnFailure: boolean },
+  ): Promise<SessionSpawnResult | null> {
+    if (this.disposed) return Promise.resolve(null);
     const generation = ++this.startGeneration;
     // 前 generation の attach replay 用 buffer を新しい起動へ持ち越さない。
     this.attachLiveBuffer = null;
@@ -437,8 +460,13 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     this.term.reset();
 
     return (async () => {
+      const stopIfStale = (): boolean => {
+        if (!this.isStaleStart(generation)) return false;
+        if (opts.rejectOnSpawnFailure) throw new SupersededPtyStartError();
+        return true;
+      };
       try {
-        if (this.isStaleStart(generation)) return;
+        if (stopIfStale()) return null;
         if (this.attachedContainer) {
           this.syncAttachedRect();
         }
@@ -455,9 +483,9 @@ class TerminalRuntimeImpl implements TerminalRuntime {
             if (this.disposed && result.attached) {
               if (this.attachLiveBuffer === liveBuffer) this.attachLiveBuffer = null;
               void sessionDestroy({ sessionId: this.sessionId });
-              return;
+              return null;
             }
-            if (this.isStaleStart(generation)) return;
+            if (stopIfStale()) return null;
             const bufferedLive = this.attachLiveBuffer === liveBuffer ? liveBuffer : [];
             this.attachLiveBuffer = null;
             if (result.attached) {
@@ -466,10 +494,10 @@ class TerminalRuntimeImpl implements TerminalRuntime {
                 this.handlePtyBytes(liveBytes, { replay: false });
               }
               this.resyncAttachedPtyDisplay();
-              return;
+              return null;
             }
           } catch {
-            if (this.isStaleStart(generation)) return;
+            if (stopIfStale()) return null;
             if (this.attachLiveBuffer === liveBuffer) this.attachLiveBuffer = null;
           }
           if (this.attachLiveBuffer === liveBuffer) this.attachLiveBuffer = null;
@@ -477,26 +505,43 @@ class TerminalRuntimeImpl implements TerminalRuntime {
         if (this.attachedContainer) {
           this.syncAttachedRect();
         }
-        if (this.isStaleStart(generation)) return;
+        if (stopIfStale()) return null;
         const cols = Math.max(2, this.term.cols || 80);
         const rows = Math.max(1, this.term.rows || 24);
         const spawnChannel = this.createOutputChannel(generation);
-        await sessionSpawn({
-          sessionId: this.sessionId,
-          spec: params.spec,
-          cols,
-          rows,
-          cwd: params.cwd,
-          onOutput: spawnChannel,
+        const spawnOperation = this.ptySpawnQueue.then(async () => {
+          if (stopIfStale()) return null;
+          return sessionSpawn({
+            sessionId: this.sessionId,
+            spec: params.spec,
+            cols,
+            rows,
+            cwd: params.cwd,
+            onOutput: spawnChannel,
+          });
         });
+        // 失敗した spawn が後続 start の dequeue を妨げないよう queue tail は
+        // fulfilled に戻す。caller には spawnOperation 自体の失敗を返す。
+        this.ptySpawnQueue = spawnOperation.then(
+          () => {},
+          () => {},
+        );
+        const spawnResult = await spawnOperation;
         if (this.disposed) {
           void sessionDestroy({ sessionId: this.sessionId });
+          if (opts.rejectOnSpawnFailure) throw new SupersededPtyStartError();
+          return null;
         }
+        if (stopIfStale()) return null;
+        return spawnResult;
       } catch (err) {
-        if (this.isStaleStart(generation)) return;
+        if (err instanceof SupersededPtyStartError) throw err;
+        if (stopIfStale()) return null;
         const label = describeSpec(params.spec);
         this.term.write(`\x1b[31mFailed to start ${label}: ${err}\x1b[0m\r\n`);
         this.term.write(`\x1b[90mMake sure ${label} is installed and in your PATH.\x1b[0m\r\n`);
+        if (opts.rejectOnSpawnFailure) throw err;
+        return null;
       }
     })();
   }
@@ -916,12 +961,15 @@ class TerminalRuntimeImpl implements TerminalRuntime {
   forceRespawn(): void {
     if (this.disposed) return;
     if (!this.currentParams) return;
-    void this.startPty(this.currentParams, { attachFirst: false });
+    void this.startPty(this.currentParams, {
+      attachFirst: false,
+      rejectOnSpawnFailure: false,
+    });
   }
 
-  forceRespawnWithParams(params: PtyParams): Promise<void> {
-    if (this.disposed) return Promise.resolve();
-    return this.startPty(params, { attachFirst: false });
+  forceRespawnWithParams(params: PtyParams): Promise<SessionSpawnResult | null> {
+    if (this.disposed) return Promise.resolve(null);
+    return this.startPty(params, { attachFirst: false, rejectOnSpawnFailure: true });
   }
 
   private isStaleStart(generation: number): boolean {

--- a/src/runtime/terminal-runtime/types.ts
+++ b/src/runtime/terminal-runtime/types.ts
@@ -1,6 +1,6 @@
 import type { ITheme as XTermTheme } from "@xterm/xterm";
 import type { Disposable, TerminalCellData } from "@yorishiro/sdk";
-import type { SpawnSpec } from "../../bindings/tauri-commands";
+import type { SessionSpawnResult, SpawnSpec } from "../../bindings/tauri-commands";
 import type { Perception } from "../../core/perception";
 import type { TerminalCommandRun } from "./command-run-store";
 import type { RegionPoint } from "./region-selection";
@@ -359,7 +359,8 @@ export interface TerminalRuntime {
   /**
    * canonical な currentParams は保ったまま、1回だけ別 params で置き換え起動する。
    * Main Agent の「新しいセッション」のように、通常は resume する session を今回だけ
-   * resume=false で fresh 起動するときに使う。
+   * resume=false で fresh 起動するときに使う。戻り値にはbackendがreplace直前に
+   * 保持していたprovider-confirmed session IDが含まれる。
    */
-  forceRespawnWithParams(params: PtyParams): Promise<void>;
+  forceRespawnWithParams(params: PtyParams): Promise<SessionSpawnResult | null>;
 }

--- a/src/title-bar.test.tsx
+++ b/src/title-bar.test.tsx
@@ -101,6 +101,22 @@ describe("TitleBar", () => {
     expect(onToggleVoice).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the GPT Live control visible but blocks it during a session transition", () => {
+    const onToggleVoice = vi.fn();
+    renderTitleBar({
+      voiceAvailable: true,
+      voiceDisabled: true,
+      voiceState: "idle",
+      voiceLabel: "Start voice",
+      onToggleVoice,
+    });
+
+    const button = screen.getByRole("button", { name: "Start voice" });
+    expect(button.getAttribute("disabled")).not.toBeNull();
+    fireEvent.click(button);
+    expect(onToggleVoice).not.toHaveBeenCalled();
+  });
+
   it("shows a plain unpressed mic while idle", () => {
     renderTitleBar({
       voiceAvailable: true,

--- a/src/title-bar.tsx
+++ b/src/title-bar.tsx
@@ -18,6 +18,7 @@ export interface TitleBarProps {
   readonly settingsLabel: string;
   readonly sidebarLabel: string;
   readonly voiceAvailable?: boolean;
+  readonly voiceDisabled?: boolean;
   readonly voiceState?: VoiceControlState;
   /** Browser-owned microphone capture liveness, independent of the conversation status. */
   readonly voiceMicrophoneActive?: boolean;
@@ -35,6 +36,7 @@ export default function TitleBar({
   settingsLabel,
   sidebarLabel,
   voiceAvailable = false,
+  voiceDisabled = false,
   voiceState = "idle",
   voiceMicrophoneActive = false,
   voiceLabel = "",
@@ -79,6 +81,7 @@ export default function TitleBar({
             data-voice-state={voiceState}
             data-microphone-active={voiceMicrophoneActive}
             onClick={onToggleVoice}
+            disabled={voiceDisabled}
             aria-label={voiceLabel}
             aria-pressed={voiceState === "active"}
             aria-busy={voiceState === "connecting" || undefined}


### PR DESCRIPTION
## Summary

- add Back and Forward controls for Main Agent conversations
- keep per-workspace navigation history across New, Back, and Forward replacements
- serialize all conversation replacements through one navigation gate
- preserve GPT Live reconnection and restore the exact previous Codex session when a spawn fails

## Why

PR #119 added one-click **New conversation** and intentionally left previous-conversation navigation out of scope. This follow-up lets users return to the conversation they just left without opening a provider-specific history picker.

A frontend-only history stack is not sufficient: the confirmed Codex session ID can arrive after the UI starts replacing the PTY, and overlapping New/Back/Forward spawns can complete out of order. The Rust replacement boundary now returns an atomic snapshot of the outgoing confirmed session, while the frontend serializes replacements and uses that snapshot as the authoritative history entry.

## User impact

Users can move backward and forward through Main Agent conversations while keeping shell tabs, pack state, the active writer, and GPT Live lifecycle intact. A failed navigation spawn restores the exact outgoing conversation.

## Validation

- frontend: 177 files / 2,346 tests passed
- Rust: 306 tests passed
- TypeScript typecheck passed
- Biome lint/format passed
- cargo fmt and clippy passed
- git diff check passed
- production macOS app build passed
- physical-device verification passed for Back/Forward and the previously affected pack
- independent GPT-5.6 Sol xhigh review found no new High or Medium issues

## Related

- follow-up to #118 / #119
