### PR TITLE
Expose bundled Pack capabilities to local authoring

### DIFF
--- a/bundled-packs/ambient-ui/attention-aura/ui.test.ts
+++ b/bundled-packs/ambient-ui/attention-aura/ui.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import type {
   AmbientUiContext,
+  AmenityServicesAPI,
   AttentionAPI,
   AttentionSnapshot,
   AttentionTarget,
@@ -44,6 +45,8 @@ function makeFakeAttention(initial: AttentionSnapshot = { target: null }): FakeA
   };
 }
 
+const noAmenities = { get: () => null } satisfies AmenityServicesAPI;
+
 const sampleTarget: AttentionTarget = {
   kind: "mouse",
   source: "mouse",
@@ -73,7 +76,7 @@ describe("Aura component", () => {
 
   it("renders nothing initially when target is null and opacity is 0", () => {
     const fake = makeFakeAttention();
-    const ctx = { attention: fake.api } satisfies AmbientUiContext;
+    const ctx = { attention: fake.api, amenities: noAmenities } satisfies AmbientUiContext;
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -91,7 +94,7 @@ describe("Aura component", () => {
     const rafSpy = vi.spyOn(window, "requestAnimationFrame");
     try {
       const fake = makeFakeAttention();
-      const ctx = { attention: fake.api } satisfies AmbientUiContext;
+      const ctx = { attention: fake.api, amenities: noAmenities } satisfies AmbientUiContext;
 
       container = document.createElement("div");
       document.body.appendChild(container);
@@ -109,7 +112,7 @@ describe("Aura component", () => {
 
   it("renders overlay div when target snapshot is published", async () => {
     const fake = makeFakeAttention();
-    const ctx = { attention: fake.api } satisfies AmbientUiContext;
+    const ctx = { attention: fake.api, amenities: noAmenities } satisfies AmbientUiContext;
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -137,7 +140,7 @@ describe("Aura component", () => {
 
   it("dispose unmounts the React root cleanly", () => {
     const fake = makeFakeAttention({ target: sampleTarget });
-    const ctx = { attention: fake.api } satisfies AmbientUiContext;
+    const ctx = { attention: fake.api, amenities: noAmenities } satisfies AmbientUiContext;
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -169,7 +172,7 @@ describe("Aura component", () => {
     vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
 
     const fake = makeFakeAttention({ target: sampleTarget });
-    const ctx = { attention: fake.api } satisfies AmbientUiContext;
+    const ctx = { attention: fake.api, amenities: noAmenities } satisfies AmbientUiContext;
 
     container = document.createElement("div");
     document.body.appendChild(container);

--- a/bundled-packs/ambient-ui/pomodoro-ui/README.md
+++ b/bundled-packs/ambient-ui/pomodoro-ui/README.md
@@ -24,7 +24,8 @@ amenity → persona の正規 pattern」）。
 - mount 時に渡される public `AmbientUiContext.amenities` から `get("pomodoro")` で
   opt-in service handle を取得する。internal registry や global singleton は import しない。
 - 1 秒ごとに `service.getState()` を poll し、返ってきた `phase` / `round` /
-  `totalRounds` / `remainingMs` を表示に反映する。
+  `totalRounds` / `remainingMs` を runtime で検証してから表示に反映する。これは
+  pomodoro pack version 0.1.0 固有 contract の consumer であり、汎用 SDK shape ではない。
 - `phase === "idle"` の間は何も描画しない（`null` を返す）。
 - 表示は phase 色つきの dot、`WORK` / `BREAK` / `LONG BREAK` ラベル、`mm:ss` 形式の残り時間、
   `round/totalRounds` のカウンタ。

--- a/bundled-packs/ambient-ui/pomodoro-ui/README.md
+++ b/bundled-packs/ambient-ui/pomodoro-ui/README.md
@@ -21,15 +21,15 @@ amenity → persona の正規 pattern」）。
 
 ## state 連携
 
-- `getAmenityPackRegistry()` singleton から `getActiveHandle("pomodoro")` で pomodoro amenity の
-  handle を取得する。
-- 1 秒ごとに `handle.tools.pomodoro_status({})` を poll し、返ってきた `phase` / `round` /
+- mount 時に渡される public `AmbientUiContext.amenities` から `get("pomodoro")` で
+  opt-in service handle を取得する。internal registry や global singleton は import しない。
+- 1 秒ごとに `service.getState()` を poll し、返ってきた `phase` / `round` /
   `totalRounds` / `remainingMs` を表示に反映する。
 - `phase === "idle"` の間は何も描画しない（`null` を返す）。
 - 表示は phase 色つきの dot、`WORK` / `BREAK` / `LONG BREAK` ラベル、`mm:ss` 形式の残り時間、
   `round/totalRounds` のカウンタ。
-- **Stop ボタン**は `handle.tools.pomodoro_stop({})` を呼んでセッションを停止する。これは MCP tool
-  （住人 AI 用）と対称に、user に同じ操作を開いた経路。
+- **Stop ボタン**は UI 用に明示公開された `service.execute("stop")` を呼ぶ。MCP tool handle は
+  Ambient UI に公開されず、開始・状態取得を含む tool namespace 全体への権限拡大を避ける。
 
 ## 編集について
 

--- a/bundled-packs/ambient-ui/pomodoro-ui/ui.test.ts
+++ b/bundled-packs/ambient-ui/pomodoro-ui/ui.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import type { AmenityServiceHandle, AmenityServicesAPI } from "@yorishiro/sdk";
+import React, { act } from "react";
+import ReactDOM from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PomodoroUi } from "./ui";
+
+describe("PomodoroUi", () => {
+  let container: HTMLDivElement | null = null;
+  let root: ReactDOM.Root | null = null;
+
+  afterEach(() => {
+    if (root !== null) {
+      act(() => root?.unmount());
+      root = null;
+    }
+    container?.remove();
+    container = null;
+  });
+
+  async function render(amenities: AmenityServicesAPI): Promise<void> {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = ReactDOM.createRoot(container);
+    await act(async () => {
+      root?.render(React.createElement(PomodoroUi, { amenities }));
+    });
+  }
+
+  it("reads pomodoro state through the public amenity service", async () => {
+    const service: AmenityServiceHandle = {
+      getState: vi.fn(async () => ({
+        phase: "work",
+        round: 1,
+        totalRounds: 4,
+        remainingMs: 65_000,
+      })),
+      execute: vi.fn(),
+    };
+    await render({ get: (id) => (id === "pomodoro" ? service : null) });
+
+    expect(container?.textContent).toContain("WORK");
+    expect(container?.textContent).toContain("01:05");
+    expect(container?.textContent).toContain("1/4");
+    expect(service.getState).toHaveBeenCalledTimes(1);
+  });
+
+  it("executes only the public stop command and hides the timer", async () => {
+    const service: AmenityServiceHandle = {
+      getState: async () => ({
+        phase: "short-break",
+        round: 2,
+        totalRounds: 4,
+        remainingMs: 30_000,
+      }),
+      execute: vi.fn(async () => ({ cancelled: true })),
+    };
+    await render({ get: () => service });
+    const stop = container?.querySelector("button");
+
+    expect(stop?.textContent).toBe("Stop");
+    await act(async () => {
+      stop?.click();
+    });
+
+    expect(service.execute).toHaveBeenCalledWith("stop");
+    expect(container?.querySelector("button")).toBeNull();
+  });
+
+  it("renders nothing when the amenity service is unavailable", async () => {
+    await render({ get: () => null });
+
+    expect(container?.children).toHaveLength(0);
+  });
+
+  it("does not trust an invalid service state shape", async () => {
+    await render({
+      get: () => ({
+        getState: async () => ({ phase: "danger", remainingMs: "forever" }),
+        execute: vi.fn(),
+      }),
+    });
+
+    expect(container?.children).toHaveLength(0);
+  });
+});

--- a/bundled-packs/ambient-ui/pomodoro-ui/ui.tsx
+++ b/bundled-packs/ambient-ui/pomodoro-ui/ui.tsx
@@ -2,14 +2,18 @@
  * Pomodoro Timer ambient-ui — 画面右下に残り時間と操作ボタンを表示する。
  *
  * user が直接ポモドーロを操作する経路。MCP tool（住人用）と対称。
- * AmenityPackRegistry singleton から pomodoro handle の tools を呼ぶ。
+ * AmbientUiContext の public amenity service から state / command を使う。
  */
 
-import type { AmbientUiContext, AmbientUiPackDefinition, Disposable } from "@yorishiro/sdk";
+import type {
+  AmbientUiContext,
+  AmbientUiPackDefinition,
+  AmenityServicesAPI,
+  Disposable,
+} from "@yorishiro/sdk";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
-import { getAmenityPackRegistry } from "../../../src/runtime/amenity-pack-registry";
 
 // ─── Types ───────────────────────────────────────────────
 
@@ -64,23 +68,55 @@ function phaseColor(phase: Phase): string {
   }
 }
 
+function parseStatus(value: unknown): PomodoroStatus | null {
+  if (value === null || typeof value !== "object") return null;
+  const candidate = value as Record<string, unknown>;
+  if (
+    candidate.phase !== "idle" &&
+    candidate.phase !== "work" &&
+    candidate.phase !== "short-break" &&
+    candidate.phase !== "long-break"
+  ) {
+    return null;
+  }
+  if (
+    typeof candidate.round !== "number" ||
+    typeof candidate.totalRounds !== "number" ||
+    typeof candidate.remainingMs !== "number"
+  ) {
+    return null;
+  }
+  return {
+    phase: candidate.phase,
+    round: candidate.round,
+    totalRounds: candidate.totalRounds,
+    remainingMs: candidate.remainingMs,
+  };
+}
+
 // ─── Component ───────────────────────────────────────────
 
-function PomodoroUi(): React.JSX.Element | null {
+export function PomodoroUi({
+  amenities,
+}: {
+  amenities: AmenityServicesAPI;
+}): React.JSX.Element | null {
   const [status, setStatus] = useState<PomodoroStatus>(IDLE_STATUS);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const poll = useCallback(async () => {
-    const registry = getAmenityPackRegistry();
-    const handle = registry.getActiveHandle("pomodoro");
-    if (!handle) return;
+    const service = amenities.get("pomodoro");
+    if (service === null) {
+      setStatus(IDLE_STATUS);
+      return;
+    }
     try {
-      const result = (await handle.tools.pomodoro_status({})) as PomodoroStatus;
-      setStatus(result);
+      const result = parseStatus(await service.getState());
+      if (result !== null) setStatus(result);
     } catch {
       /* ignore */
     }
-  }, []);
+  }, [amenities]);
 
   useEffect(() => {
     poll();
@@ -91,12 +127,11 @@ function PomodoroUi(): React.JSX.Element | null {
   }, [poll]);
 
   const handleStop = useCallback(async () => {
-    const registry = getAmenityPackRegistry();
-    const handle = registry.getActiveHandle("pomodoro");
-    if (!handle) return;
-    await handle.tools.pomodoro_stop({});
+    const service = amenities.get("pomodoro");
+    if (service === null) return;
+    await service.execute("stop");
     setStatus(IDLE_STATUS);
-  }, []);
+  }, [amenities]);
 
   if (status.phase === "idle") return null;
 
@@ -164,9 +199,9 @@ function PomodoroUi(): React.JSX.Element | null {
 const pomodoroUiPack = {
   type: "ambient-ui",
   id: "pomodoro-ui",
-  mount: (_ctx: AmbientUiContext, container: HTMLDivElement): Disposable => {
+  mount: (ctx: AmbientUiContext, container: HTMLDivElement): Disposable => {
     const root = ReactDOM.createRoot(container);
-    root.render(<PomodoroUi />);
+    root.render(<PomodoroUi amenities={ctx.amenities} />);
     return {
       dispose: () => queueMicrotask(() => root.unmount()),
     };

--- a/bundled-packs/amenities/pomodoro/README.md
+++ b/bundled-packs/amenities/pomodoro/README.md
@@ -16,6 +16,13 @@ state machine（`idle → work → short-break → work → ... → long-break �
 default は work 25 分 / short break 5 分 / long break 15 分 / 4 rounds。
 最終 round の break が long break になり、終了で `idle` に戻る。
 
+## Ambient UI 向け public service
+
+`AmenityHandle.service` に timer state の `getState()` と `execute("stop")` だけを公開する。
+これは `AmbientUiContext.amenities` 経由で pomodoro-ui が使う opt-in surface であり、MCP tool
+handler や amenity registry は渡さない。`pomodoro_start` は UI service command としては公開せず、
+未知の command は reject する。
+
 ## emit する event
 
 フェーズ遷移ごとに synthetic event を emit する（trigger match 経由で persona reflex が反応する）。

--- a/bundled-packs/amenities/pomodoro/README.md
+++ b/bundled-packs/amenities/pomodoro/README.md
@@ -23,6 +23,27 @@ default は work 25 分 / short break 5 分 / long break 15 分 / 4 rounds。
 handler や amenity registry は渡さない。`pomodoro_start` は UI service command としては公開せず、
 未知の command は reject する。
 
+### Pomodoro service contract（version 0.1.0）
+
+この shape は汎用 SDK contract ではなく、pomodoro pack 固有の versioned contract。
+
+`getState()` は次を返す：
+
+| field | type | 説明 |
+|---|---|---|
+| `phase` | `"idle" \| "work" \| "short-break" \| "long-break"` | 現在の phase |
+| `round` | `number` | 現在の round。idle は `0` |
+| `totalRounds` | `number` | 設定 round 数。idle は `0` |
+| `remainingMs` | `number` | phase の残り時間（ms、0以上） |
+| `config.workMs` | `number` | work duration（ms） |
+| `config.shortBreakMs` | `number` | short break duration（ms） |
+| `config.longBreakMs` | `number` | long break duration（ms） |
+| `config.rounds` | `number` | session の総 round 数 |
+
+`execute("stop")` は params を必要とせず、`{ cancelled, phase, round }` を返す。
+進行中なら `cancelled: true` と停止前の phase / round、idle なら
+`{ cancelled: false, phase: "idle", round: 0 }`。`"stop"` 以外は reject する。
+
 ## emit する event
 
 フェーズ遷移ごとに synthetic event を emit する（trigger match 経由で persona reflex が反応する）。

--- a/bundled-packs/amenities/pomodoro/amenity.ts
+++ b/bundled-packs/amenities/pomodoro/amenity.ts
@@ -239,6 +239,13 @@ export function createPomodoroAmenity(ctx: PomodoroActivateContext): AmenityHand
       pomodoro_stop: async () => timer.stop(),
       pomodoro_status: async () => timer.status(),
     },
+    service: {
+      getState: async () => timer.status(),
+      execute: async (command) => {
+        if (command === "stop") return timer.stop();
+        throw new Error(`unknown pomodoro service command '${command}'`);
+      },
+    },
     dispose: () => timer.dispose(),
   };
 }

--- a/bundled-packs/scenes/abandoned-factory/lib/atmosphere.tsx
+++ b/bundled-packs/scenes/abandoned-factory/lib/atmosphere.tsx
@@ -4,11 +4,10 @@
  * SDK controls で sizeMult / alpha / dust speed / godRays alpha をリアルタイム調整可能.
  */
 
-import { controlFolder, useYorishiroControls } from "@yorishiro/sdk/controls";
+import { controlFolder, useControlsBridge, useYorishiroControls } from "@yorishiro/sdk/controls";
 import { useFrame } from "@yorishiro/sdk/r3f";
 import { useMemo, useRef } from "react";
 import * as THREE from "three";
-import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
 import { PALETTE } from "./palette";
 
 /* ---- 決定論的 LCG 乱数 ---- */

--- a/bundled-packs/scenes/abandoned-factory/lib/camera-rig.tsx
+++ b/bundled-packs/scenes/abandoned-factory/lib/camera-rig.tsx
@@ -8,11 +8,10 @@
  * SDK controls で振幅を runtime 調整可能.
  */
 
-import { controlFolder, useYorishiroControls } from "@yorishiro/sdk/controls";
+import { controlFolder, useControlsBridge, useYorishiroControls } from "@yorishiro/sdk/controls";
 import { useFrame } from "@yorishiro/sdk/r3f";
 import { useRef } from "react";
 import * as THREE from "three";
-import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
 
 export function CameraRig(): null {
   const baseFovRef = useRef<number | null>(null);

--- a/bundled-packs/scenes/abandoned-factory/lib/lights.tsx
+++ b/bundled-packs/scenes/abandoned-factory/lib/lights.tsx
@@ -7,11 +7,10 @@
  * Spec §7.1–§7.4.
  */
 
-import { useYorishiroControls } from "@yorishiro/sdk/controls";
+import { useControlsBridge, useYorishiroControls } from "@yorishiro/sdk/controls";
 import { useFrame } from "@yorishiro/sdk/r3f";
 import { useRef } from "react";
 import type * as THREE from "three";
-import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
 import { computeCrtFlicker, computeLanternFlicker, type FlickerParams } from "./flicker";
 import { PALETTE } from "./palette";
 

--- a/bundled-packs/scenes/abandoned-factory/lib/post-process.tsx
+++ b/bundled-packs/scenes/abandoned-factory/lib/post-process.tsx
@@ -20,7 +20,7 @@ import {
   ToneMapping,
   Vignette,
 } from "@react-three/postprocessing";
-import { controlFolder, useYorishiroControls } from "@yorishiro/sdk/controls";
+import { controlFolder, useControlsBridge, useYorishiroControls } from "@yorishiro/sdk/controls";
 import { useFrame } from "@yorishiro/sdk/r3f";
 import {
   BlendFunction,
@@ -33,7 +33,6 @@ import {
 } from "postprocessing";
 import { useContext, useEffect, useMemo, useRef } from "react";
 import { Uniform, Vector2 } from "three";
-import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
 import {
   createGlitchState,
   DEFAULT_GLITCH_PARAMS,

--- a/bundled-packs/scenes/abandoned-factory/scene.tsx
+++ b/bundled-packs/scenes/abandoned-factory/scene.tsx
@@ -10,10 +10,9 @@
  * - specs/2026-05-03-scene-pack-r3f-component.md
  */
 
-import { controlFolder, useYorishiroControls } from "@yorishiro/sdk/controls";
+import { controlFolder, useControlsBridge, useYorishiroControls } from "@yorishiro/sdk/controls";
 import type { ScenePackComponentProps, ScenePackDefinition } from "@yorishiro/sdk/scene-pack";
 import { AttentionCueLight } from "../../../src/runtime/three-runtime/attention-cue-light";
-import { useControlsBridge } from "../../../src/runtime/ui-state-store";
 import { DustMotes } from "./lib/atmosphere";
 import { CameraBreath } from "./lib/camera-breath";
 import { Ceiling } from "./lib/ceiling";

--- a/bundled-packs/scenes/abandoned-factory/scene.tsx
+++ b/bundled-packs/scenes/abandoned-factory/scene.tsx
@@ -10,9 +10,9 @@
  * - specs/2026-05-03-scene-pack-r3f-component.md
  */
 
+import { AttentionCueLight } from "@yorishiro/sdk/attention-cue";
 import { controlFolder, useControlsBridge, useYorishiroControls } from "@yorishiro/sdk/controls";
 import type { ScenePackComponentProps, ScenePackDefinition } from "@yorishiro/sdk/scene-pack";
-import { AttentionCueLight } from "../../../src/runtime/three-runtime/attention-cue-light";
 import { DustMotes } from "./lib/atmosphere";
 import { CameraBreath } from "./lib/camera-breath";
 import { Ceiling } from "./lib/ceiling";

--- a/bundled-packs/scenes/misty-grasslands/lib/lights.tsx
+++ b/bundled-packs/scenes/misty-grasslands/lib/lights.tsx
@@ -5,8 +5,7 @@
  * SDK controls で intensity / color を調整可能.
  */
 
-import { useYorishiroControls } from "@yorishiro/sdk/controls";
-import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
+import { useControlsBridge, useYorishiroControls } from "@yorishiro/sdk/controls";
 
 export function Lights() {
   const [controls, setControls] = useYorishiroControls("lights", () => ({

--- a/bundled-packs/scenes/misty-grasslands/scene.tsx
+++ b/bundled-packs/scenes/misty-grasslands/scene.tsx
@@ -12,8 +12,8 @@
  * Internal design-record: 2026-04-29-misty-grasslands-mirror-redesign.md
  */
 
+import { AttentionCueLight } from "@yorishiro/sdk/attention-cue";
 import type { ScenePackComponentProps, ScenePackDefinition } from "@yorishiro/sdk/scene-pack";
-import { AttentionCueLight } from "../../../src/runtime/three-runtime/attention-cue-light";
 import { Lights } from "./lib/lights";
 
 // overcast morning の明るい拡散光（directional 1.5 + ambient 0.47）に対して

--- a/bundled-packs/scenes/simple-room/lib/lights.tsx
+++ b/bundled-packs/scenes/simple-room/lib/lights.tsx
@@ -6,11 +6,10 @@
  * 値は simple-room (Night) に合わせた。SDK controls で intensity / color / 位置等を調整可能。
  */
 
-import { useYorishiroControls } from "@yorishiro/sdk/controls";
+import { useControlsBridge, useYorishiroControls } from "@yorishiro/sdk/controls";
 import { useFrame } from "@yorishiro/sdk/r3f";
 import { useRef } from "react";
 import type { SpotLight as ThreeSpotLight } from "three";
-import { useControlsBridge } from "../../../../src/runtime/ui-state-store";
 
 export function Lights() {
   const lightRef = useRef<ThreeSpotLight>(null);

--- a/bundled-packs/scenes/simple-room/scene.tsx
+++ b/bundled-packs/scenes/simple-room/scene.tsx
@@ -10,8 +10,8 @@
  * Internal design-record: specs/2026-04-18-scene-pack-compositor-design.md §2.3
  */
 
+import { AttentionCueLight } from "@yorishiro/sdk/attention-cue";
 import type { ScenePackComponentProps, ScenePackDefinition } from "@yorishiro/sdk/scene-pack";
-import { AttentionCueLight } from "../../../src/runtime/three-runtime/attention-cue-light";
 import { Lights } from "./lib/lights";
 
 function SimpleRoomScene({ vrmSlot }: ScenePackComponentProps) {

--- a/bundled-packs/ui/yorishiro-settings/README.md
+++ b/bundled-packs/ui/yorishiro-settings/README.md
@@ -20,17 +20,24 @@ Yorishiro の設定画面。`activeUi` を `"yorishiro-settings"` に一時 swap
 
 ## Fork
 
-`~/.yorishiro/packs/yorishiro-settings/` 配下に同 id の pack を置けば、bundled を override する形で改変可能。`feedback_pack_override_pattern` 参照。
+`~/.yorishiro/packs/yorishiro-settings/` 配下に同 id の pack を置けば、bundled を override する形で改変可能。ただし id は capability token ではなく、user fork は bundled source の system authority を継承しない。通常 UI Pack と同じく supported authoring surface は `@yorishiro/sdk` と明示された host shim に限られる。`docs/decisions/pack-override-pattern.md` と `docs/decisions/system-settings-privileged-boundary.md` を参照。
 
 ## Known limitations (user fork)
 
-このバージョンは bundled として動くことを前提に書かれており、`~/.yorishiro/packs/` に置く user fork で完全再現するには SDK 拡張が必要です。具体的には：
+このバージョンは app と同じ release/review 単位の system-owned bundled UI として動く。`~/.yorishiro/packs/` に置く user fork で完全再現する契約ではない。
+
+汎用性と安全性が明白な機能は public capability を使う：
 
 - ショートカット pre-fill は `ctx.app.insertFixedPrompt("shortcut")`（host 所有の固定プロンプトを key で指す SDK verb）経由。pack は文字列を渡さず、`src/bindings/tauri-commands` の直 import は持たない。任意テキストを terminal に書く API は意図的に存在しない（設計境界: `docs/decisions/input-prefill-boundary.md`）
-- VRM file picker (`@tauri-apps/plugin-dialog` + `import_vrm`) を bundled で直接呼んでいる
-- `localStorage["yorishiro:vrm"]` の magic string を直接読んでいる
+- app version は `ctx.app.getVersion()`、HTTPS link は `ctx.app.openExternal()`、snapshot 操作は確認 UX を host が所有する `ctx.history` を使う
 
-VRM picker / localStorage 系は将来 SDK 側で `UiAppAPI.pickVrm()`, `getVrm()` を追加することで user fork でも完全再現可能になります（spec § 8 の将来課題参照）。terminal 入力については `insertFixedPrompt` の固定 key 集合が SDK 公開面であり、任意書き込み口は追加しない方針（`input-prefill-boundary.md`）。
+一方、以下は監査済み bundled exception のまま残す：
+
+- VRM file picker (`@tauri-apps/plugin-dialog` + `import_vrm`)
+- `localStorage["yorishiro:vrm"]` の magic string を直接読んでいる
+- updater / process relaunch、app 固有 i18n、snapshot 表示 helper、language/config policy helper、app component、bundled default scene manifest
+
+これらを user Pack に公開するには permission declaration、host-side gate、approval UX の設計が必要。今回 raw Tauri passthrough は追加しない。terminal 入力については `insertFixedPrompt` の固定 key 集合が SDK 公開面であり、任意書き込み口は追加しない方針（`input-prefill-boundary.md`）。
 
 ## 関連 doc
 

--- a/bundled-packs/ui/yorishiro-settings/README.md
+++ b/bundled-packs/ui/yorishiro-settings/README.md
@@ -29,13 +29,13 @@ Yorishiro の設定画面。`activeUi` を `"yorishiro-settings"` に一時 swap
 汎用性と安全性が明白な機能は public capability を使う：
 
 - ショートカット pre-fill は `ctx.app.insertFixedPrompt("shortcut")`（host 所有の固定プロンプトを key で指す SDK verb）経由。pack は文字列を渡さず、`src/bindings/tauri-commands` の直 import は持たない。任意テキストを terminal に書く API は意図的に存在しない（設計境界: `docs/decisions/input-prefill-boundary.md`）
-- app version は `ctx.app.getVersion()`、HTTPS link は `ctx.app.openExternal()`、snapshot 操作は確認 UX を host が所有する `ctx.history` を使う
+- app version は `ctx.app.getVersion()`、HTTPS link は `ctx.app.openExternal()`、snapshot 操作は確認 component と destructive command を host が所有する `ctx.history` を使う
 
 一方、以下は監査済み bundled exception のまま残す：
 
 - VRM file picker (`@tauri-apps/plugin-dialog` + `import_vrm`)
 - `localStorage["yorishiro:vrm"]` の magic string を直接読んでいる
-- updater / process relaunch、app 固有 i18n、snapshot 表示 helper、language/config policy helper、app component、bundled default scene manifest
+- updater / process relaunch、app 固有 i18n、snapshot 表示 helper、language/config policy helper、bundled default scene manifest
 
 これらを user Pack に公開するには permission declaration、host-side gate、approval UX の設計が必要。今回 raw Tauri passthrough は追加しない。terminal 入力については `insertFixedPrompt` の固定 key 集合が SDK 公開面であり、任意書き込み口は追加しない方針（`input-prefill-boundary.md`）。
 

--- a/bundled-packs/ui/yorishiro-settings/manifest.json
+++ b/bundled-packs/ui/yorishiro-settings/manifest.json
@@ -3,6 +3,7 @@
   "id": "yorishiro-settings",
   "name": "Yorishiro Settings",
   "type": "ui",
+  "executionClass": "trusted-main-thread-js",
   "version": "0.1.0",
   "yorishiroVersion": "^0.1.0",
   "author": "Yorishiro team",

--- a/bundled-packs/ui/yorishiro-settings/ui.tsx
+++ b/bundled-packs/ui/yorishiro-settings/ui.tsx
@@ -8,14 +8,13 @@
  * Internal design-record: specs/2026-04-25-settings-screen-design.md
  */
 
-import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
-import { openUrl } from "@tauri-apps/plugin-opener";
 import type {
   AppLanguage,
   Disposable,
   FixedTerminalPromptKey,
   ResolvedLanguage,
+  SnapshotEntry,
   UiAppPackDiagnoseResponse,
   UiAppPackStatusEntry,
   UiContext,
@@ -37,14 +36,7 @@ import {
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
-import { snapshotList, snapshotRestore } from "../../../src/bindings/tauri-commands";
-import { RestoreConfirmDialog } from "../../../src/components/RestoreConfirmDialog";
-import {
-  changeStrings,
-  getStrings,
-  restoreConfirmStrings,
-  type UiStrings,
-} from "../../../src/i18n/strings";
+import { changeStrings, getStrings, type UiStrings } from "../../../src/i18n/strings";
 import { buildRestoreRows } from "../../../src/runtime/history/describe-snapshot";
 import { getBrowserLocales, resolveLanguage } from "../../../src/runtime/language/language";
 import { type AvailableUpdate, checkForUpdate } from "../../../src/runtime/updater/app-updater";
@@ -52,7 +44,6 @@ import {
   isBundledYoriPersonaId,
   localizedYoriPersonaId,
 } from "../../../src/runtime/user-pack-loader/config";
-import type { SnapshotEntry } from "../../../src/sdk/history";
 import simpleRoomManifest from "../../scenes/simple-room/manifest.json";
 import { COLORS, FONT, RADIUS, SPACING } from "./tokens";
 
@@ -77,12 +68,6 @@ const QUICK_ACTION_KEYS: ReadonlyArray<{
   { key: "create-pack", stringKey: "quickCreatePack" },
   { key: "pomodoro", stringKey: "quickPomodoro" },
 ];
-
-interface RestoreDialogTarget {
-  readonly seq: number;
-  readonly changeText: string;
-  readonly timeText: string;
-}
 
 export interface ResolveCloseTargetArgs {
   readonly saved: string | null;
@@ -1161,24 +1146,39 @@ function HealthDiagnostics({
  * 確認 → restore → reload で config/init.js も再適用する。
  */
 function SnapshotRestoreSection({
+  ctx,
   locale,
   strings,
 }: {
+  ctx: UiContext;
   locale: ResolvedLanguage;
   strings: UiStrings;
 }): React.JSX.Element {
   const [open, setOpen] = useState(false);
   const [snapshots, setSnapshots] = useState<ReadonlyArray<SnapshotEntry> | null>(null);
   const [loading, setLoading] = useState(false);
-  const [restoreTarget, setRestoreTarget] = useState<RestoreDialogTarget | null>(null);
+  const [restorePending, setRestorePending] = useState(false);
 
   const refresh = useCallback(() => {
     setLoading(true);
-    snapshotList()
+    ctx.history
+      .list()
       .then((next) => setSnapshots(next))
       .catch(() => setSnapshots([]))
       .finally(() => setLoading(false));
-  }, []);
+  }, [ctx.history]);
+
+  const restore = useCallback(
+    async (seq: number) => {
+      setRestorePending(true);
+      try {
+        await ctx.history.restore(seq);
+      } finally {
+        setRestorePending(false);
+      }
+    },
+    [ctx.history],
+  );
 
   useEffect(() => {
     if (open && snapshots === null) refresh();
@@ -1257,14 +1257,8 @@ function SnapshotRestoreSection({
         {row.isLatest ? null : (
           <button
             type="button"
-            disabled={restoreTarget !== null}
-            onClick={() =>
-              setRestoreTarget({
-                seq: row.seq,
-                changeText: row.changeText,
-                timeText: row.timeText,
-              })
-            }
+            disabled={restorePending}
+            onClick={() => void restore(row.seq)}
             style={{
               flexShrink: 0,
               border: `1px solid ${COLORS.borderSubtle}`,
@@ -1274,8 +1268,8 @@ function SnapshotRestoreSection({
               font: "inherit",
               fontSize: FONT.sizeXs,
               padding: `${SPACING.xs} ${SPACING.sm}`,
-              cursor: restoreTarget ? "default" : "pointer",
-              opacity: restoreTarget ? 0.5 : 1,
+              cursor: restorePending ? "default" : "pointer",
+              opacity: restorePending ? 0.5 : 1,
             }}
           >
             {strings.restoreButton}
@@ -1370,17 +1364,6 @@ function SnapshotRestoreSection({
           </div>
         </>
       )}
-      {restoreTarget ? (
-        <RestoreConfirmDialog
-          seq={restoreTarget.seq}
-          changeText={restoreTarget.changeText}
-          timeText={restoreTarget.timeText}
-          surface="themed"
-          strings={restoreConfirmStrings(strings)}
-          onClose={() => setRestoreTarget(null)}
-          onConfirm={() => snapshotRestore({ seq: restoreTarget.seq })}
-        />
-      ) : null}
     </section>
   );
 }
@@ -1910,12 +1893,19 @@ const CREDITS_RISE_KEYFRAMES = `
  * 版面で「ちゃんと手入れされている」ことを伝える（presence over spectacle）。
  * 読み込み時に section を控えめに rise させる以上の演出はしない。
  */
-function CreditsOverlay({ onBack }: { onBack: () => void }): React.JSX.Element {
+function CreditsOverlay({
+  ctx,
+  onBack,
+}: {
+  ctx: UiContext;
+  onBack: () => void;
+}): React.JSX.Element {
   const [version, setVersion] = useState<string>("");
 
   useEffect(() => {
     let active = true;
-    getVersion()
+    ctx.app
+      .getVersion()
       .then((v) => {
         if (active) setVersion(v);
       })
@@ -1925,7 +1915,7 @@ function CreditsOverlay({ onBack }: { onBack: () => void }): React.JSX.Element {
     return () => {
       active = false;
     };
-  }, []);
+  }, [ctx.app]);
 
   const sections = creditsSections();
 
@@ -2035,7 +2025,7 @@ function CreditsOverlay({ onBack }: { onBack: () => void }): React.JSX.Element {
             <button
               type="button"
               onClick={() => {
-                void openUrl(YORISHIRO_REPO_URL);
+                void ctx.app.openExternal(YORISHIRO_REPO_URL);
               }}
               style={{
                 background: "none",
@@ -2131,7 +2121,7 @@ function CreditsOverlay({ onBack }: { onBack: () => void }): React.JSX.Element {
           <button
             type="button"
             onClick={() => {
-              void openUrl(YORISHIRO_CREDITS_URL);
+              void ctx.app.openExternal(YORISHIRO_CREDITS_URL);
             }}
             style={{
               background: "none",
@@ -2938,7 +2928,7 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
         {/* 32px gap */}
         <div style={{ height: "32px" }} />
 
-        <SnapshotRestoreSection locale={resolvedLanguage} strings={strings} />
+        <SnapshotRestoreSection ctx={ctx} locale={resolvedLanguage} strings={strings} />
 
         {/* 32px gap */}
         <div style={{ height: "32px" }} />
@@ -2946,7 +2936,7 @@ function Panel({ ctx }: { ctx: UiContext }): React.JSX.Element {
         <PackWorkbench ctx={ctx} strings={strings} onClose={fireCloseRequest} />
       </main>
 
-      {creditsOpen && <CreditsOverlay onBack={() => setCreditsOpen(false)} />}
+      {creditsOpen && <CreditsOverlay ctx={ctx} onBack={() => setCreditsOpen(false)} />}
       {newSessionConfirmContent ? (
         <NewSessionConfirmDialog
           message={newSessionConfirmContent.message}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 | TypeScript 側のどこに何があるか知りたい | [`../src/README.md`](../src/README.md) |
 | Rust 側のどこに何があるか知りたい | [`../src-tauri/README.md`](../src-tauri/README.md) |
 | Pack を書きたい | [`../src/sdk/README.md`](../src/sdk/README.md) |
+| Local TSX Packで使えるimport・asset・version制約を確認したい | [`decisions/local-source-authoring-contract.md`](decisions/local-source-authoring-contract.md) |
 | GitHub 等で共有された pack を手動導入したい | [`decisions/scene-execution-sandbox.md`](decisions/scene-execution-sandbox.md) |
 | 標準 hook / DispatchEvent の語彙を確認したい | [`catalogs/standard-hooks.md`](catalogs/standard-hooks.md) |
 | 過去に「なぜそう決めたか」を引きたい | [`decisions/README.md`](decisions/README.md) |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -87,6 +87,8 @@
 - [**single-active-config-picks.md**](single-active-config-picks.md) — single-active な pack は config で user picks、pack 自薦の `defaultActive` は持たせない
 - [**user-pack-layout.md**](user-pack-layout.md) — userはflat layout（通常`.js`、一部`.tsx`）、bundledはkind-first。意図的に非対称
 - [**local-source-authoring-contract.md**](local-source-authoring-contract.md) — bundled Vite buildとlocal runtime source compilerの対応範囲（entry/source extension、host module、asset/JSON/raw、Pack containment、diagnostics、version policy）
+- [**pack-authoring-capability-parity.md**](pack-authoring-capability-parity.md) — bundled referenceが正式利用する表現能力は原則local user Packにもsemanticなpublic APIで提供する。内部module parityではなく、third-party bridge / host-owned API / system exception / not-yet-demandedで分類
+- [**ambient-ui-amenity-service-boundary.md**](ambient-ui-amenity-service-boundary.md) — Ambient UIからAmenityへはopt-in serviceだけを公開。stable共通面は`get(id)` / `getState()` / `execute()` / lifecycle失効に限定し、個別state・commandは各Amenityが所有
 - [**system-settings-privileged-boundary.md**](system-settings-privileged-boundary.md) — `yorishiro-settings` は system-owned bundled UI。監査済み internal/Tauri import だけを例外とし、通常 UI Pack は SDK surface に限定
 - [**scene-controls-api.md**](scene-controls-api.md) — Scene Pack の lighting / post effect / camera modulation は `useYorishiroControls`（`@yorishiro/sdk/controls`）経由で Scene panel に登録、base camera は Common panel。F2 は Common / Scene の 2 枚。Leva は adapter / debug UI に留める
 - [**scene-layer-override-semantics.md**](scene-layer-override-semantics.md) — Scene が layer 構造を握る、override は既存 layer への patch のみ（auto-create 廃止）。scene 切替で override は clear（共通管理 Camera のみ持ち越し）

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -85,7 +85,8 @@
 - [**pack-override-pattern.md**](pack-override-pattern.md) — user pack が bundled を override する semantic（dispose + 置換、reference 比較で listener fire）
 - [**bundled-pack-immutability.md**](bundled-pack-immutability.md) — bundled は本体の一部、全経路で編集不可、改変は user fork で
 - [**single-active-config-picks.md**](single-active-config-picks.md) — single-active な pack は config で user picks、pack 自薦の `defaultActive` は持たせない
-- [**user-pack-layout.md**](user-pack-layout.md) — user は flat layout (.js)、bundled は kind-first (.ts)、意図的に非対称
+- [**user-pack-layout.md**](user-pack-layout.md) — userはflat layout（通常`.js`、一部`.tsx`）、bundledはkind-first。意図的に非対称
+- [**local-source-authoring-contract.md**](local-source-authoring-contract.md) — bundled Vite buildとlocal runtime source compilerの対応範囲（entry/source extension、host module、asset/JSON/raw、Pack containment、diagnostics、version policy）
 - [**system-settings-privileged-boundary.md**](system-settings-privileged-boundary.md) — `yorishiro-settings` は system-owned bundled UI。監査済み internal/Tauri import だけを例外とし、通常 UI Pack は SDK surface に限定
 - [**scene-controls-api.md**](scene-controls-api.md) — Scene Pack の lighting / post effect / camera modulation は `useYorishiroControls`（`@yorishiro/sdk/controls`）経由で Scene panel に登録、base camera は Common panel。F2 は Common / Scene の 2 枚。Leva は adapter / debug UI に留める
 - [**scene-layer-override-semantics.md**](scene-layer-override-semantics.md) — Scene が layer 構造を握る、override は既存 layer への patch のみ（auto-create 廃止）。scene 切替で override は clear（共通管理 Camera のみ持ち越し）

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -86,12 +86,13 @@
 - [**bundled-pack-immutability.md**](bundled-pack-immutability.md) — bundled は本体の一部、全経路で編集不可、改変は user fork で
 - [**single-active-config-picks.md**](single-active-config-picks.md) — single-active な pack は config で user picks、pack 自薦の `defaultActive` は持たせない
 - [**user-pack-layout.md**](user-pack-layout.md) — user は flat layout (.js)、bundled は kind-first (.ts)、意図的に非対称
+- [**system-settings-privileged-boundary.md**](system-settings-privileged-boundary.md) — `yorishiro-settings` は system-owned bundled UI。監査済み internal/Tauri import だけを例外とし、通常 UI Pack は SDK surface に限定
 - [**scene-controls-api.md**](scene-controls-api.md) — Scene Pack の lighting / post effect / camera modulation は `useYorishiroControls`（`@yorishiro/sdk/controls`）経由で Scene panel に登録、base camera は Common panel。F2 は Common / Scene の 2 枚。Leva は adapter / debug UI に留める
 - [**scene-layer-override-semantics.md**](scene-layer-override-semantics.md) — Scene が layer 構造を握る、override は既存 layer への patch のみ（auto-create 廃止）。scene 切替で override は clear（共通管理 Camera のみ持ち越し）
 - [**user-init-script-seed.md**](user-init-script-seed.md) — `~/.yorishiro/init.js` は初回だけ雛形を seed、既存 file は touch しない。app bundle 内設置は採らない
 - [**init-js-hot-reload.md**](init-js-hot-reload.md) — init.js は保存で自動 hot reload する。runtime auto-capture は downstream 誤捕捉 + top-level 取りこぼしで却下し、`ctx.registerShortcut` / `ctx.onDispose` の opt-in scope を畳む
 - [**explicit-over-implicit-ugc.md**](explicit-over-implicit-ugc.md) — Agentic UGC 前提では implicit な便利さより explicit な予測可能性
-- *UI pack（5 つ目の pack kind）は Plan 3 完了まで shape が変わるため、この topic-indexed index には未 promote*
+- UI Pack の実行 class と配布境界は [`pack-execution-classes.md`](pack-execution-classes.md)、system settings 固有の例外は [`system-settings-privileged-boundary.md`](system-settings-privileged-boundary.md) を参照。
 
 ### Design discipline / compass
 

--- a/docs/decisions/ambient-ui-amenity-service-boundary.md
+++ b/docs/decisions/ambient-ui-amenity-service-boundary.md
@@ -1,0 +1,88 @@
+# Ambient UI と Amenity service の境界
+
+> このファイルは「Amenity の state / 操作を Ambient UI にどう公開するか」「共通 API をどこまで stable にするか」を判断する時に読む。対象：dev / AI / Pack author。
+
+**Status**: active
+**Last updated**: 2026-08-12
+
+## TL;DR
+
+Amenity は opt-in の `AmenityHandle.service` を公開でき、Ambient UI は `ctx.amenities.get(id)` からそれを利用する。共通 stable contract は `get(id)`、`getState()`、`execute(command, params?)`、inactive / unavailable 時の fail-closed semantics だけに限定する。
+
+Amenity 固有の state shape、command、payload、version は各 Amenity の contract で定義する。registry、enable/disable、MCP tool handler、内部 singleton は Ambient UI に公開しない。
+
+## 何を決めたか
+
+### 1. 共通の public envelope
+
+- `ctx.amenities.get(id)` は、active かつ明示的に service を公開した Amenity の facade を返す。
+- inactive、未登録、service 非公開なら `null` を返す。
+- facade は `getState(): Promise<unknown>` と `execute(command, params?): Promise<unknown>` だけを持つ。
+- 取得済み facade は呼び出しごとに active service を再解決する。Amenity が disable / replace された後の呼び出しは reject し、古い handle を生かさない。
+- unknown command は silent no-op にせず reject する。具体的な error / result shape は各 Amenity contract が定義する。
+
+これは通常の public API として提供し、作者に preview / stable の選択を要求しない。ただし stable とするのは上記 envelope の意味だけである。
+
+### 2. Amenity 固有 protocol は個別所有
+
+次は共通 stable contract に含めない。
+
+- `getState()` が返す object の field と意味
+- command 名、parameter、result、error taxonomy
+- subscribe / event stream / push update
+- generated typed helper や schema discovery
+- community / isolated Pack の permission model
+
+必要なら各 Amenity が version 付き contract と validation を持つ。consumer は `unknown` を信頼せず、自分が対応する protocol として parse する。
+
+Pomodoro v0.1.0 は reference implementation であり、state snapshot と `stop` command だけを service に公開する。`start`、`status` 等の MCP tool surfaceを自動的に UI serviceへ複製しない。
+
+### 3. Host facade が registry と lifecycle を隠す
+
+Ambient UI に Amenity registry 自体を渡さない。host facade は active handle の opt-in service だけを解決し、次を公開しない。
+
+- Amenity の列挙、登録、enable / disable
+- `AmenityHandle.tools` と MCP handler
+- runtime registry / singleton / internal store
+- 別 Amenity の private state
+
+これにより UI が state ownership を奪わず、Amenity の lifetime と同時に capability を失効できる。
+
+## なぜそう決めたか
+
+Pomodoro UI は timer state の表示と停止だけが必要だったが、従来は host 内部 registry と MCP tool handler を直接参照していた。この形では bundled UI だけが動き、local Ambient UI が同じ連携を作れない。また、UI が registry の mutation capability や MCP 向けの広い操作面まで取得する。
+
+一方、Pomodoro 専用 APIだけを host context に追加すると Amenity ごとに host ABI が増える。すべての Amenity protocol を一つの型へ統合すると、将来の state / command 設計まで早期に固定してしまう。
+
+そこで、discovery と lifecycle を共通 envelope にし、業務 protocol は各 Amenity に残す。これなら user-created Amenity も同じ窓口を使える一方、共通 API は小さく保てる。
+
+## 検討したが却下した代替案
+
+- **内部 registry を public にする** — mutation、enumeration、stale handle、runtime coupling を Ambient UI へ漏らす。
+- **MCP tool handler をそのまま UI に渡す** — external tool protocol と in-app UI protocol の権限・lifecycleを混同する。
+- **Pomodoro 専用 host API にする** — user-created Amenity に再利用できず、機能追加ごとに host ABI が増える。
+- **全 Amenity に共通の強い state / command schema を先に決める** — 実需要が一例しかない段階で過剰な抽象化と互換性負債になる。
+- **preview API として作者に選択させる** — consumer が安定度を選ぶ問題ではない。host が最小 envelope を安定保証し、個別 protocol のversionを各 Amenity が管理する方が責務が明確。
+
+## この決定の implication / 制約
+
+- Amenity 作者は Ambient UI 連携が必要な場合だけ `service` を opt-in する。
+- Consumer は state / result を runtime validation し、未知 field や command failure を扱う。
+- subscribe が必要になっても、既存 polling contract を壊さず追加 API として設計する。
+- service envelope は same-realm の supported contractであり、sandboxやpermission enforcementではない。
+- community Amenityを有効化する条件は [`pack-execution-classes.md`](pack-execution-classes.md) と [`pack-sandbox-strategy.md`](pack-sandbox-strategy.md) が所有する。
+
+## 関連 reference
+
+- `src/sdk/amenity-service.d.ts`
+- `src/sdk/amenity.d.ts`
+- `src/sdk/ambient-ui-pack.d.ts`
+- `src/runtime/amenity-services/amenity-services.ts`
+- `bundled-packs/amenities/pomodoro/README.md`
+- `bundled-packs/ambient-ui/pomodoro-ui/README.md`
+- [`pack-authoring-capability-parity.md`](pack-authoring-capability-parity.md)
+- [`pack-execution-classes.md`](pack-execution-classes.md)
+
+## 改訂履歴
+
+- 2026-08-12: 初版。Amenity service の minimum stable envelope、個別 protocol の ownership、lifecycle失効、registry / MCP surface 非公開を固定。

--- a/docs/decisions/local-source-authoring-contract.md
+++ b/docs/decisions/local-source-authoring-contract.md
@@ -1,0 +1,191 @@
+# Local source authoring contract
+
+**Status**: active
+**Last updated**: 2026-08-12
+
+## TL;DR
+
+Bundled Pack はYorishiro本体のVite buildに参加するが、`~/.yorishiro/packs/`の
+local source Packは限定されたruntime compilerを通る。local sourceはPack内の
+`.ts` / `.tsx` / `.js` / `.jsx`と明示的なhost moduleだけを使える。Viteの
+JSON・`?raw`・asset import、任意npm package、Pack外relative import、raw Tauri
+moduleはlocal authoring contractに含めない。
+
+この非対称はsecurity boundaryだけではない。bundled codeはreleaseと一緒に
+review・compileされる本体コード、local Packは実行中に読み込むtrusted user code
+だからである。local Packはsandboxではない。
+
+## 1. 二つのbuild経路
+
+| 能力 | Bundled Pack | Local user Pack |
+|---|---|---|
+| Build | repositoryのTypeScript + Vite build | 起動時にWebView上の`esbuild-wasm`でbundle（`.tsx` entryのみ） |
+| Entry | repositoryから明示import | `~/.yorishiro/packs/<id>/`を規約名でdiscovery |
+| Relative source | Viteが解決できるsource | 同一Pack内の`.tsx`, `.ts`, `.jsx`, `.js` |
+| Bare module | repository dependency / alias | 下記host module allowlistのみ |
+| JSON import | Vite標準で可 | 非対応 |
+| `?raw` import | Vite標準で可 | 非対応 |
+| Asset import / `?url` | Vite標準で可 | 非対応。hostの`resolveAsset`を使う |
+| Cross-Pack / internal import | 本体実装として技術的に可 | 非対応・非契約 |
+| Hot reload | Vite HMR | entryまたは同一Pack内sourceの変更で再bundle・再登録 |
+
+Bundled Packが利用している表現能力は、原則としてstable SDKまたはhost moduleへ
+翻訳してlocal Packにも提供する。ただしbundled codeのimport path自体はpublic API
+ではない。system-owned settings UI、内部registry、raw Tauri API、Pack間の暗黙な
+mutable stateは明示的な例外であり、そのままlocal Packへ公開しない。
+
+## 2. Local entryとsource extension
+
+Local Packのdirectoryはkind-firstではなくflatである。
+
+```text
+~/.yorishiro/packs/<pack-id>/
+├── manifest.json
+├── <kind>.js または対応kindの<kind>.tsx
+├── lib/
+│   └── helper.ts
+└── assets/
+    └── model.glb
+```
+
+Discoveryが認識するentryは次のとおり。
+
+| Kind | Entry | 備考 |
+|---|---|---|
+| `effect` | `effect.js` | 事前build済みES module |
+| `persona` | `persona.js` | `persona.md`はhostが別途読み込める |
+| `amenity` | `amenity.js` | 事前build済みES module |
+| `scene` | `scene.js` または `scene.tsx` | 両方ある場合は`.js`を優先 |
+| `ui` | `ui.js` または `ui.tsx` | 両方ある場合は`.js`を優先 |
+| `ambient-ui` | `ambient-ui.js` または `ambient-ui.tsx` | 両方ある場合は`.js`を優先 |
+
+Runtime source compilerを通るのは`.tsx` entryだけである。そのentryからのrelative
+source importは`.tsx`, `.ts`, `.jsx`, `.js`を明示extensionまたはextensionなしで
+参照できる。extensionなしの場合はこの順で探索する。directory index import、
+`.json`、CSS、WASM、画像、音声、動画、modelはsource moduleとして解決しない。
+
+`.js` entryはBYOC（bring your own compiled JavaScript）経路であり、runtime
+compilerのhost bridgeやcontainment検査を受けない。authoring contract上は単一の
+事前bundle、または同じPack内だけを参照するbrowser ES moduleとして扱う。別Packや
+Yorishiro内部へのrelative importが偶然動いても互換性を保証しない。
+
+## 3. Runtime TSXで使えるhost module
+
+次のbare importだけをhostと同じmodule instanceへbridgeする。
+
+| Import | 用途 |
+|---|---|
+| `react` | React API |
+| `react/jsx-runtime` | automatic JSX runtime（通常はcompilerが生成） |
+| `react-dom/client` | DOM root |
+| `three` | Three.js |
+| `@react-three/fiber` | R3F |
+| `@react-three/drei` | Drei helper |
+| `@react-three/postprocessing` | R3F post-processing component |
+| `postprocessing` | lower-level post-processing primitive |
+| `@yorishiro/sdk/controls` | Scene controls |
+| `@yorishiro/sdk/r3f` | Yorishiro推奨R3F entry |
+| `@yorishiro/sdk/attention-cue` | attention cue component / hook |
+| `@yorishiro/sdk` | 型import専用。runtime value exportは提供しない |
+
+型は`import type`で参照する。`leva`、`lucide-react`、`three/addons/*`、
+`@tauri-apps/*`、Node builtin、Yorishiroの`src/` path、未記載のnpm packageは
+allowlist外である。dependencyをPackに同梱したいという要望は、任意npm importを
+開くのではなく、host module昇格・Pack自身への事前bundle・新しい明示dependency
+contractのいずれかとして別途判断する。
+
+## 4. Pack境界
+
+`.tsx` entryを含むdirectoryがPack rootになる。`./`と`../`はimport元からPOSIX
+normalizationした結果がそのroot内に残る場合だけ許可する。したがって
+`lib/view.tsx`から`../theme.ts`は許可し、entryから`../other-pack/scene.tsx`へ
+出るimportはcompile errorにする。absolute filesystem path、URL、bare importの
+allowlist回避も許可しない。
+
+Shared sourceが必要な場合は次のいずれかを使う。
+
+- stable `@yorishiro/sdk/*` APIへ昇格する
+- Packへsourceを複製または事前bundleする
+- assetとして各Packに置き、各Packの`resolveAsset`から参照する
+- 将来、versionとownershipを持つ明示dependency contractを設計する
+
+Bundled Packのcross-Pack relative importは本体内部の実装detailであり、local
+Pack向けの前例ではない。
+
+## 5. JSON・raw text・asset
+
+### JSONとraw text
+
+Local runtime TSXはVite互換loaderではないため、`import data from "./data.json"`と
+`import text from "./note.md?raw"`を受け付けない。小さなstatic dataは`.ts` module
+のliteralとしてexportする。Personaの`persona.md`だけはPersona loaderが明示的に
+読み、`thinking.systemPromptAddition`が未指定なら注入するspecial caseである。
+
+任意のraw file read APIは提供しない。JSON/raw import追加はMIME、size、watch、
+error表示、containmentを一体で定義してから行う。
+
+### Asset
+
+Assetはsource importせず、Pack APIが渡すresolverを使う。
+
+- declarative Scene layer: `src: "./assets/background.webp"`
+- component Scene: `resolveAsset("./assets/model.glb")`
+- Amenity: `ctx.resolveAsset("./assets/sound.mp3")`
+
+Local component Sceneの`resolveAsset`はPack root内だけを`asset://` URLへ変換する。
+absolute path、remote/data/file/blob URL、`..` traversalは拒否する。raw Tauri
+`convertFileSrc`をPackへ公開しない。Declarative Scene layerでbundle対象になる形式は
+`src/runtime/scene-pack-registry/asset-resolver.ts`のallowlistを正本とする。
+
+## 6. Diagnosticsとreload
+
+Authoring時はrepository checkoutから次を実行する。
+
+```bash
+npm run check:pack -- ~/.yorishiro/packs/<pack-id>
+```
+
+`check:pack`はmanifest、entry存在、unsafe path/URL、forbidden API、symlink、sizeを
+検査する。ただしJS/TS scanはheuristicであり、runtime compilerの代わりではない。
+
+Runtime TSX compileではunsupported bare import、Pack外relative import、missing
+relative source、source fetch、esbuild diagnosticsをload failureとして記録する。
+起動時は失敗したPackだけを`last-startup.json`/Dev Logへ残し、他Packのloadを続行
+する。Hot reload失敗時は既存のactive registrationを置き換えない。起動不能時の
+safe modeは復旧経路であり、untrusted codeを安全に実行するsandboxではない。
+
+## 7. Version policy
+
+Manifestのversion fieldは役割を分ける。
+
+- `version`: Pack自身のversion。現在のlocal loaderは順序比較しない。
+- `yorishiroVersion`: schema上必須の互換range metadata。現在のlocal loaderはrangeを
+  評価しないため、これだけを実行可否gateと考えない。
+- `minClientVersion`: exact SemVer形式の任意field。指定時はentry import前に現在の
+  Yorishiro versionと比較し、古いclientまたはversion取得不能ならfail closed。
+- `platform`: `macos`, `windows`, `linux`の任意allowlist。指定時はimport前に現在の
+  platformを検証する。
+
+新しいruntime APIが必要なPackは、現行では`yorishiroVersion`に意図するrangeを記し、
+実行gateとして対応する`minClientVersion`も指定する。range evaluatorを導入するまで
+両fieldを同義に扱わない。
+
+## 8. 保守ルール
+
+Host module、source extension、asset resolver、version gateを変更するときは、
+この文書とruntime testsを同じchangeで更新する。Bundled referenceが新しい表現能力を
+正式利用した場合は、local authoringへstableに公開できるかを監査し、公開しない場合は
+security、host ownership、platform、bundle compatibility、resource riskの具体的理由を
+記録する。
+
+## 関連reference
+
+- `src/runtime/user-pack-loader/tsx-transpiler.ts`
+- `src/runtime/user-pack-loader/runtime-wire.ts`
+- `src/runtime/user-pack-loader/watcher.ts`
+- `src/runtime/user-pack-loader/pack-execution-policy.ts`
+- `src/runtime/scene-pack-registry/asset-resolver-pack.ts`
+- `src-tauri/src/lib.rs` (`list_user_packs` / manifest summary)
+- [`user-pack-layout.md`](user-pack-layout.md)
+- [`pack-execution-classes.md`](pack-execution-classes.md)
+- [`bundled-pack-immutability.md`](bundled-pack-immutability.md)

--- a/docs/decisions/local-source-authoring-contract.md
+++ b/docs/decisions/local-source-authoring-contract.md
@@ -34,6 +34,30 @@ Bundled Packが利用している表現能力は、原則としてstable SDKま�
 ではない。system-owned settings UI、内部registry、raw Tauri API、Pack間の暗黙な
 mutable stateは明示的な例外であり、そのままlocal Packへ公開しない。
 
+### Public exposureの分類
+
+Bundled codeで使われた能力をlocal sourceへ露出するかは、次の三分類で判断する。
+importが存在すること、またはbuild時に解決できることだけではpublic API化の根拠に
+ならない。
+
+1. **Third-party host module bridge** — React / Three.js系のように、hostとPackで
+   package namespaceとmodule instanceを共有する必要があるdependency。これは
+   Yorishiro独自のsemantic SDKではなく、bridge対象packageのpublic APIを共有する
+   contractである。とくに`@react-three/postprocessing`と`postprocessing`は、installed
+   package namespaceからnamed exportを生成するcomplete dynamic shimを使う。package
+   更新時は新しい有効なnamed exportも自動的にbridgeへ入る方針とし、conformance test
+   でshimとinstalled packageの整合、およびPackが依存する代表symbolを確認する。
+   新しいpackage bridgeには同一instanceの必要性、WebViewでの安全性、bundle size、
+   version互換性を別途確認する。
+2. **Host-internal capability** — controls、attention cue、asset解決などYorishiroが
+   lifecycleやfailure semanticsを所有する能力。内部module namespaceは共有せず、
+   `@yorishiro/sdk/*`にsemanticなcurated minimum surfaceだけを公開する。bundled側の
+   private helperやrelative importが増えても、そのままSDK surfaceを拡張しない。
+3. **System-owned exception** — settings / updater UI、raw Tauri command、内部registry、
+   起動履歴、Pack間の暗黙なmutable stateなど、本体だけが所有する能力。これはpublic
+   parityの対象外である。local Packにも必要になった場合は例外をbridgeせず、権限・
+   version・failure modeを持つ最小のsemantic SDKとして別途設計する。
+
 ## 2. Local entryとsource extension
 
 Local Packのdirectoryはkind-firstではなくflatである。

--- a/docs/decisions/pack-authoring-capability-parity.md
+++ b/docs/decisions/pack-authoring-capability-parity.md
@@ -1,0 +1,87 @@
+# Pack authoring capability parity
+
+> このファイルは「bundled Pack が使う能力を local user Pack にも公開すべきか」を判断する時に読む。対象：dev / AI / Pack API reviewer。
+
+**Status**: active
+**Last updated**: 2026-08-12
+
+## TL;DR
+
+Bundled Pack が reference implementation として正式利用する**ユーザーから見える表現能力**は、原則として local user Pack にも stable な public host API で提供する。ただし、同じ source path や内部 module を公開するのではなく、能力を Yorishiro 所有の契約へ翻訳する。
+
+Security、host ownership、compatibility、platform、resource の具体的理由があるものだけを例外とする。local Pack は現在 `trusted-main-thread-js` であり、この parity は sandbox の主張ではない。
+
+## 何を決めたか
+
+### 1. Parity は source parity ではなく semantic capability parity
+
+判断単位は import path や component 名ではなく、Pack 作者が実現できる結果である。
+
+- bundled scene が post-processing、controls、attention cue を正式な表現として使うなら、local scene にも対応する public contract を用意する。
+- bundled code が relative import できること、Vite plugin を使えること、内部 registry を参照できることだけでは public API 化の根拠にならない。
+- bundled と local で build 経路が違っても、作者から見た supported capability と failure semantics は一致させる。
+
+### 2. Public exposure を4分類する
+
+| 分類 | 方針 | 例 |
+|---|---|---|
+| Third-party host module bridge | host と Pack が package namespace / instance を共有する必要がある場合、対象 package の public API を bridge する | React、Three.js、R3F、postprocessing |
+| Host-owned semantic API | lifecycle、ownership、failure semantics を host が持つ最小 API に翻訳する | controls、attention cue、asset resolver、amenity service |
+| System-owned privileged exception | app 本体と同じ release / review 単位でだけ許可し、通常 Pack の前例にしない | settings、updater、native picker、raw Tauri |
+| Not yet demanded | bundled reference が正式利用しておらず、実需要もない能力は先回りして公開しない | 未使用 addon、任意 npm package、将来の GPU primitive |
+
+例外にする場合は「internal だから」だけで終わらせず、security、host ownership、compatibility、platform、resource のどれが理由かを decision または contract test に残す。
+
+### 3. 共通化は stable な最小 envelope に留める
+
+複数 Pack が同種の能力を必要としても、個別 protocol まで一つの巨大 API に統合しない。共通に安定保証できる discovery、lifecycle、failure semantics だけを固定し、Pack 固有の state shape、command、payload、version は個別 contract に置く。
+
+Amenity service はこの規則の reference である。共通保証は `get(id)`、`getState()`、`execute(command, params?)` と inactive 時の失敗だけで、Pomodoro 固有の state / command は Pomodoro 自身が所有する。
+
+### 4. Bundled reference 自身も public 経路を使う
+
+public API を用意した後も bundled Pack が内部 import を使い続けると、SDK の破損を製品内で検出できない。権限例外でない bundled reference は public import / context を使い、local runtime と generated `sdk.d.ts` を含む conformance test で維持する。
+
+## なぜそう決めたか
+
+Bundled Pack は Pack authoring の見本でもある。製品内の reference だけが使える表現を増やすと、次の三つが分裂する。
+
+1. ユーザーとAIに説明する SDK の約束
+2. Yorishiro 自身が dogfood している実装
+3. local runtime compiler が実際に実行できる範囲
+
+この分裂は通常の unit test では見つかりにくく、実際に post-processing は bundled Vite build では動く一方、local TSX runtime では import できなかった。semantic parity を decision として固定し、例外を明示することで、silent drift を review 可能な差分へ変える。
+
+一方、全内部 module の公開は Pack を runtime 構造へ結合し、privileged capability と mutable registry まで漏らす。必要なのは内部実装の複製ではなく、host が継続保守できる意味的な窓口である。
+
+## 検討したが却下した代替案
+
+- **Bundled が import するものをすべて allowlist に足す** — raw Tauri、内部 registry、app component まで public ABI になり、ownership と権限境界を失う。
+- **Issue になった symbol だけ個別 shim する** — package update や別の bundled reference で同じ drift を繰り返す。第三者 package bridge と host-owned semantic API を分けて保守する。
+- **Bundled Pack は本体コードなので user Pack と違ってよい、とだけする** — reference implementation と authoring contract が分裂し、ユーザーが製品内の表現を再現できない。
+- **Parity を sandbox enforcement とみなす** — same-realm の supported API contract は権限分離ではない。community / untrusted execution は別 decision の対象である。
+
+## この決定の implication / 制約
+
+- 新しい bundled 表現能力を追加する PR は、local authoring contractへの公開可否を確認する。
+- public にする場合は bundled reference をその経路へ移し、local runtime regression testを加える。
+- public にしない場合は具体的な例外理由と ownership を記録する。
+- shared React / R3F / Three instance、Pack containment、unknown bare import の fail-closed を維持する。
+- raw Tauri、任意 npm import、cross-Pack relative import、mutable registry は parity の shortcut にしない。
+- resource budget、GPU/platform compatibility、community distribution、sandbox はこの決定の保証外である。
+
+## 関連 reference
+
+- [`local-source-authoring-contract.md`](local-source-authoring-contract.md)
+- [`system-settings-privileged-boundary.md`](system-settings-privileged-boundary.md)
+- [`ambient-ui-amenity-service-boundary.md`](ambient-ui-amenity-service-boundary.md)
+- [`scene-controls-api.md`](scene-controls-api.md)
+- [`pack-execution-classes.md`](pack-execution-classes.md)
+- [`pack-sandbox-strategy.md`](pack-sandbox-strategy.md)
+- `src/runtime/user-pack-loader/tsx-transpiler.ts`
+- `src/sdk/bundled-scene-authoring-contract.test.ts`
+- `src/sdk/bundled-sdk-dts.test.ts`
+
+## 改訂履歴
+
+- 2026-08-12: 初版。bundled/local の能力差を semantic capability parity として固定し、公開分類、例外理由、minimum stable envelope、sandbox との非同一性を記録。

--- a/docs/decisions/pack-execution-classes.en.md
+++ b/docs/decisions/pack-execution-classes.en.md
@@ -281,7 +281,7 @@ Conversion examples:
 | `persona.js` + `persona.md` | Persona data JSON + `persona.md` | Schema-ize only prompt / reflex mapping |
 | `effect.js` | Effect recipe JSON | Only effects expressible via runtime primitives are publishable |
 | `amenity.js` | Future `isolated-js` bundle | Aligned to capability permission and RPC API. Not published in MVP |
-| `ui.js` / `ui.tsx` / `ambient-ui.js` | Generally not convertible | Requires future isolated UI or curated trusted review |
+| `ui.js` / `ui.tsx` / `ambient-ui.js` / `ambient-ui.tsx` | Generally not convertible | Requires future isolated UI or curated trusted review |
 
 Items that cannot be converted to `declarative`:
 

--- a/docs/decisions/pack-execution-classes.md
+++ b/docs/decisions/pack-execution-classes.md
@@ -281,7 +281,7 @@ JS / TS static scan は正規表現ではなく AST で行う。`import`, dynami
 | `persona.js` + `persona.md` | persona data JSON + `persona.md` | prompt / reflex mapping だけを schema 化 |
 | `effect.js` | effect recipe JSON | runtime primitive で表現できる演出だけ公開可能 |
 | `amenity.js` | 将来の `isolated-js` bundle | capability permission と RPC API に合わせる。MVP では公開しない |
-| `ui.js` / `ui.tsx` / `ambient-ui.js` | 原則変換不可 | 将来 isolated UI または curated trusted review が必要 |
+| `ui.js` / `ui.tsx` / `ambient-ui.js` / `ambient-ui.tsx` | 原則変換不可 | 将来 isolated UI または curated trusted review が必要 |
 
 `declarative` へ変換できないもの：
 

--- a/docs/decisions/system-settings-privileged-boundary.md
+++ b/docs/decisions/system-settings-privileged-boundary.md
@@ -1,0 +1,102 @@
+# System settings UI の privileged boundary
+
+**Status**: active
+**Last updated**: 2026-08-12
+
+## TL;DR
+
+`yorishiro-settings` は Pack authoring の見本ではなく、アプリ本体に同梱される
+system-owned UI である。通常の UI Pack は `@yorishiro/sdk` と明示された host shim
+だけを使い、Tauri/plugin や `src/**` を直接 import しない。
+
+設定画面に残る直接 import は、host 所有の更新・VRM import・表示部品・ローカライズを
+組み立てるための監査済み例外である。例外を一般 Pack の権限へ広げるには、別途
+permission / isolation 設計が必要であり、この decision だけでは許可しない。
+
+## 何を決めたか
+
+### 1. `yorishiro-settings` は system-owned exception
+
+`bundled-packs/ui/yorishiro-settings` は次の条件をすべて満たす特別な UI とする。
+
+- app と同じ release / review / signature 単位で配布する bundled code
+- manifest で `executionClass: "trusted-main-thread-js"` を明示する
+- user override と同じ API 互換を約束しない
+- source 内の privileged / internal import は conformance test の allowlist で監査する
+- allowlist 追加は「設定 UI に必要」だけでは不十分で、SDK 昇格不能な理由をこの文書へ追記する
+
+同じ id の user pack は bundled source の authority を継承しない。id は capability token
+ではない。user fork は通常の local trusted UI Pack として扱い、supported authoring surface
+は `@yorishiro/sdk` と明示された host shim に限る。
+
+### 2. 監査結果
+
+| 使用箇所 | 分類 | 結論 |
+|---|---|---|
+| `@tauri-apps/api/core` の `import_vrm` | file import + host write | privileged のまま。picker、copy、VRM validation、保存先をまとめた host-mediated API が未設計 |
+| `@tauri-apps/plugin-dialog` | native file picker | privileged のまま。任意 file picker を UI Pack capability として開けない |
+| updater / process relaunch | network update、署名検証、app replace、再起動 | system-only。Pack API にしない |
+| `src/components/RestoreConfirmDialog` | app-level modal / reload UX | system component。Pack 向け component ABI にしない |
+| `src/i18n/strings` | app 固有 settings / recovery 文言 | system content。汎用 SDK にしない |
+| `src/runtime/history/describe-snapshot` | app 固有の snapshot 表示文言 | system presentation。history 操作自体は `ctx.history` へ公開 |
+| `src/runtime/language/language` | app language の optimistic UI 解決 | system presentation helper。設定値の正本は `ctx.app.getConfig()` / `setLanguage()` |
+| `src/runtime/user-pack-loader/config` | bundled Yori persona と agent の app 規約 | system policy。Pack authoring API にしない |
+| bundled `simple-room/manifest.json` | null config の app default 表示 | bundled topology。Pack 間 import の一般契約にしない |
+| app version read | read-only app metadata | `ctx.app.getVersion()` へ公開 |
+| HTTPS URL open | external side effect | scheme / credential / length を host が検証する `ctx.app.openExternal()` へ公開。user gesture から呼ぶ authoring contract |
+| snapshot list/create/restore | reversible state management。restore は destructive | 既存 `HistoryAPI` を `ctx.history` として UI Pack にも公開。restore confirmation は host が所有 |
+
+### 3. 通常 UI Pack の authoring contract
+
+通常の UI Pack は次を守る。
+
+- Tauri API / plugin、`window.__TAURI_INTERNALS__`、`src/bindings/**` を直接使わない
+- app component、runtime helper、別 bundled Pack の manifest を import しない
+- app metadata / external link / history は `ctx.app` / `ctx.history` を使う
+- `openExternal` は user の明示操作（link/button）からのみ呼ぶ。mount 時や timer から開かない
+- updater、process relaunch、native file picker、任意 IPC が必要なら Pack 実装を止め、host capability を別途設計する
+
+現状の local UI Pack は main WebView realm で動くため、これは runtime sandbox ではなく
+supported API contract である。community 配布や隔離済み UI Pack を有効にする前には、
+manifest permission、host-side gate、audit、rate limit、user approval を実装する必要がある。
+
+## なぜそう決めたか
+
+設定画面はアプリ更新、復元、ファイル import といった app lifecycle の責務を持つ。
+見た目が Pack であることを理由に、これらを全 UI Pack へ公開すると、Pack API が実質的な
+Tauri passthrough になり permission 境界を失う。一方、読み取り専用 metadata と制約付き
+external link、既に確認 UX を内蔵する history は host-mediated capability として再利用できる。
+
+## 検討したが却下した代替案
+
+- **設定 Pack の直接 import をすべて禁止する**: updater / VRM import / app modal を先に
+  public ABI 化することになり、不要な権限拡張になる。
+- **`system: true` のような manifest flag を追加する**: id や自己申告 field は authority の
+  根拠にならない。bundled provenance と app release review が根拠である。
+- **raw Tauri を local Pack の公式 API として記載する**: 現在技術的に到達可能でも、将来の
+  isolation / community distribution と両立しない。
+- **updater / picker を今回 SDK 化する**: permission declaration と user approval の設計が
+  先に必要。今回の安全で明白な汎用 capability の範囲を超える。
+
+## この決定の implication / 制約
+
+- `yorishiro-settings` の allowlist 増加は security review を要する。
+- Tauri capability file や Rust command permission は、この例外文書を理由に変更しない。
+- settings の user fork parity は保証しない。必要な汎用機能は個別に host-mediated SDK へ昇格する。
+- 将来 updater / picker を公開する場合は permission manifest と approval UX を伴う新 decision を作る。
+
+## 関連 reference
+
+- `bundled-packs/ui/yorishiro-settings/ui.tsx`
+- `bundled-packs/ui/yorishiro-settings/README.md`
+- `src/sdk/ui-pack.d.ts`
+- `src/sdk/settings-privileged-boundary.test.ts`
+- [`pack-execution-classes.md`](pack-execution-classes.md)
+- [`pack-provenance-boundary.md`](pack-provenance-boundary.md)
+- [`pack-rollback-recovery.md`](pack-rollback-recovery.md)
+- [`input-prefill-boundary.md`](input-prefill-boundary.md)
+- [`../security.md`](../security.md)
+
+## 改訂履歴
+
+- 2026-08-12: 初版。settings の privileged/internal import を監査し、app version、制約付き HTTPS open、HistoryAPI を public UI Pack capability として切り出した。

--- a/docs/decisions/system-settings-privileged-boundary.md
+++ b/docs/decisions/system-settings-privileged-boundary.md
@@ -36,7 +36,7 @@ permission / isolation 設計が必要であり、この decision だけでは�
 | `@tauri-apps/api/core` の `import_vrm` | file import + host write | privileged のまま。picker、copy、VRM validation、保存先をまとめた host-mediated API が未設計 |
 | `@tauri-apps/plugin-dialog` | native file picker | privileged のまま。任意 file picker を UI Pack capability として開けない |
 | updater / process relaunch | network update、署名検証、app replace、再起動 | system-only。Pack API にしない |
-| `src/components/RestoreConfirmDialog` | app-level modal / reload UX | system component。Pack 向け component ABI にしない |
+| `src/components/RestoreConfirmDialog` | app-level modal / reload UX | settings からの直接 import を除去。`ctx.history.restore()` の host-owned confirmation として維持し、Pack 向け component ABI にしない |
 | `src/i18n/strings` | app 固有 settings / recovery 文言 | system content。汎用 SDK にしない |
 | `src/runtime/history/describe-snapshot` | app 固有の snapshot 表示文言 | system presentation。history 操作自体は `ctx.history` へ公開 |
 | `src/runtime/language/language` | app language の optimistic UI 解決 | system presentation helper。設定値の正本は `ctx.app.getConfig()` / `setLanguage()` |

--- a/docs/decisions/system-settings-privileged-boundary.md
+++ b/docs/decisions/system-settings-privileged-boundary.md
@@ -59,6 +59,8 @@ permission / isolation 設計が必要であり、この decision だけでは�
 現状の local UI Pack は main WebView realm で動くため、これは runtime sandbox ではなく
 supported API contract である。community 配布や隔離済み UI Pack を有効にする前には、
 manifest permission、host-side gate、audit、rate limit、user approval を実装する必要がある。
+特に `openExternal` の HTTPS validator は `ctx.app` 経路だけの contract であり、same-realm
+code から raw Tauri opener / IPC へ到達できる現状の authority を狭めるものではない。
 
 ## なぜそう決めたか
 
@@ -69,6 +71,13 @@ external link、既に確認 UX を内蔵する history は host-mediated capabi
 
 ## 検討したが却下した代替案
 
+- **system-owned 例外の文書化だけで止め、汎用 API 昇格を見送る**: 変更量が最小で、
+  settings の raw import をそのまま例外化できる。しかし、app version は副作用のない
+  metadata read、external link は既存の HTTPS 2 件を同一 validator に集約でき、history は
+  amenity 向けに既に公開済みで restore confirmation も host が所有している。これらまで
+  settings 固有に留めると、通常 UI Pack が同じ用途で unsupported import を再発明し、特に
+  restore で raw destructive binding と app component を複製する誘因になる。そのため、この
+  3 件は supported contract に昇格し、updater / picker 等は例外のまま維持した。
 - **設定 Pack の直接 import をすべて禁止する**: updater / VRM import / app modal を先に
   public ABI 化することになり、不要な権限拡張になる。
 - **`system: true` のような manifest flag を追加する**: id や自己申告 field は authority の
@@ -84,6 +93,9 @@ external link、既に確認 UX を内蔵する history は host-mediated capabi
 - Tauri capability file や Rust command permission は、この例外文書を理由に変更しない。
 - settings の user fork parity は保証しない。必要な汎用機能は個別に host-mediated SDK へ昇格する。
 - 将来 updater / picker を公開する場合は permission manifest と approval UX を伴う新 decision を作る。
+- Tauri の `opener:default` 自体の narrow 化は今回実装しない。isolated/community UI を
+  有効にする前の follow-up とし、raw plugin を guest realm から外した上で、manifest permission、
+  user activation、URL policy、audit/rate limit を host capability RPC で強制する。
 
 ## 関連 reference
 
@@ -99,4 +111,5 @@ external link、既に確認 UX を内蔵する history は host-mediated capabi
 
 ## 改訂履歴
 
+- 2026-08-12: Fable review を反映。same-realm では SDK validation が sandbox/enforcement ではないこと、文書化だけの最小案を採らなかった理由、opener narrow 化の follow-up を明記。
 - 2026-08-12: 初版。settings の privileged/internal import を監査し、app version、制約付き HTTPS open、HistoryAPI を public UI Pack capability として切り出した。

--- a/docs/decisions/system-settings-privileged-boundary.md
+++ b/docs/decisions/system-settings-privileged-boundary.md
@@ -42,9 +42,9 @@ permission / isolation 設計が必要であり、この decision だけでは�
 | `src/runtime/language/language` | app language の optimistic UI 解決 | system presentation helper。設定値の正本は `ctx.app.getConfig()` / `setLanguage()` |
 | `src/runtime/user-pack-loader/config` | bundled Yori persona と agent の app 規約 | system policy。Pack authoring API にしない |
 | bundled `simple-room/manifest.json` | null config の app default 表示 | bundled topology。Pack 間 import の一般契約にしない |
-| app version read | read-only app metadata | `ctx.app.getVersion()` へ公開 |
-| HTTPS URL open | external side effect | scheme / credential / length を host が検証する `ctx.app.openExternal()` へ公開。user gesture から呼ぶ authoring contract |
-| snapshot list/create/restore | reversible state management。restore は destructive | 既存 `HistoryAPI` を `ctx.history` として UI Pack にも公開。restore confirmation は host が所有 |
+| `@tauri-apps/api/app` の version read | read-only app metadata | settings の直接 import を除去し、`ctx.app.getVersion()` へ公開 |
+| `@tauri-apps/plugin-opener` の URL open | external side effect | settings の直接 import を除去。scheme / credential / length を host が検証する `ctx.app.openExternal()` へ公開し、user gesture から呼ぶ authoring contract とする |
+| `src/bindings/tauri-commands` の snapshot binding | reversible state management。restore は destructive | settings の直接 import を除去。既存 `HistoryAPI` を `ctx.history` として UI Pack にも公開し、restore confirmation は host が所有 |
 
 ### 3. 通常 UI Pack の authoring contract
 

--- a/docs/decisions/user-pack-layout.md
+++ b/docs/decisions/user-pack-layout.md
@@ -1,24 +1,24 @@
-# User pack は flat layout（.js 強制）
+# User packはflat layout（通常.js、一部kindは.tsx）
 
 > このファイルは「**user pack を scan / write / `/yori` で create する path** を扱う時に読む。対象：dev / AI。
 
 **Status**: active
-**Last updated**: 2026-04-19
+**Last updated**: 2026-08-12
 
 ## TL;DR
 
-user pack は **flat layout**：`~/.yorishiro/packs/<id>/<kind>.{js,md}`、`.js` 強制。bundled の **kind-first layout**（`bundled-packs/<kind_plural>/<id>/<kind>.{ts,md}`）と意図的に非対称。Rust の `list_user_packs` は flat 前提で scan する。
+user packは**flat layout**：`~/.yorishiro/packs/<id>/<kind>.js`が基本で、`scene` / `ui` / `ambient-ui`だけは`.tsx`も選べる。bundledの**kind-first layout**（`bundled-packs/<kind_plural>/<id>/`）とは意図的に非対称であり、Rustの`list_user_packs`はflat前提でscanする。
 
 ## 何を決めたか
 
-- user pack: `~/.yorishiro/packs/<id>/<kind>.js`（flat、`.js` のみ）
+- user pack: `~/.yorishiro/packs/<id>/<kind>.js`（flat）が基本。`scene` / `ui` / `ambient-ui`はlocal trusted sourceとして`.tsx` entryも選べる
 - bundled pack: `bundled-packs/<kind_plural>/<id>/<kind>.ts`（kind-first、`.ts` + tsconfig）
-- user 側は `.js` のみ受け付ける（user が TS から自分で transpile）
+- user 側の`.js`は作者が事前compileする。`scene.tsx` / `ui.tsx` / `ambient-ui.tsx`だけは限定runtime compilerを通す
 - Rust `list_user_packs` の scan logic はこの flat 構造前提で書かれている
 
 ## なぜそう決めたか
 
-- user 側は **runtime に直接 load** されるため `.js` で良い（TS toolchain は user pack 開発時のみ、runtime 依存にしない）
+- user 側の通常entryは **runtime に直接 load** されるため`.js`とする。React/R3F authoringが必要な3 kindだけは、host moduleとPack内sourceに閉じたruntime `.tsx`経路を持つ
 - bundled 側は **Yorishiro 開発の build 対象** で `.ts` + tsconfig 拘束、種類別整理が build / test の単位として自然
 - 役割が違うので非対称が正解。「対称な方が綺麗」と統合する誘惑に乗らない（[separate-distinct-systems.md](separate-distinct-systems.md)）
 
@@ -27,6 +27,7 @@ user pack は **flat layout**：`~/.yorishiro/packs/<id>/<kind>.{js,md}`、`.js`
 - path を書く時 / ドキュメントで例示する時、**user と bundled を混同すると永遠に pack が見つからない**（最頻発の事故）
 - `/yori` が user pack を write する時は flat layout に従う
 - bundled-packs/ の layout を user-style に合わせない、user-packs/ を kind-first にしない
+- `.tsx`経路の正確なimport/asset/version contractは[`local-source-authoring-contract.md`](local-source-authoring-contract.md)を正本とする
 
 ## 関連 reference
 

--- a/scripts/lib/pack-checker.mjs
+++ b/scripts/lib/pack-checker.mjs
@@ -1,3 +1,5 @@
+import ts from "typescript";
+
 const SUPPORTED_PACK_TYPES = new Set([
   "effect",
   "persona",
@@ -37,10 +39,14 @@ const FORBIDDEN_SOURCE_PATTERNS = [
     "forbidden-node-child-process",
     /(?:from\s+["'](?:node:)?child_process["']|require\s*\(\s*["'](?:node:)?child_process["']\s*\))/,
   ],
-  ["forbidden-process", /\bprocess\./],
   ["forbidden-buffer", /\bBuffer\./],
-  ["forbidden-system-exec", /\bsystem\.exec\b/],
   ["forbidden-pty-write", /\b(?:ptyWrite|write_terminal_input|terminal_prefill)\b/],
+];
+// HTML is not parsed by the TypeScript source scanner. Preserve the prior
+// conservative detection for executable inline scripts and event handlers.
+const FORBIDDEN_HTML_PATTERNS = [
+  ["forbidden-process", /\bprocess\./],
+  ["forbidden-system-exec", /\bsystem\.exec\b/],
 ];
 const UNSAFE_URL_PATTERN = /\b(?:https?|javascript|data|file|blob):/i;
 const CSS_URL_PATTERN = /url\s*\(/i;
@@ -96,7 +102,7 @@ export function checkPackFiles({ files, packDirName, mode = "local-authoring" })
   if (manifest === null) return result(mode, diagnostics);
 
   validateManifest({ manifest, files, packDirName, mode, diagnostics });
-  scanTextFiles(files, diagnostics);
+  scanTextFiles({ files, manifest, mode, diagnostics });
 
   return result(mode, diagnostics);
 }
@@ -210,13 +216,16 @@ function validateEntry({ entry, executionClass, files, mode, diagnostics }) {
   }
 }
 
-function scanTextFiles(files, diagnostics) {
+function scanTextFiles({ files, manifest, mode, diagnostics }) {
   for (const [path, rawFile] of files) {
     const file = fileRecord(rawFile);
     if (file === undefined || file.kind !== "text") continue;
     if (path === "manifest.json") continue;
     if (isSourcePath(path)) {
-      scanSourceFile(path, file.text, diagnostics);
+      scanSourceFile(path, file.text, {
+        allowSystemExec: allowsLocalAmenitySystemExec({ manifest, mode }),
+        diagnostics,
+      });
       continue;
     }
     if (isStylePath(path)) {
@@ -256,7 +265,7 @@ function scanFileMetadata(files, diagnostics) {
   }
 }
 
-function scanSourceFile(path, text, diagnostics) {
+function scanSourceFile(path, text, { allowSystemExec, diagnostics }) {
   if (UNSAFE_URL_PATTERN.test(text)) {
     add(diagnostics, "error", "unsafe-url", `${path} contains http/data/file/blob URL usage`);
   }
@@ -272,6 +281,71 @@ function scanSourceFile(path, text, diagnostics) {
       add(diagnostics, "error", code, `${path} contains ${code.replace("forbidden-", "")}`);
     }
   }
+  scanSourceSyntax(path, text, { allowSystemExec, diagnostics });
+}
+
+function allowsLocalAmenitySystemExec({ manifest, mode }) {
+  return (
+    mode === "local-authoring" &&
+    manifest.type === "amenity" &&
+    manifest.executionClass === "trusted-main-thread-js"
+  );
+}
+
+/**
+ * Parse JS/TS source so comments and string/template literal contents are not
+ * mistaken for executable property access. The checker deliberately recognizes
+ * the same direct property shapes as the previous regexes (`process.*` and
+ * `system.exec` / `ctx.system.exec`) rather than attempting data-flow analysis.
+ */
+function scanSourceSyntax(path, text, { allowSystemExec, diagnostics }) {
+  const sourceFile = ts.createSourceFile(
+    path,
+    text,
+    ts.ScriptTarget.Latest,
+    false,
+    scriptKindForPath(path),
+  );
+  let foundProcess = false;
+  let foundSystemExec = false;
+
+  const visit = (node) => {
+    if (
+      !foundProcess &&
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "process"
+    ) {
+      foundProcess = true;
+    }
+    if (!foundSystemExec && isSystemExecPropertyAccess(node)) {
+      foundSystemExec = true;
+    }
+    if (!foundProcess || !foundSystemExec) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  if (foundProcess) {
+    add(diagnostics, "error", "forbidden-process", `${path} contains process`);
+  }
+  if (foundSystemExec && !allowSystemExec) {
+    add(diagnostics, "error", "forbidden-system-exec", `${path} contains system-exec`);
+  }
+}
+
+function isSystemExecPropertyAccess(node) {
+  if (!ts.isPropertyAccessExpression(node) || node.name.text !== "exec") return false;
+  const owner = node.expression;
+  if (ts.isIdentifier(owner)) return owner.text === "system";
+  return ts.isPropertyAccessExpression(owner) && owner.name.text === "system";
+}
+
+function scriptKindForPath(path) {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (lower.endsWith(".ts")) return ts.ScriptKind.TS;
+  if (lower.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  return ts.ScriptKind.JS;
 }
 
 const STATIC_MODULE_SPECIFIER_PATTERN =
@@ -327,7 +401,7 @@ function scanStyleFile(path, text, diagnostics) {
   }
   // HTML can carry inline <script> / event-handler attributes, so style files are
   // still scanned for forbidden APIs (CSS has no realistic false positives here).
-  for (const [code, pattern] of FORBIDDEN_SOURCE_PATTERNS) {
+  for (const [code, pattern] of [...FORBIDDEN_SOURCE_PATTERNS, ...FORBIDDEN_HTML_PATTERNS]) {
     if (pattern.test(text)) {
       add(diagnostics, "error", code, `${path} contains ${code.replace("forbidden-", "")}`);
     }

--- a/scripts/lib/pack-checker.mjs
+++ b/scripts/lib/pack-checker.mjs
@@ -313,8 +313,7 @@ function scanSourceSyntax(path, text, { allowSystemExec, diagnostics }) {
     if (
       !foundProcess &&
       ts.isPropertyAccessExpression(node) &&
-      ts.isIdentifier(node.expression) &&
-      node.expression.text === "process"
+      isProcessObjectExpression(node.expression)
     ) {
       foundProcess = true;
     }
@@ -331,6 +330,26 @@ function scanSourceSyntax(path, text, { allowSystemExec, diagnostics }) {
   if (foundSystemExec && !allowSystemExec) {
     add(diagnostics, "error", "forbidden-system-exec", `${path} contains system-exec`);
   }
+}
+
+function isProcessObjectExpression(node) {
+  const expression = unwrapExpression(node);
+  if (ts.isIdentifier(expression)) return expression.text === "process";
+  return ts.isPropertyAccessExpression(expression) && expression.name.text === "process";
+}
+
+function unwrapExpression(node) {
+  let expression = node;
+  while (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isTypeAssertionExpression(expression) ||
+    ts.isNonNullExpression(expression) ||
+    ts.isSatisfiesExpression(expression)
+  ) {
+    expression = expression.expression;
+  }
+  return expression;
 }
 
 function isSystemExecPropertyAccess(node) {

--- a/scripts/lib/pack-checker.mjs
+++ b/scripts/lib/pack-checker.mjs
@@ -263,7 +263,8 @@ function scanSourceFile(path, text, diagnostics) {
   if (CSS_URL_PATTERN.test(text)) {
     add(diagnostics, "error", "css-url", `${path} contains CSS url(...) usage`);
   }
-  if (text.includes("../") || text.includes("..\\")) {
+  const traversalScanText = maskContainedParentImports(path, text);
+  if (traversalScanText.includes("../") || traversalScanText.includes("..\\")) {
     add(diagnostics, "error", "path-traversal", `${path} contains parent-directory traversal`);
   }
   for (const [code, pattern] of FORBIDDEN_SOURCE_PATTERNS) {
@@ -271,6 +272,47 @@ function scanSourceFile(path, text, diagnostics) {
       add(diagnostics, "error", code, `${path} contains ${code.replace("forbidden-", "")}`);
     }
   }
+}
+
+const STATIC_MODULE_SPECIFIER_PATTERN =
+  /\b(?:import|export)\s+(?:type\s+)?(?:(?:[^"'`;]|\n)*?\s+from\s+)?(["'])([^"']+)\1/g;
+const DYNAMIC_MODULE_SPECIFIER_PATTERN = /\bimport\s*\(\s*(["'])([^"']+)\1\s*\)/g;
+
+/**
+ * runtime TSX containmentと同じく、nested sourceからPack root内へ戻る`../` importは
+ * traversal diagnosticの対象外にする。import以外のasset/path文字列はmaskしない。
+ */
+function maskContainedParentImports(importerPath, text) {
+  const masked = [...text];
+  for (const pattern of [STATIC_MODULE_SPECIFIER_PATTERN, DYNAMIC_MODULE_SPECIFIER_PATTERN]) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const specifier = match[2];
+      if (specifier === undefined || !specifier.startsWith("../")) continue;
+      if (resolvePackRelativeImport(importerPath, specifier) === null) continue;
+      const matchStart = match.index ?? 0;
+      const specifierOffset = match[0].indexOf(specifier);
+      for (let index = 0; index < specifier.length; index += 1) {
+        masked[matchStart + specifierOffset + index] = " ";
+      }
+    }
+  }
+  return masked.join("");
+}
+
+function resolvePackRelativeImport(importerPath, specifier) {
+  const parts = normalizeRelativePath(importerPath).split("/");
+  parts.pop();
+  for (const segment of specifier.replace(/\\/g, "/").split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (parts.length === 0) return null;
+      parts.pop();
+      continue;
+    }
+    parts.push(segment);
+  }
+  return parts.join("/");
 }
 
 function scanStyleFile(path, text, diagnostics) {

--- a/scripts/lib/pack-checker.test.mjs
+++ b/scripts/lib/pack-checker.test.mjs
@@ -105,6 +105,65 @@ describe("checkPackFiles", () => {
     );
   });
 
+  it("allows a nested source import that remains inside the pack", () => {
+    const result = checkPackFiles({
+      packDirName: "my-scene",
+      files: files([
+        [
+          "manifest.json",
+          JSON.stringify({
+            id: "my-scene",
+            type: "scene",
+            executionClass: "trusted-main-thread-js",
+            entry: "scene.tsx",
+          }),
+        ],
+        ["scene.tsx", 'import { view } from "./lib/view"; export default view;'],
+        ["lib/view.ts", 'export { theme as view } from "../theme";'],
+        ["theme.ts", "export const theme = {};"],
+      ]),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.errors.map((diagnostic) => diagnostic.code)).not.toContain("path-traversal");
+  });
+
+  it("still rejects relative imports and asset strings that escape the pack", () => {
+    const importResult = checkPackFiles({
+      packDirName: "bad-scene",
+      files: files([
+        [
+          "manifest.json",
+          JSON.stringify({
+            id: "bad-scene",
+            type: "scene",
+            executionClass: "trusted-main-thread-js",
+            entry: "scene.tsx",
+          }),
+        ],
+        ["scene.tsx", 'import "../other-pack/scene"; export default {};'],
+      ]),
+    });
+    const assetResult = checkPackFiles({
+      packDirName: "bad-scene",
+      files: files([
+        [
+          "manifest.json",
+          JSON.stringify({
+            id: "bad-scene",
+            type: "scene",
+            executionClass: "trusted-main-thread-js",
+            entry: "scene.tsx",
+          }),
+        ],
+        ["scene.tsx", 'export default { src: "../secret.png" };'],
+      ]),
+    });
+
+    expect(importResult.errors.map((diagnostic) => diagnostic.code)).toContain("path-traversal");
+    expect(assetResult.errors.map((diagnostic) => diagnostic.code)).toContain("path-traversal");
+  });
+
   it("rejects forbidden APIs hidden in HTML assets", () => {
     const result = checkPackFiles({
       packDirName: "my-scene",

--- a/scripts/lib/pack-checker.test.mjs
+++ b/scripts/lib/pack-checker.test.mjs
@@ -176,6 +176,19 @@ describe("checkPackFiles", () => {
     expect(result.errors.map((diagnostic) => diagnostic.code)).toContain("forbidden-process");
   });
 
+  it.each([
+    "globalThis.process.stdout",
+    "window.process.stdout",
+    "(process).stdout",
+  ])("preserves forbidden process detection for %s", (expression) => {
+    const result = checkPackFiles({
+      packDirName: "exec-pack",
+      files: systemExecPack({ source: `export default ${expression};` }),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).toContain("forbidden-process");
+  });
+
   it("still rejects process access inside a template expression", () => {
     const source = ["export default `", "$", "{process.stdout}`;"].join("");
     const result = checkPackFiles({

--- a/scripts/lib/pack-checker.test.mjs
+++ b/scripts/lib/pack-checker.test.mjs
@@ -13,6 +13,24 @@ import {
 const files = (entries) => new Map(entries);
 
 describe("checkPackFiles", () => {
+  const systemExecPack = ({
+    type = "amenity",
+    executionClass = "trusted-main-thread-js",
+    source = "export default { activate: (ctx) => ctx.system.exec('date') };",
+  } = {}) =>
+    files([
+      [
+        "manifest.json",
+        JSON.stringify({
+          id: "exec-pack",
+          type,
+          executionClass,
+          entry: `${type}.js`,
+        }),
+      ],
+      [`${type}.js`, source],
+    ]);
+
   it("accepts local trusted authoring packs with a warning", () => {
     const result = checkPackFiles({
       packDirName: "my-effect",
@@ -59,6 +77,134 @@ describe("checkPackFiles", () => {
     expect(result.errors.map((diagnostic) => diagnostic.code)).toContain(
       "trusted-main-thread-publish",
     );
+  });
+
+  it("allows system.exec only for local trusted-main-thread amenity authoring", () => {
+    const result = checkPackFiles({
+      mode: "local-authoring",
+      packDirName: "exec-pack",
+      files: systemExecPack(),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).not.toContain(
+      "forbidden-system-exec",
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it.each([
+    "persona",
+    "effect",
+    "scene",
+    "ui",
+    "ambient-ui",
+  ])("rejects system.exec for local %s packs", (type) => {
+    const result = checkPackFiles({
+      mode: "local-authoring",
+      packDirName: "exec-pack",
+      files: systemExecPack({ type }),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).toContain("forbidden-system-exec");
+  });
+
+  it("rejects system.exec for publish-candidate amenities", () => {
+    const result = checkPackFiles({
+      mode: "publish-candidate",
+      packDirName: "exec-pack",
+      files: systemExecPack(),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).toContain("forbidden-system-exec");
+  });
+
+  it.each([
+    "isolated-js",
+    "declarative",
+  ])("rejects system.exec for local amenities with %s execution", (executionClass) => {
+    const result = checkPackFiles({
+      mode: "local-authoring",
+      packDirName: "exec-pack",
+      files: systemExecPack({ executionClass }),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).toContain("forbidden-system-exec");
+  });
+
+  it("ignores forbidden-looking process access inside strings and comments", () => {
+    const result = checkPackFiles({
+      packDirName: "exec-pack",
+      files: systemExecPack({
+        source: `
+          const stdoutHint = "process.stdout";
+          const templateHint = \`process.stderr\`;
+          // process.exit(1)
+          /* process.env.SECRET */
+          export default { stdoutHint, templateHint };
+        `,
+      }),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).not.toContain("forbidden-process");
+  });
+
+  it("ignores system.exec inside strings and comments", () => {
+    const result = checkPackFiles({
+      packDirName: "exec-pack",
+      files: systemExecPack({
+        type: "scene",
+        source: `
+          const migrationHint = "use ctx.system.exec only from an amenity";
+          // ctx.system.exec("date")
+          /* system.exec("date") */
+          export default { migrationHint };
+        `,
+      }),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).not.toContain(
+      "forbidden-system-exec",
+    );
+  });
+
+  it("still rejects executable process property access", () => {
+    const result = checkPackFiles({
+      packDirName: "exec-pack",
+      files: systemExecPack({ source: "export default process.stdout;" }),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).toContain("forbidden-process");
+  });
+
+  it("still rejects process access inside a template expression", () => {
+    const source = ["export default `", "$", "{process.stdout}`;"].join("");
+    const result = checkPackFiles({
+      packDirName: "exec-pack",
+      files: systemExecPack({ source }),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).toContain("forbidden-process");
+  });
+
+  it("keeps conservative forbidden API scanning for HTML", () => {
+    const result = checkPackFiles({
+      packDirName: "exec-pack",
+      files: files([
+        [
+          "manifest.json",
+          JSON.stringify({
+            id: "exec-pack",
+            type: "amenity",
+            executionClass: "trusted-main-thread-js",
+            entry: "amenity.js",
+          }),
+        ],
+        ["amenity.js", "export default {};"],
+        ["panel.html", '<button onclick="process.exit(1)">Stop</button>'],
+      ]),
+    });
+
+    expect(result.errors.map((diagnostic) => diagnostic.code)).toContain("forbidden-process");
   });
 
   it("rejects declarative packs with JS entries", () => {

--- a/src-tauri/resources/yorishiro-plugin/commands-en/create.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/create.md
@@ -91,6 +91,8 @@ Scene packs have two formats:
 
 You may split `scene.tsx` with pack-relative imports such as `./lib/lights.tsx`. Edits to source files inside the pack reload the owning `scene.tsx`.
 
+Trusted local `scene.tsx` packs may import post-processing components from `@react-three/postprocessing` and lower-level effects, enums, or types from `postprocessing`. These imports resolve to Yorishiro's host bridge, so the scene shares the host React, R3F, Three.js, and post-processing instances. Use `bundled-packs/scenes/abandoned-factory/lib/post-process.tsx` as the reference pipeline. This support does not allow arbitrary npm packages: unrelated bare imports remain rejected.
+
 Keep components to React + three.js rendering; do not use `fetch`, `fs`, `system.exec`, Tauri APIs, Node builtins, or PTY writes from the pack. The base camera is owned by Common controls, so scene packs should not set it directly. Design small camera breath / shake / sway changes as Scene-side modulations.
 
 ### Wiring Controls For R3F Scenes

--- a/src-tauri/resources/yorishiro-plugin/commands-en/create.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/create.md
@@ -41,7 +41,7 @@ Yorishiro is an app where an AI "lives" in a terminal. The sidebar character obs
 2. **Read existing packs.** Follow existing patterns and tone. If cwd is the Yorishiro repo, read `bundled-packs/` directly; otherwise read bundled pack sources with the `bundled_example_read` MCP tool (ids from `list_packs`).
 3. **Propose, confirm, then implement.** Do not write a full pack before the user agrees.
 4. **Always include `description` and `author` in `manifest.json`.** `description` is 1-2 sentences in English explaining what the pack does. `author` is the creator's name. These appear in Settings > Packs and help the user decide whether to enable or disable the pack.
-5. **Respect pack boundaries.** Persona has no system API; amenity may use local-trusted `system.exec` but is motion-free; effect has only the minimal rendering API; scene is declarative or React+three.js rendering only; ui / ambient-ui handle rendering and state only. Types enforce this, but treat it as a design rule too.
+5. **Respect pack boundaries.** Persona has no system API; amenity may use local-trusted `system.exec` but is motion-free; effect has only the minimal rendering API; scene is declarative or React+three.js rendering only; ui / ambient-ui handle rendering and state only. When Ambient UI needs an Amenity's state or commands, use `AmenityHandle.service` and `ctx.amenities`; never build a cross-Pack bridge with `globalThis` or an internal registry. Types enforce this, but treat it as a design rule too.
 6. **Use CSS variables for UI colors.** In ui / ambient-ui packs, do not hardcode colors such as `#eceff4` or `rgba(77, 217, 207, ...)`. Use `var(--yorishiro-fg)`, `var(--yorishiro-accent)`, and related variables so UI follows scene themes.
 
 ## Hot Reload and Self-Check
@@ -478,9 +478,14 @@ from `@yorishiro/sdk`, and pack-local relative `.tsx` / `.ts` / `.jsx` / `.js` f
 source edits hot-reload the owning entry. Arbitrary npm imports, raw Tauri APIs, and
 imports outside the pack are rejected. Return a complete disposer from `mount`.
 
-Reference: `bundled-packs/ambient-ui/attention-aura/`.
+References: `attention-aura` for a standalone overlay and `pomodoro` + `pomodoro-ui`
+for Amenity integration. In a packaged build, read them with `bundled_example_read`.
 
-Ambient-UI has renderer and attention information only. It does not have persona or system APIs. Because it is always visible, keep performance conservative.
+Ambient UI may use rendering, attention, and services explicitly exposed by active Amenities
+through `ctx.amenities`. It has no persona/system API, Amenity registry, or MCP tool handlers.
+For Amenity integration, use only `ctx.amenities.get(id)` followed by `getState()` / `execute()`,
+and validate the Amenity-specific state in the consumer. Because it is always visible, keep
+performance conservative.
 
 Use the same CSS variable rule as UI packs. Hardcoded colors are acceptable only for effect-specific colors that intentionally do not follow the scene theme.
 

--- a/src-tauri/resources/yorishiro-plugin/commands-en/create.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/create.md
@@ -468,9 +468,15 @@ Ambient-UI packs are always-on overlays. They are **multi-active**. They can dra
   "executionClass": "trusted-main-thread-js",
   "description": "Short description of this overlay",
   "author": "Your name",
-  "entry": "ambient-ui.js"
+  "entry": "ambient-ui.tsx"
 }
 ```
+
+Create `~/.yorishiro/packs/my-overlay/ambient-ui.tsx` as the implementation. It is
+runtime-transpiled trusted local source and may import `react`, `react-dom/client`, types
+from `@yorishiro/sdk`, and pack-local relative `.tsx` / `.ts` / `.jsx` / `.js` files. Nested
+source edits hot-reload the owning entry. Arbitrary npm imports, raw Tauri APIs, and
+imports outside the pack are rejected. Return a complete disposer from `mount`.
 
 Reference: `bundled-packs/ambient-ui/attention-aura/`.
 

--- a/src-tauri/resources/yorishiro-plugin/commands-en/help.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/help.md
@@ -72,7 +72,7 @@ Required files:
 | File | Role |
 |---|---|
 | `manifest.json` | Shared declaration for id / type / version / entry |
-| `<kind>.js` | Pack implementation: `persona.js`, `effect.js`, `scene.js`, `ui.js`, or `ambient-ui.js` |
+| `<kind>.js` / `scene.tsx` | Pack implementation. Scene packs may use the runtime-transpiled R3F `scene.tsx` format |
 | `persona.md` | Persona only. Canonical source for the character prompt |
 
 Common `manifest.json` fields:
@@ -87,7 +87,7 @@ Common `manifest.json` fields:
 }
 ```
 
-- User packs use `.js` entry files.
+- Most user packs use `.js` entries. Trusted local scene packs may instead use `scene.tsx`, including host-bridged `@react-three/postprocessing` and `postprocessing` imports. Arbitrary npm imports are not supported.
 - Bundled packs and user packs have different layouts. Bundled packs live under `bundled-packs/<kind_plural>/<id>/`; user packs are flat directories under `~/.yorishiro/packs/<id>/`.
 
 ---

--- a/src-tauri/resources/yorishiro-plugin/commands-en/help.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/help.md
@@ -180,7 +180,7 @@ Pack boundaries are enforced at the type level.
 | **effect** | Almost everything except renderer, audio, and time | Effects are short-lived rendering units without persistent state |
 | **scene** | Handlers | Scene packs are declarative data |
 | **ui** | `ctx.system` / `ctx.character` / `ctx.voice` | UI packs handle rendering and state only |
-| **ambient-ui** | persona / system APIs | Ambient UI receives renderer and attention information only |
+| **ambient-ui** | persona/system APIs, Amenity registry / MCP tool handlers | Rendering, attention, and opt-in `ctx.amenities` services only |
 
 If a handler needs to trigger another reaction, announce a **synthetic event** with `ctx.emitEvent()`, then match it from a persona trigger.
 

--- a/src-tauri/resources/yorishiro-plugin/commands-en/help.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/help.md
@@ -72,7 +72,7 @@ Required files:
 | File | Role |
 |---|---|
 | `manifest.json` | Shared declaration for id / type / version / entry |
-| `<kind>.js` / `scene.tsx` | Pack implementation. Scene packs may use the runtime-transpiled R3F `scene.tsx` format |
+| `<kind>.js` / `{scene,ui,ambient-ui}.tsx` | Pack implementation. Trusted local scene, UI, and ambient-UI packs may use runtime-transpiled TSX |
 | `persona.md` | Persona only. Canonical source for the character prompt |
 
 Common `manifest.json` fields:
@@ -87,7 +87,7 @@ Common `manifest.json` fields:
 }
 ```
 
-- Most user packs use `.js` entries. Trusted local scene packs may instead use `scene.tsx`, including host-bridged `@react-three/postprocessing` and `postprocessing` imports. Arbitrary npm imports are not supported.
+- Most user packs use `.js` entries. Trusted local scene packs may instead use `scene.tsx`, including host-bridged `@react-three/postprocessing` and `postprocessing` imports. Trusted local ambient UI may use `ambient-ui.tsx`; pack-local relative source imports hot-reload their owning TSX entry. Arbitrary npm imports, raw Tauri APIs, and imports outside the pack remain unsupported.
 - Bundled packs and user packs have different layouts. Bundled packs live under `bundled-packs/<kind_plural>/<id>/`; user packs are flat directories under `~/.yorishiro/packs/<id>/`.
 
 ---

--- a/src-tauri/resources/yorishiro-plugin/commands-en/update.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/update.md
@@ -79,6 +79,14 @@ For non-persona packs:
 
 Scene colors, layer structure, effect parameters, UI layout, and ambient overlay tuning can usually be handled in this flow.
 
+When editing Amenity-to-Ambient-UI integration, use `AmenityHandle.service` on the
+Amenity side and `ctx.amenities.get(id)` on the Ambient UI side. Do not assume a
+common surface beyond `getState()` / `execute(command, params?)`, and validate
+Amenity-specific state in the consumer. If existing code uses `globalThis`, an
+internal registry, or MCP tool handlers as a cross-Pack bridge, read the bundled
+`pomodoro` + `pomodoro-ui` sources with `bundled_example_read` and migrate it to
+the public service path.
+
 ## Realtime Scene Parameter Tuning
 
 If the active scene exposes controls through SDK controls, tune values without editing files first. F2 opens two panels: Common (runtime-wide) and Scene (active scene pack). Values registered with `useYorishiroControls` appear in the Scene panel.

--- a/src-tauri/resources/yorishiro-plugin/commands-en/update.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-en/update.md
@@ -71,7 +71,7 @@ Adapt first person and tone to the persona.
 
 For non-persona packs:
 
-1. Read `manifest.json` and the entry file (`scene.js`, `effect.js`, `ui.js`, or `ambient-ui.js`)
+1. Read `manifest.json` and the entry file (`scene.js` / `scene.tsx`, `effect.js`, `ui.js` / `ui.tsx`, or `ambient-ui.js` / `ambient-ui.tsx`)
 2. Edit according to the user's request
 3. Let hot reload apply it
 4. Use `pack_diagnose({ id: "<id>" })` to confirm status, manifest, and load errors

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/create.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/create.md
@@ -462,9 +462,15 @@ ambient-ui pack は常時表示のオーバーレイ UI。**multi-active**（複
   "version": "0.1.0",
   "yorishiroVersion": "^0.1.0",
   "executionClass": "trusted-main-thread-js",
-  "entry": "ambient-ui.js"
+  "entry": "ambient-ui.tsx"
 }
 ```
+
+実装は `~/.yorishiro/packs/my-overlay/ambient-ui.tsx` に置く。trusted local source として
+runtime transpile され、`react`、`react-dom/client`、`@yorishiro/sdk` の型と pack 内の relative
+`.tsx` / `.ts` / `.jsx` / `.js` を import できる。nested source の編集も owning entry を
+hot reload する。任意の npm import、raw Tauri API、pack 外 import は拒否される。
+`mount` から完全な disposer を返すこと。
 
 bundled の参考実装: `bundled-packs/ambient-ui/attention-aura/`
 

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/create.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/create.md
@@ -40,7 +40,7 @@ AI がターミナルに「住む」ためのアプリ。サイドバーのキ�
 1. **まず具体例を一つ聞く** — 「どんな場面で」「何が起きたら」「どう反応してほしい」のような肌触りを一つ引き出してから動く
 2. **既存の pack を読む** — `bundled_example_read({id})` で bundled pack のソースを取得し、pattern と文体を踏襲する（`list_packs()` で利用可能な id を確認できる）
 3. **提案 → 確認 → 実装** の順で合意を取る。一気に書き下ろさない
-4. **境界を守る** — persona は system API 不可、amenity は local-trusted の system.exec ありだが motion-free、effect は最小 API のみ、scene は宣言または React+three.js の描画のみ、ui / ambient-ui は描画と state のみ。型で強制されるが、設計意図としても守る
+4. **境界を守る** — persona は system API 不可、amenity は local-trusted の system.exec ありだが motion-free、effect は最小 API のみ、scene は宣言または React+three.js の描画のみ、ui / ambient-ui は描画と state のみ。Ambient UI が Amenity の state / command を必要とする場合は `AmenityHandle.service` と `ctx.amenities` を使い、`globalThis` や内部 registry で Pack 間 bridge を作らない。型で強制されるが、設計意図としても守る
 5. **色は CSS 変数を使う** — UI / ambient-ui pack でハードコード色（`#eceff4`, `rgba(77, 217, 207, ...)` 等）を直書きしない。`var(--yorishiro-fg)`, `var(--yorishiro-accent)` 等の CSS 変数を使う。scene テーマが変わったときに全 UI が追従するため
 
 ## Hot reload と自己検証
@@ -472,11 +472,15 @@ runtime transpile され、`react`、`react-dom/client`、`@yorishiro/sdk` の�
 hot reload する。任意の npm import、raw Tauri API、pack 外 import は拒否される。
 `mount` から完全な disposer を返すこと。
 
-bundled の参考実装: `bundled-packs/ambient-ui/attention-aura/`
+bundled の参考実装: 単独 overlay は `attention-aura`、Amenity 連携は
+`pomodoro` + `pomodoro-ui`。packaged build では `bundled_example_read` で読む。
 
 ### 境界
 
-ambient-ui は **renderer と attention 情報のみ**。persona / system API は持たない。常時表示される性質上、パフォーマンスに注意すること。
+ambient-ui は renderer、attention、および active Amenity が明示公開した
+`ctx.amenities` serviceを使える。persona / system API、Amenity registry、MCP tool handlerは
+持たない。Amenity連携は `ctx.amenities.get(id)` → `getState()` / `execute()` だけを使い、
+consumer側で固有stateを検証する。常時表示される性質上、パフォーマンスに注意すること。
 
 **色は CSS 変数を使う**: UI pack と同じルール。ハードコード色を直書きせず `var(--yorishiro-*)` を使う。ただしエフェクト固有の色（パーティクル色等、scene テーマに依存しないもの）はハードコードで OK。
 

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/create.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/create.md
@@ -91,6 +91,8 @@ scene pack には 2 つの形式がある：
 
 `scene.tsx` から pack 内の `./lib/*.tsx` 等へ相対 import して分割してよい。pack 内 source file の編集は owning `scene.tsx` の reload として扱われる。
 
+trusted local `scene.tsx` では、post-processing component を `@react-three/postprocessing` から、lower-level effect / enum / type を `postprocessing` から import できる。これらは Yorishiro の host bridge に解決されるため、host と同じ React / R3F / Three.js / post-processing instance を共有する。pipeline の参考実装は `bundled-packs/scenes/abandoned-factory/lib/post-process.tsx`。任意の npm package が使えるわけではなく、無関係な bare import は引き続き拒否される。
+
 component 内では React + three.js の描画に留め、`fetch` / `fs` / `system.exec` / Tauri API / Node builtin / PTY write は使わない。base camera は Common controls の所有なので scene から直接触らない。camera breath / shake / sway のような微小変調だけを Scene 側 controls として設計する。
 
 ### R3F scene の controls 結線

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/help.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/help.md
@@ -182,7 +182,7 @@ pack 種類ごとに使えない API が型レベルで強制されている。
 | **effect** | ほぼ全部（renderer + audio + time のみ） | state を持たない short-lived rendering 単位 |
 | **scene** | handler 無し（宣言のみ） | 純粋なデータ定義 |
 | **ui** | `ctx.system` / `ctx.character` / `ctx.voice` | 描画と state 管理のみ |
-| **ambient-ui** | persona / system API | renderer と attention 情報のみ |
+| **ambient-ui** | persona / system API、Amenity registry / MCP tool handler | renderer、attention、`ctx.amenities` の opt-in service のみ |
 
 - handler 内から新 reaction を起こしたい場合 → `ctx.emitEvent()` で **synthetic event** を announce、trigger match 経由で発火
 

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/help.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/help.md
@@ -72,7 +72,7 @@ Claude Code 使用時に、AI が `/yori:create` や `/yori:update` 経由で pa
 | ファイル | 役割 |
 |---|---|
 | `manifest.json` | id / type / version / entry の宣言（全 pack 共通） |
-| `<kind>.js` / `scene.tsx` | pack 本体。scene は runtime transpile される R3F `scene.tsx` も利用可能 |
+| `<kind>.js` / `{scene,ui,ambient-ui}.tsx` | pack 本体。trusted local の scene / UI / ambient UI は runtime transpile される TSX も利用可能 |
 | `persona.md` | **persona のみ**。キャラクター人格の canonical source |
 
 `manifest.json` の共通 fields:
@@ -87,7 +87,7 @@ Claude Code 使用時に、AI が `/yori:create` や `/yori:update` 経由で pa
 }
 ```
 
-- 多くの user pack は `.js` entry を使う。trusted local scene は `scene.tsx` も利用でき、`@react-three/postprocessing` / `postprocessing` は host bridge 経由で import できる。任意の npm import は利用できない
+- 多くの user pack は `.js` entry を使う。trusted local scene は `scene.tsx` も利用でき、`@react-three/postprocessing` / `postprocessing` は host bridge 経由で import できる。trusted local ambient UI は `ambient-ui.tsx` を利用でき、pack 内の relative source import も owning TSX entry として hot reload される。任意の npm import、raw Tauri API、pack 外 import は利用できない
 - bundled pack とは layout が異なる（bundled は `bundled-packs/<kind_plural>/<id>/`、user は flat `~/.yorishiro/packs/<id>/`）
 
 ---

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/help.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/help.md
@@ -72,7 +72,7 @@ Claude Code 使用時に、AI が `/yori:create` や `/yori:update` 経由で pa
 | ファイル | 役割 |
 |---|---|
 | `manifest.json` | id / type / version / entry の宣言（全 pack 共通） |
-| `<kind>.js` | pack 本体（persona.js / effect.js / scene.js / ui.js / ambient-ui.js） |
+| `<kind>.js` / `scene.tsx` | pack 本体。scene は runtime transpile される R3F `scene.tsx` も利用可能 |
 | `persona.md` | **persona のみ**。キャラクター人格の canonical source |
 
 `manifest.json` の共通 fields:
@@ -87,7 +87,7 @@ Claude Code 使用時に、AI が `/yori:create` や `/yori:update` 経由で pa
 }
 ```
 
-- user pack は `.js` のみ（TS から transpile する）
+- 多くの user pack は `.js` entry を使う。trusted local scene は `scene.tsx` も利用でき、`@react-three/postprocessing` / `postprocessing` は host bridge 経由で import できる。任意の npm import は利用できない
 - bundled pack とは layout が異なる（bundled は `bundled-packs/<kind_plural>/<id>/`、user は flat `~/.yorishiro/packs/<id>/`）
 
 ---

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/update.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/update.md
@@ -69,7 +69,7 @@ AI は persona 作業が完了したら **必ず住人の声で案内する**（
 
 persona 以外の pack は比較的軽量に編集できる。
 
-1. 対象の `manifest.json` と entry file（`scene.js` / `effect.js` / `ui.js` / `ambient-ui.js`）を Read する
+1. 対象の `manifest.json` と entry file（`scene.js` / `scene.tsx`、`effect.js`、`ui.js` / `ui.tsx`、`ambient-ui.js` / `ambient-ui.tsx`）を Read する
 2. user の要望に合わせて修正し、Write する
 3. hot reload で即反映される（再起動不要）
 4. 編集後 `pack_diagnose({id: "<id>"})` で status / manifest / load error を確認する

--- a/src-tauri/resources/yorishiro-plugin/commands-ja/update.md
+++ b/src-tauri/resources/yorishiro-plugin/commands-ja/update.md
@@ -77,6 +77,13 @@ persona 以外の pack は比較的軽量に編集できる。
 
 scene の色・layer 構成、effect の parameter 調整、ui のレイアウト変更、ambient-ui の表示調整など、いずれもこのフローで完結する。
 
+Amenity と Ambient UI の連携を編集する場合は、Amenity 側の
+`AmenityHandle.service` と Ambient UI 側の `ctx.amenities.get(id)` を正式経路にする。
+`getState()` / `execute(command, params?)` 以外の共通 surface を仮定せず、固有 state は
+consumer 側で検証する。`globalThis`、内部 registry、MCP tool handler を Pack 間 bridge に
+使っている既存コードを見つけたら、bundled の `pomodoro` + `pomodoro-ui` を
+`bundled_example_read` で読み、この public service 経路へ移行する。
+
 ## Scene pack のパラメータをリアルタイム調整する
 
 scene pack が SDK controls 経由で F2 の **Scene panel** にパラメータを公開している場合、ファイル編集なしでリアルタイムに値を変えられる。F2 で開く panel は Common（runtime-wide）と Scene（active scene pack 固有）の 2 枚に分かれており、`useYorishiroControls` で登録された scene pack の値はすべて Scene panel に出る。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1331,6 +1331,14 @@ const SDK_DTS_PARTS: &[(&str, &str)] = &[
     ("persona.d.ts", include_str!("../../src/sdk/persona.d.ts")),
     ("amenity.d.ts", include_str!("../../src/sdk/amenity.d.ts")),
     ("effect.d.ts", include_str!("../../src/sdk/effect.d.ts")),
+    (
+        "attention.d.ts",
+        include_str!("../../src/sdk/attention.d.ts"),
+    ),
+    (
+        "ambient-ui-pack.d.ts",
+        include_str!("../../src/sdk/ambient-ui-pack.d.ts"),
+    ),
     ("scene.d.ts", include_str!("../../src/sdk/scene.d.ts")),
     (
         "scene-pack.d.ts",
@@ -2591,6 +2599,8 @@ mod sdk_bundle_tests {
         assert!(bundle.contains("export interface PersonaDefinition"));
         assert!(bundle.contains("export interface EffectContext"));
         assert!(bundle.contains("export interface UiPackDefinition"));
+        assert!(bundle.contains("export interface AmbientUiPackDefinition"));
+        assert!(bundle.contains("export interface AttentionAPI"));
         assert!(!bundle.contains("from \"./reaction\""));
         assert!(!bundle.contains("from \"./context\""));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1187,8 +1187,8 @@ async fn poll_hook_signals() -> Vec<String> {
 //   ~/.yorishiro/
 //   ├── init.js                         # 起動時 entry (~= init.el)
 //   ├── packs/
-//   │   └── <pack-id>/<kind>.js         # kind ∈ {effect, persona, voice, body, scene, ui}
-//   │       <pack-id>/ui.tsx            # Plan 4 MVP: user UI pack source
+//   │   └── <pack-id>/<kind>.js         # kind ∈ {effect, persona, voice, body, scene, ui, ambient-ui}
+//   │       <pack-id>/{ui,scene,ambient-ui}.tsx # trusted local runtime-transpiled source
 //   ├── config.json                     # 将来の宣言的設定
 //   ├── sdk.d.ts                        # Yorishiro が ship する IDE 用 type hint
 //   └── sdk-guide.md                    # Yorishiro が ship する pack 作者向け narrative ガイド
@@ -1473,7 +1473,7 @@ async fn ensure_yorishiro_dirs() -> Result<(), String> {
 /// Scan ~/.yorishiro/packs/ and return discovered packs.
 ///
 /// Convention: ~/.yorishiro/packs/<id>/<kind>.js where kind is one of PACK_KINDS.
-/// UI / scene packs also support runtime-transpiled .tsx entries.
+/// UI / scene / ambient-ui packs also support runtime-transpiled .tsx entries.
 /// Multiple kind files in one pack directory produce multiple entries.
 /// Missing directory returns empty vec (not an error).
 #[tauri::command]
@@ -1487,7 +1487,7 @@ fn entry_file_for_kind(pack_dir: &Path, kind: &str) -> Option<PathBuf> {
     if js_entry.is_file() {
         return Some(js_entry);
     }
-    if kind == "ui" || kind == "scene" {
+    if kind == "ui" || kind == "scene" || kind == "ambient-ui" {
         let tsx_entry = pack_dir.join(format!("{}.tsx", kind));
         if tsx_entry.is_file() {
             return Some(tsx_entry);
@@ -2698,6 +2698,60 @@ mod user_pack_discovery_tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].kind, "scene");
         assert!(entries[0].entry_path.ends_with("/my-room/scene.js"));
+
+        let _ = fs::remove_dir_all(&packs);
+    }
+
+    #[test]
+    fn discovers_ambient_ui_tsx_with_manifest_summary() {
+        let packs = fresh_packs_dir("ambient-ui-tsx");
+        let pack_dir = packs.join("my-overlay");
+        fs::create_dir_all(&pack_dir).expect("create pack dir");
+        fs::write(
+            pack_dir.join("ambient-ui.tsx"),
+            "export default { type: 'ambient-ui' };\n",
+        )
+        .expect("write ambient-ui.tsx");
+        fs::write(
+            pack_dir.join("manifest.json"),
+            r#"{
+              "id": "my-overlay",
+              "type": "ambient-ui",
+              "version": "0.1.0",
+              "yorishiroVersion": "^0.1.0",
+              "executionClass": "trusted-main-thread-js",
+              "entry": "ambient-ui.tsx"
+            }"#,
+        )
+        .expect("write manifest");
+
+        let entries = discover_user_pack_entries(&packs).expect("discover ok");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "my-overlay");
+        assert_eq!(entries[0].kind, "ambient-ui");
+        assert!(entries[0]
+            .entry_path
+            .ends_with("/my-overlay/ambient-ui.tsx"));
+        let manifest = entries[0].manifest.as_ref().expect("manifest summary");
+        assert_eq!(manifest.kind, "ambient-ui");
+        assert_eq!(manifest.entry, "ambient-ui.tsx");
+
+        let _ = fs::remove_dir_all(&packs);
+    }
+
+    #[test]
+    fn prefers_ambient_ui_js_over_tsx_for_compatibility() {
+        let packs = fresh_packs_dir("ambient-ui-js-precedence");
+        let pack_dir = packs.join("my-overlay");
+        fs::create_dir_all(&pack_dir).expect("create pack dir");
+        fs::write(pack_dir.join("ambient-ui.js"), "export default {};\n")
+            .expect("write ambient-ui.js");
+        fs::write(pack_dir.join("ambient-ui.tsx"), "export default {};\n")
+            .expect("write ambient-ui.tsx");
+
+        let entry = entry_file_for_kind(&pack_dir, "ambient-ui").expect("ambient-ui entry");
+        assert!(entry.ends_with("ambient-ui.js"));
 
         let _ = fs::remove_dir_all(&packs);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1270,6 +1270,10 @@ struct UserPackManifestSummary {
     description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     author: Option<String>,
+    #[serde(rename = "minClientVersion", skip_serializing_if = "Option::is_none")]
+    min_client_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    platform: Option<Vec<String>>,
     /// 能力ラダーの sandbox 宣言。Rust 側は素通しし、検証は TS（pack-execution-policy）が行う。
     #[serde(skip_serializing_if = "Option::is_none")]
     sandbox: Option<serde_json::Value>,
@@ -1541,6 +1545,8 @@ fn discover_user_pack_entries(packs_dir: &Path) -> Result<Vec<UserPackEntry>, St
                         execution_class: m.execution_class.clone(),
                         description: m.description.clone(),
                         author: m.author.clone(),
+                        min_client_version: m.min_client_version.clone(),
+                        platform: m.platform.clone(),
                         sandbox: m.sandbox.clone(),
                     }),
                 });
@@ -2780,6 +2786,8 @@ mod user_pack_discovery_tests {
               "version": "0.1.0",
               "yorishiroVersion": "^0.1.0",
               "executionClass": "trusted-main-thread-js",
+              "minClientVersion": "0.7.0",
+              "platform": ["macos", "linux"],
               "entry": "effect.js"
             }"#,
         )
@@ -2796,6 +2804,11 @@ mod user_pack_discovery_tests {
         assert_eq!(
             manifest.execution_class.as_deref(),
             Some("trusted-main-thread-js")
+        );
+        assert_eq!(manifest.min_client_version.as_deref(), Some("0.7.0"));
+        assert_eq!(
+            manifest.platform.as_deref(),
+            Some(["macos".to_string(), "linux".to_string()].as_slice())
         );
 
         let _ = fs::remove_dir_all(&packs);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1333,6 +1333,10 @@ const SDK_DTS_PARTS: &[(&str, &str)] = &[
     ("context.d.ts", include_str!("../../src/sdk/context.d.ts")),
     ("history.d.ts", include_str!("../../src/sdk/history.d.ts")),
     ("persona.d.ts", include_str!("../../src/sdk/persona.d.ts")),
+    (
+        "amenity-service.d.ts",
+        include_str!("../../src/sdk/amenity-service.d.ts"),
+    ),
     ("amenity.d.ts", include_str!("../../src/sdk/amenity.d.ts")),
     ("effect.d.ts", include_str!("../../src/sdk/effect.d.ts")),
     (
@@ -1352,15 +1356,62 @@ const SDK_DTS_PARTS: &[(&str, &str)] = &[
     ("index.d.ts", include_str!("../../src/sdk/index.d.ts")),
 ];
 
-/// Detect `import ... from "./..."` and `export ... from "./..."` lines.
-/// Relative cross-file module references become unresolvable once all parts
-/// are flattened into a single d.ts, so they get stripped.
+/// Detect a complete `import ... from "./..."` or `export ... from "./..."`
+/// statement. Relative cross-file module references become unresolvable once
+/// all parts are flattened into a single d.ts, so they get stripped.
 fn is_cross_file_module_line(line: &str) -> bool {
     let trimmed = line.trim_start();
     if !(trimmed.starts_with("import") || trimmed.starts_with("export")) {
         return false;
     }
     trimmed.contains("from \"./") || trimmed.contains("from './")
+}
+
+fn is_module_statement_start(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("import ")
+        || trimmed.starts_with("export *")
+        || trimmed.starts_with("export type {")
+        || trimmed.starts_with("export {")
+}
+
+fn append_flattened_sdk_part(out: &mut String, src: &str) {
+    let mut statement: Option<Vec<&str>> = None;
+
+    for line in src.lines() {
+        if let Some(lines) = statement.as_mut() {
+            lines.push(line);
+            if line.trim_end().ends_with(';') {
+                let lines = statement.take().unwrap_or_default();
+                let joined = lines.join("\n");
+                if !is_cross_file_module_line(&joined) {
+                    out.push_str(&joined);
+                    out.push('\n');
+                }
+            }
+            continue;
+        }
+
+        if is_module_statement_start(line) {
+            if line.trim_end().ends_with(';') {
+                if !is_cross_file_module_line(line) {
+                    out.push_str(line);
+                    out.push('\n');
+                }
+            } else {
+                statement = Some(vec![line]);
+            }
+            continue;
+        }
+
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    if let Some(lines) = statement {
+        out.push_str(&lines.join("\n"));
+        out.push('\n');
+    }
 }
 
 fn build_bundled_sdk_dts() -> String {
@@ -1375,13 +1426,7 @@ fn build_bundled_sdk_dts() -> String {
     );
     for (name, src) in SDK_DTS_PARTS {
         out.push_str(&format!("// ---- {} ----\n\n", name));
-        for line in src.lines() {
-            if is_cross_file_module_line(line) {
-                continue;
-            }
-            out.push_str(line);
-            out.push('\n');
-        }
+        append_flattened_sdk_part(&mut out, src);
         out.push('\n');
     }
     out
@@ -2582,7 +2627,7 @@ pub fn run() {
 
 #[cfg(test)]
 mod sdk_bundle_tests {
-    use super::{build_bundled_sdk_dts, is_cross_file_module_line};
+    use super::{append_flattened_sdk_part, build_bundled_sdk_dts, is_cross_file_module_line};
 
     #[test]
     fn drops_relative_import_and_export_lines() {
@@ -2599,6 +2644,17 @@ mod sdk_bundle_tests {
     }
 
     #[test]
+    fn drops_multiline_relative_re_exports_as_one_statement() {
+        let mut flattened = String::new();
+        append_flattened_sdk_part(
+            &mut flattened,
+            "export type {\n  AmenityHandle,\n  AmenityToolHandler,\n} from \"./amenity\";\nexport interface Kept {}",
+        );
+
+        assert_eq!(flattened, "export interface Kept {}\n");
+    }
+
+    #[test]
     fn bundle_contains_key_types_and_omits_cross_refs() {
         let bundle = build_bundled_sdk_dts();
         assert!(bundle.contains("export interface EffectDefinition"));
@@ -2607,8 +2663,11 @@ mod sdk_bundle_tests {
         assert!(bundle.contains("export interface UiPackDefinition"));
         assert!(bundle.contains("export interface AmbientUiPackDefinition"));
         assert!(bundle.contains("export interface AttentionAPI"));
+        assert!(bundle.contains("export interface AmenityServiceHandle"));
+        assert!(bundle.contains("export interface AmenityServicesAPI"));
         assert!(!bundle.contains("from \"./reaction\""));
         assert!(!bundle.contains("from \"./context\""));
+        assert!(!bundle.contains("from \"./amenity-service\""));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -331,6 +331,7 @@ import {
   startSessionAttentionProducer,
   startWorkspaceAttentionPresenceBridge,
 } from "./runtime/workspace-attention";
+import * as YorishiroAttentionCue from "./sdk/attention-cue";
 import * as YorishiroControls from "./sdk/controls";
 import type { PersonaDefinition } from "./sdk/persona";
 import type { PersonaPackManifest } from "./sdk/persona-pack";
@@ -689,6 +690,7 @@ declare global {
   var __YORISHIRO_REACT_THREE_POSTPROCESSING__: typeof ReactThreePostprocessing | undefined;
   var __YORISHIRO_POSTPROCESSING__: typeof Postprocessing | undefined;
   var __YORISHIRO_THREE__: typeof THREE | undefined;
+  var __YORISHIRO_SDK_ATTENTION_CUE__: typeof YorishiroAttentionCue | undefined;
   var __YORISHIRO_SDK_CONTROLS__: typeof YorishiroControls | undefined;
   var __YORISHIRO_SDK_R3F__: typeof YorishiroR3f | undefined;
 }
@@ -701,6 +703,7 @@ globalThis.__YORISHIRO_REACT_THREE_FIBER__ = ReactThreeFiber;
 globalThis.__YORISHIRO_REACT_THREE_POSTPROCESSING__ = ReactThreePostprocessing;
 globalThis.__YORISHIRO_POSTPROCESSING__ = Postprocessing;
 globalThis.__YORISHIRO_THREE__ = THREE;
+globalThis.__YORISHIRO_SDK_ATTENTION_CUE__ = YorishiroAttentionCue;
 globalThis.__YORISHIRO_SDK_CONTROLS__ = YorishiroControls;
 globalThis.__YORISHIRO_SDK_R3F__ = YorishiroR3f;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 import * as ReactThreeDrei from "@react-three/drei";
 import * as ReactThreeFiber from "@react-three/fiber";
 import * as ReactThreePostprocessing from "@react-three/postprocessing";
+import { getVersion } from "@tauri-apps/api/app";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import type {
   AmbientAudioAPI,
   AmbientAudioState,
@@ -292,6 +294,7 @@ import {
 } from "./runtime/three-runtime/scene-pack-leva-store";
 import { getThreeRuntime } from "./runtime/three-runtime/three-runtime";
 import { getClaimState } from "./runtime/ui-claim-state";
+import { validateUiPackExternalUrl } from "./runtime/ui-pack-external-url";
 import { getUiRegistry, type UiPackEntry } from "./runtime/ui-pack-registry";
 import {
   playStageTransition,
@@ -1112,6 +1115,19 @@ function App() {
     [resolveRestoreDialogTarget],
   );
 
+  // Shared by amenity and UI Pack contexts. The restore method always delegates
+  // confirmation to the host-owned app dialog before invoking the raw command.
+  const historyApi = useMemo(
+    () =>
+      createHistoryApi({
+        list: () => snapshotList(),
+        create: (label) => snapshotCreate({ trigger: "sdk:snapshot", label }),
+        restore: (seq) => snapshotRestore({ seq }),
+        confirmRestore: (seq, runRestore) => openRestoreDialog(seq, runRestore),
+      }),
+    [openRestoreDialog],
+  );
+
   const handleRestoreDialogClose = useCallback(() => {
     restoreDialogResolveRef.current?.(false);
     restoreDialogResolveRef.current = null;
@@ -1407,12 +1423,6 @@ function App() {
     // 住人 AI の MCP history_snapshot は Rust 完結で別 trigger "mcp:snapshot"
     // を打つ（P2b Task 4）。watcher 自動は "watcher-settled"、baseline は
     // "startup-baseline"。これで監査・UI でどの経路の snapshot か区別できる。
-    const historyApi = createHistoryApi({
-      list: () => snapshotList(),
-      create: (label) => snapshotCreate({ trigger: "sdk:snapshot", label }),
-      restore: (seq) => snapshotRestore({ seq }),
-      confirmRestore: (seq, runRestore) => openRestoreDialog(seq, runRestore),
-    });
     let ambientAudioLiveState: AmbientAudioState = { muted: false, volume: 1 };
     const ambientAudio: AmbientAudioAPI = {
       getState: () => ambientAudioLiveState,
@@ -3357,6 +3367,7 @@ function App() {
         time,
         tween,
         log: createLogAPI(logBridge, packId),
+        history: historyApi,
         signal,
         layout: {
           update: (layout: UiLayout) => {
@@ -3367,6 +3378,8 @@ function App() {
           },
         },
         app: {
+          getVersion,
+          openExternal: (url) => openUrl(validateUiPackExternalUrl(url)),
           setVrm: (path: string | null) => applyVrmPath(path),
           // host 所有の固定プロンプトのみ解決して pre-fill する（pack はバイトを
           // 選べない）。改行なし＝user が Enter するまで実行されない。
@@ -3722,6 +3735,7 @@ function App() {
     beginCurtainReload,
     switchMainAgent,
     setActiveSceneFromUserSelection,
+    historyApi,
   ]);
 
   const bodyDevLog = useMemo(() => createSubsystemLog(devLog, "Body"), [devLog]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import * as ReactThreeDrei from "@react-three/drei";
 import * as ReactThreeFiber from "@react-three/fiber";
+import * as ReactThreePostprocessing from "@react-three/postprocessing";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import type {
   AmbientAudioAPI,
@@ -18,6 +19,7 @@ import type {
   UiThreeAPI,
 } from "@yorishiro/sdk";
 import { LevaPanel } from "leva";
+import * as Postprocessing from "postprocessing";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as ReactJsxRuntime from "react/jsx-runtime";
@@ -684,6 +686,8 @@ declare global {
   var __YORISHIRO_REACT_JSX_RUNTIME__: typeof ReactJsxRuntime | undefined;
   var __YORISHIRO_REACT_THREE_DREI__: typeof ReactThreeDrei | undefined;
   var __YORISHIRO_REACT_THREE_FIBER__: typeof ReactThreeFiber | undefined;
+  var __YORISHIRO_REACT_THREE_POSTPROCESSING__: typeof ReactThreePostprocessing | undefined;
+  var __YORISHIRO_POSTPROCESSING__: typeof Postprocessing | undefined;
   var __YORISHIRO_THREE__: typeof THREE | undefined;
   var __YORISHIRO_SDK_CONTROLS__: typeof YorishiroControls | undefined;
   var __YORISHIRO_SDK_R3F__: typeof YorishiroR3f | undefined;
@@ -694,6 +698,8 @@ globalThis.__YORISHIRO_REACT_DOM_CLIENT__ = ReactDomClient;
 globalThis.__YORISHIRO_REACT_JSX_RUNTIME__ = ReactJsxRuntime;
 globalThis.__YORISHIRO_REACT_THREE_DREI__ = ReactThreeDrei;
 globalThis.__YORISHIRO_REACT_THREE_FIBER__ = ReactThreeFiber;
+globalThis.__YORISHIRO_REACT_THREE_POSTPROCESSING__ = ReactThreePostprocessing;
+globalThis.__YORISHIRO_POSTPROCESSING__ = Postprocessing;
 globalThis.__YORISHIRO_THREE__ = THREE;
 globalThis.__YORISHIRO_SDK_CONTROLS__ = YorishiroControls;
 globalThis.__YORISHIRO_SDK_R3F__ = YorishiroR3f;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,6 +128,7 @@ import { createBodyStateExpressionAdapter } from "./runtime/agent-state-expressi
 import { type AmbientAudioRuntime, initAmbientAudio } from "./runtime/ambient-audio";
 import { getAmbientUiPackRegistry } from "./runtime/ambient-ui-pack-registry";
 import { getAmenityPackRegistry } from "./runtime/amenity-pack-registry";
+import { createAmenityServices } from "./runtime/amenity-services";
 import {
   getAttentionLightCueStore,
   startAttentionLightCueBridge,
@@ -4216,6 +4217,7 @@ function App() {
   useEffect(() => {
     const ambientUiRegistry = getAmbientUiPackRegistry();
     const attention = getAttentionRuntime();
+    const amenities = createAmenityServices(getAmenityPackRegistry());
 
     // #ambient-layer を document.body 直下に生成する（v1 の zIndex: 20 を踏襲）
     const ambientLayer = document.createElement("div");
@@ -4251,7 +4253,7 @@ function App() {
         container.dataset.packId = id;
         ambientLayer.appendChild(container);
 
-        const ctx: AmbientUiContext = { attention };
+        const ctx: AmbientUiContext = { attention, amenities };
         const disposable = packEntry.pack.mount(ctx, container);
         mounted.set(id, { container, disposable });
       }

--- a/src/runtime/amenity-services/amenity-services.test.ts
+++ b/src/runtime/amenity-services/amenity-services.test.ts
@@ -1,0 +1,72 @@
+import type { AmenityHandle, AmenityServiceHandle } from "@yorishiro/sdk";
+import { describe, expect, it, vi } from "vitest";
+import { AmenityPackRegistryImpl } from "../amenity-pack-registry";
+import { createAmenityServices } from "./amenity-services";
+
+function register(
+  registry: AmenityPackRegistryImpl,
+  id: string,
+  service?: AmenityServiceHandle,
+): AmenityHandle {
+  const handle: AmenityHandle = { tools: {}, service, dispose: vi.fn() };
+  registry.register({
+    id,
+    origin: "bundled",
+    manifest: {
+      id,
+      type: "amenity",
+      version: "1.0.0",
+      yorishiroVersion: "^0.7.0",
+      entry: "amenity.ts",
+    },
+    handle,
+  });
+  return handle;
+}
+
+describe("createAmenityServices", () => {
+  it("resolves only an active amenity's opt-in service surface", async () => {
+    const registry = new AmenityPackRegistryImpl();
+    const service: AmenityServiceHandle = {
+      getState: vi.fn(async () => ({ phase: "work" })),
+      execute: vi.fn(async (command) => ({ command })),
+    };
+    register(registry, "pomodoro", service);
+    const amenities = createAmenityServices(registry);
+
+    expect(amenities.get("pomodoro")).toBeNull();
+    registry.enable("pomodoro");
+
+    const exposed = amenities.get("pomodoro");
+    expect(exposed).not.toBeNull();
+    await expect(exposed?.getState()).resolves.toEqual({ phase: "work" });
+    await expect(exposed?.execute("stop")).resolves.toEqual({ command: "stop" });
+    expect(exposed).not.toBe(service);
+    expect("tools" in (exposed as unknown as object)).toBe(false);
+  });
+
+  it("does not expose an active amenity that omitted the public service", () => {
+    const registry = new AmenityPackRegistryImpl();
+    register(registry, "private-amenity");
+    registry.enable("private-amenity");
+
+    expect(createAmenityServices(registry).get("private-amenity")).toBeNull();
+  });
+
+  it("re-resolves a cached facade so disable cannot leave a live stale service", async () => {
+    const registry = new AmenityPackRegistryImpl();
+    register(registry, "pomodoro", {
+      getState: async () => ({ phase: "work" }),
+      execute: async () => ({ stopped: true }),
+    });
+    registry.enable("pomodoro");
+
+    const exposed = createAmenityServices(registry).get("pomodoro");
+    registry.disable("pomodoro");
+
+    await expect(exposed?.getState()).rejects.toThrow("amenity service 'pomodoro' is unavailable");
+    await expect(exposed?.execute("stop")).rejects.toThrow(
+      "amenity service 'pomodoro' is unavailable",
+    );
+  });
+});

--- a/src/runtime/amenity-services/amenity-services.ts
+++ b/src/runtime/amenity-services/amenity-services.ts
@@ -1,0 +1,37 @@
+/**
+ * Ambient UI 用 amenity service bridge。
+ *
+ * registry 自体や AmenityHandle.tools は渡さず、active handle が opt-in した
+ * service surface だけを、呼び出し時に再解決する facade として公開する。
+ */
+
+import type { AmenityServiceHandle, AmenityServicesAPI } from "@yorishiro/sdk";
+import type { AmenityPackRegistry } from "../amenity-pack-registry";
+
+function unavailable(id: string): Error {
+  return new Error(`amenity service '${id}' is unavailable`);
+}
+
+export function createAmenityServices(registry: AmenityPackRegistry): AmenityServicesAPI {
+  const resolve = (id: string): AmenityServiceHandle | null =>
+    registry.getActiveHandle(id)?.service ?? null;
+
+  return Object.freeze({
+    get(id: string): AmenityServiceHandle | null {
+      if (resolve(id) === null) return null;
+
+      return Object.freeze({
+        async getState(): Promise<unknown> {
+          const service = resolve(id);
+          if (service === null) throw unavailable(id);
+          return service.getState();
+        },
+        async execute(command: string, params?: unknown): Promise<unknown> {
+          const service = resolve(id);
+          if (service === null) throw unavailable(id);
+          return service.execute(command, params);
+        },
+      });
+    },
+  });
+}

--- a/src/runtime/amenity-services/index.ts
+++ b/src/runtime/amenity-services/index.ts
@@ -1,0 +1,1 @@
+export { createAmenityServices } from "./amenity-services";

--- a/src/runtime/bundled-pomodoro/index.test.ts
+++ b/src/runtime/bundled-pomodoro/index.test.ts
@@ -1,0 +1,55 @@
+import type { HistoryAPI } from "@yorishiro/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { TweenManager } from "../../core/tween/tween-manager";
+import { AmenityPackRegistryImpl } from "../amenity-pack-registry";
+import { registerBundledPomodoro } from "./index";
+
+const history: HistoryAPI = {
+  list: async () => [],
+  snapshot: async () => 1,
+  restore: async () => true,
+};
+
+function tweenManager(): TweenManager {
+  return {
+    start: vi.fn(),
+    startVec3: vi.fn(),
+    cancel: vi.fn(),
+  } as unknown as TweenManager;
+}
+
+describe("registerBundledPomodoro", () => {
+  it("publishes a narrow state/stop service separately from MCP tools", async () => {
+    const registry = new AmenityPackRegistryImpl();
+    const disposable = registerBundledPomodoro({
+      registry,
+      tweenManager: tweenManager(),
+      setTerminalOpacity: vi.fn(),
+      getTerminalOpacity: () => 1,
+      emitEvent: vi.fn(),
+      loop: vi.fn(),
+      history,
+    });
+    const handle = registry.getActiveHandle("pomodoro");
+
+    expect(handle?.service).toBeDefined();
+    expect(handle?.service).not.toBe(handle?.tools);
+    await handle?.tools.pomodoro_start({ workMs: 60_000, rounds: 2 });
+    await expect(handle?.service?.getState()).resolves.toMatchObject({
+      phase: "work",
+      round: 1,
+      totalRounds: 2,
+    });
+    await expect(handle?.service?.execute("stop")).resolves.toMatchObject({
+      cancelled: true,
+      phase: "work",
+      round: 1,
+    });
+    await expect(handle?.service?.getState()).resolves.toMatchObject({ phase: "idle" });
+    await expect(handle?.service?.execute("pomodoro_start")).rejects.toThrow(
+      "unknown pomodoro service command 'pomodoro_start'",
+    );
+
+    disposable.dispose();
+  });
+});

--- a/src/runtime/scene-pack-registry/asset-resolver-pack.test.ts
+++ b/src/runtime/scene-pack-registry/asset-resolver-pack.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { makeResolveAsset } from "./asset-resolver-pack";
+import { makeResolveAsset, makeUserResolveAsset } from "./asset-resolver-pack";
 
 describe("makeResolveAsset", () => {
   const mockBundledAssets: Record<string, string> = {
@@ -52,12 +52,34 @@ describe("makeResolveAsset", () => {
     expect(resolve("./assets/missing.glb")).toBe("./assets/missing.glb");
   });
 
-  it("user origin: returns relative path as-is for now (deferred to user pack plan)", () => {
+  it("keeps the compatibility fallback for an old user entry without an injected resolver", () => {
     const resolve = makeResolveAsset({
       packId: "test-scene",
       origin: "user",
       bundledAssets: mockBundledAssets,
     });
     expect(resolve("./assets/foo.glb")).toBe("./assets/foo.glb");
+  });
+});
+
+describe("makeUserResolveAsset", () => {
+  it("resolves a pack-relative path through the host converter", () => {
+    const resolve = makeUserResolveAsset(
+      "/Users/me/.yorishiro/packs/my-room",
+      (path) => `asset://localhost${path}`,
+    );
+
+    expect(resolve("./assets/model.glb")).toBe(
+      "asset://localhost/Users/me/.yorishiro/packs/my-room/assets/model.glb",
+    );
+  });
+
+  it.each([
+    "../other-pack/model.glb",
+    "/tmp/model.glb",
+    "https://example.com/model.glb",
+  ])("rejects a path outside the pack boundary: %s", (path) => {
+    const resolve = makeUserResolveAsset("/packs/my-room", (value) => value);
+    expect(() => resolve(path)).toThrow("unsafe user pack asset path");
   });
 });

--- a/src/runtime/scene-pack-registry/asset-resolver-pack.ts
+++ b/src/runtime/scene-pack-registry/asset-resolver-pack.ts
@@ -7,8 +7,8 @@
  * Bundled origin: Vite の import.meta.glob で build 時に取得した URL 表から
  *                 lookup する. 漏れた asset は relative path をそのまま返す
  *                 （graceful degradation, log は呼び元の責務）.
- * User origin: 現状 plan では未実装. relative path をそのまま返す（user pack
- *              への component 拡張は別 plan で扱う）.
+ * User origin: loader が ScenePackEntry に注入する `makeUserResolveAsset` を使う。
+ *              本 factory の user branch は古い entry 向けの互換 fallback。
  *
  * 既存 `asset-resolver.ts` の SceneSpec 用 logic と分離している. あちらは
  * SceneSpec の layer.src / ambient.src を一括変換する宣言的 path, こちらは
@@ -17,7 +17,12 @@
  * Internal design-record: specs/2026-05-03-scene-pack-r3f-component.md §3.1
  */
 
-import { isAbsoluteUrl, stripLeadingDotSlash } from "./asset-resolver";
+import {
+  isAbsoluteUrl,
+  isSafeUserPackRelativePath,
+  normalizeRelativePath,
+  stripLeadingDotSlash,
+} from "./asset-resolver";
 import type { PackOrigin } from "./types";
 
 export interface MakeResolveAssetOptions {
@@ -28,6 +33,26 @@ export interface MakeResolveAssetOptions {
    * 定義された Vite glob 結果）を渡す. test では mock 表を渡せるよう注入可能.
    */
   readonly bundledAssets: Record<string, string>;
+}
+
+/**
+ * local user component scene 向けの pack-scoped asset resolver。
+ *
+ * source import と同じく pack directory を境界にし、absolute URL / absolute
+ * filesystem path / parent traversal は host 側で拒否する。Pack code へ raw
+ * Tauri API は渡さず、検証済み path だけを asset URL に変換する。
+ */
+export function makeUserResolveAsset(
+  packDir: string,
+  convertFileSrc: (filePath: string) => string,
+): (relativePath: string) => string {
+  return (relativePath: string): string => {
+    const clean = normalizeRelativePath(relativePath);
+    if (!isSafeUserPackRelativePath(clean)) {
+      throw new Error(`unsafe user pack asset path: ${relativePath}`);
+    }
+    return convertFileSrc(`${packDir}/${clean}`);
+  };
 }
 
 export function makeResolveAsset(opts: MakeResolveAssetOptions): (relativePath: string) => string {

--- a/src/runtime/scene-pack-registry/index.ts
+++ b/src/runtime/scene-pack-registry/index.ts
@@ -13,6 +13,7 @@ export {
   resolveSceneAssets,
   resolveUserAsset,
 } from "./asset-resolver";
+export { makeUserResolveAsset } from "./asset-resolver-pack";
 export {
   DEFAULT_BUNDLED_SCENE_ID,
   getSceneRegistry,

--- a/src/runtime/scene-pack-registry/types.ts
+++ b/src/runtime/scene-pack-registry/types.ts
@@ -27,11 +27,15 @@ export interface ScenePackEntry {
   readonly origin: PackOrigin;
 
   /**
+   * Host が所有する pack-scoped asset resolver。local component scene では
+   * loader が登録時に注入し、Pack code に filesystem/Tauri API を公開しない。
+   */
+  readonly resolveAsset?: (relativePath: string) => string;
+
+  /**
    * R3F-component scene pack の場合の component reference。
-   * Bundled pack のみ。User pack 由来の場合は loader が undefined を保つ
-   * （component field を含む user pack は loader が warn して捨てる）。
-   *
-   * Internal design-record: specs/2026-05-03-scene-pack-r3f-component.md §5.2
+   * Bundled / local user の双方で利用できる。local user component は runtime
+   * transpiler の host/containment contract を通ったものだけがここへ到達する。
    */
   readonly component?: ComponentType<ScenePackComponentProps>;
 }

--- a/src/runtime/three-runtime/r3f-runtime-root.test.tsx
+++ b/src/runtime/three-runtime/r3f-runtime-root.test.tsx
@@ -202,6 +202,31 @@ describe("R3fRuntimeRoot", () => {
     expect(props.resolveAsset("./assets/model.glb")).toBe("/resolved/model.glb");
   });
 
+  it("passes the host-injected asset resolver to a local user scene component", () => {
+    const renderedProps: ScenePackComponentProps[] = [];
+    const resolveAsset = vi.fn(
+      (path: string) => `asset://localhost/Users/me/.yorishiro/packs/local-room/${path}`,
+    );
+    const LocalComponent = (props: ScenePackComponentProps) => {
+      renderedProps.push(props);
+      return null;
+    };
+    getMockRegistry().__setActive({
+      ...makeEntry("local-room", LocalComponent),
+      origin: "user",
+      resolveAsset,
+    });
+
+    render(<R3fRuntimeRoot />);
+
+    const props = renderedProps[0];
+    if (props === undefined) throw new Error("LocalComponent が render されていない");
+    expect(props.resolveAsset("assets/model.glb")).toBe(
+      "asset://localhost/Users/me/.yorishiro/packs/local-room/assets/model.glb",
+    );
+    expect(resolveAsset).toHaveBeenCalledWith("assets/model.glb");
+  });
+
   it("re-renders when active entry changes", () => {
     const registry = getMockRegistry();
     const firstRender = vi.fn((props: ScenePackComponentProps) => {

--- a/src/runtime/three-runtime/r3f-runtime-root.tsx
+++ b/src/runtime/three-runtime/r3f-runtime-root.tsx
@@ -107,12 +107,13 @@ function ActiveSceneControlsBoundary({ entry }: ActiveSceneControlsBoundaryProps
   const sceneLevaStore = useCreateStore();
   const resolveAsset = useMemo(
     () =>
+      entry.resolveAsset ??
       makeResolveAsset({
         packId: entry.id,
         origin: entry.origin,
         bundledAssets: BUNDLED_ASSETS,
       }),
-    [entry.id, entry.origin],
+    [entry.id, entry.origin, entry.resolveAsset],
   );
 
   const camera = useMemo<ScenePackCameraAPI>(() => {

--- a/src/runtime/ui-pack-external-url.test.ts
+++ b/src/runtime/ui-pack-external-url.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { UI_PACK_EXTERNAL_URL_MAX_LENGTH, validateUiPackExternalUrl } from "./ui-pack-external-url";
+
+describe("validateUiPackExternalUrl", () => {
+  it("accepts and normalizes absolute HTTPS URLs", () => {
+    expect(validateUiPackExternalUrl("https://example.com/docs?q=pack#ui")).toBe(
+      "https://example.com/docs?q=pack#ui",
+    );
+  });
+
+  it.each([
+    "http://example.com",
+    "file:///tmp/example",
+    "mailto:author@example.com",
+    "yorishiro://settings",
+    "/relative/path",
+    "https://user:secret@example.com",
+    " https://example.com",
+    "https://example.com ",
+  ])("rejects URLs outside the public Pack boundary: %s", (url) => {
+    expect(() => validateUiPackExternalUrl(url)).toThrow();
+  });
+
+  it("rejects empty and oversized values", () => {
+    expect(() => validateUiPackExternalUrl("")).toThrow();
+    expect(() =>
+      validateUiPackExternalUrl(
+        `https://example.com/${"x".repeat(UI_PACK_EXTERNAL_URL_MAX_LENGTH)}`,
+      ),
+    ).toThrow();
+  });
+});

--- a/src/runtime/ui-pack-external-url.ts
+++ b/src/runtime/ui-pack-external-url.ts
@@ -1,0 +1,34 @@
+/** Maximum URL length accepted by the UI Pack external-link capability. */
+export const UI_PACK_EXTERNAL_URL_MAX_LENGTH = 2_048;
+
+/**
+ * Validate and normalize a URL requested by a UI Pack.
+ *
+ * This is deliberately narrower than Tauri's opener plugin: the public Pack
+ * capability only opens absolute HTTPS links without embedded credentials.
+ * Native paths, custom schemes, HTTP, and relative URLs remain unavailable.
+ */
+export function validateUiPackExternalUrl(value: string): string {
+  if (value.length === 0 || value.length > UI_PACK_EXTERNAL_URL_MAX_LENGTH) {
+    throw new Error("UI Pack external URL must be between 1 and 2048 characters");
+  }
+  if (value.trim() !== value) {
+    throw new Error("UI Pack external URL must not have surrounding whitespace");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("UI Pack external URL must be an absolute HTTPS URL");
+  }
+
+  if (url.protocol !== "https:") {
+    throw new Error("UI Pack external URL must use HTTPS");
+  }
+  if (url.username.length > 0 || url.password.length > 0) {
+    throw new Error("UI Pack external URL must not contain credentials");
+  }
+
+  return url.href;
+}

--- a/src/runtime/user-pack-loader/runtime-wire.ts
+++ b/src/runtime/user-pack-loader/runtime-wire.ts
@@ -209,6 +209,7 @@ export async function loadUserLayer(deps: LoadUserLayerDeps): Promise<LoadUserLa
     initScriptLog: deps.initScriptLog,
     onInitChanged: deps.onInitChanged,
     executionEnvironment,
+    packReloadEnabled: !safeMode,
     // safe mode は recovery 契約として user packs と init.js を実行しない。
     // watcher は diagnostics / snapshot 用に張るが、init.js 変更時も reload はせず
     // legacy の log/title marker に留める。

--- a/src/runtime/user-pack-loader/scene-pack-integration.test.ts
+++ b/src/runtime/user-pack-loader/scene-pack-integration.test.ts
@@ -111,6 +111,9 @@ describe("registerScenePack", () => {
       expect(scenePackEntries[0].id).toBe("test-scene");
       expect(scenePackEntries[0].origin).toBe("user");
       expect(scenePackEntries[0].component).toBeUndefined();
+      expect(scenePackEntries[0].resolveAsset?.("./assets/model.glb")).toBe(
+        "asset://localhost/p/test-scene/assets/model.glb",
+      );
       expect(packRegistry.has("test-scene", "scene")).toBe(true);
     } finally {
       restore();

--- a/src/runtime/user-pack-loader/scene-pack-integration.ts
+++ b/src/runtime/user-pack-loader/scene-pack-integration.ts
@@ -18,7 +18,7 @@ import {
   validateScenePackManifest,
 } from "../../sdk/validators";
 import type { ScenePackRegistry } from "../scene-pack-registry";
-import { resolveSceneAssets } from "../scene-pack-registry";
+import { makeUserResolveAsset, resolveSceneAssets } from "../scene-pack-registry";
 import type { UserPackRegistry } from "./user-pack-registry";
 
 /**
@@ -152,6 +152,7 @@ export async function registerScenePack(ctx: SceneRegisterContext): Promise<Scen
     manifest,
     scene: resolved,
     origin: "user",
+    resolveAsset: makeUserResolveAsset(packDir, ctx.convertFileSrc),
     component: scenePackDef.component,
   });
   ctx.packRegistry.register(ctx.id, "scene", handle);

--- a/src/runtime/user-pack-loader/supported-kinds.ts
+++ b/src/runtime/user-pack-loader/supported-kinds.ts
@@ -20,3 +20,9 @@ export const SUPPORTED_PACK_KINDS: ReadonlySet<string> = new Set([
   "ambient-ui",
   "amenity",
 ]);
+
+/** Rust は discovery するが、現行 TS runtime に registrar がない kind。 */
+export const DISCOVERED_ONLY_PACK_KINDS: ReadonlySet<string> = new Set(["voice", "body"]);
+
+/** Rust / TS の双方が runtime-transpiled entry として認識する kind。 */
+export const TSX_ENTRY_KINDS: ReadonlySet<string> = new Set(["ui", "scene", "ambient-ui"]);

--- a/src/runtime/user-pack-loader/tsx-transpiler.test.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.test.ts
@@ -1,3 +1,5 @@
+import * as ReactThreePostprocessing from "@react-three/postprocessing";
+import * as Postprocessing from "postprocessing";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("esbuild-wasm", async (importOriginal) => {
@@ -53,6 +55,8 @@ describe("isSupportedTsxHostImport", () => {
     expect(isSupportedTsxHostImport("@react-three/drei")).toBe(true);
     expect(isSupportedTsxHostImport("three")).toBe(true);
     expect(isSupportedTsxHostImport("@yorishiro/sdk/controls")).toBe(true);
+    expect(isSupportedTsxHostImport("@react-three/postprocessing")).toBe(true);
+    expect(isSupportedTsxHostImport("postprocessing")).toBe(true);
   });
 
   it("keeps unrelated imports unsupported", () => {
@@ -118,6 +122,88 @@ describe("transpileUiTsxEntry", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("compiles and loads the post-processing authoring surface through host bridges", async () => {
+    const entryPath = "/Users/me/.yorishiro/packs/post-processing-room/scene.tsx";
+    const source = `
+      import { EffectComposer, Bloom, Noise, Vignette } from "@react-three/postprocessing";
+      import { BlendFunction, Effect, ToneMappingMode } from "postprocessing";
+
+      export {
+        EffectComposer,
+        Bloom,
+        Noise,
+        Vignette,
+        BlendFunction,
+        Effect,
+        ToneMappingMode,
+      };
+    `;
+    const originalFetch = globalThis.fetch;
+    const originalReactThreePostprocessing = globalThis.__YORISHIRO_REACT_THREE_POSTPROCESSING__;
+    const originalPostprocessing = globalThis.__YORISHIRO_POSTPROCESSING__;
+    globalThis.fetch = (async () => new Response(source, { status: 200 })) as typeof fetch;
+    globalThis.__YORISHIRO_REACT_THREE_POSTPROCESSING__ = ReactThreePostprocessing;
+    globalThis.__YORISHIRO_POSTPROCESSING__ = Postprocessing;
+
+    try {
+      const code = await transpileUiTsxEntry(entryPath, {
+        convertFileSrc: (path) => `https://asset.local${path}`,
+      });
+      const moduleUrl = `data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`;
+      const loaded = await import(/* @vite-ignore */ moduleUrl);
+
+      expect(loaded.EffectComposer).toBe(ReactThreePostprocessing.EffectComposer);
+      expect(loaded.Bloom).toBe(ReactThreePostprocessing.Bloom);
+      expect(loaded.Noise).toBe(ReactThreePostprocessing.Noise);
+      expect(loaded.Vignette).toBe(ReactThreePostprocessing.Vignette);
+      expect(loaded.BlendFunction).toBe(Postprocessing.BlendFunction);
+      expect(loaded.Effect).toBe(Postprocessing.Effect);
+      expect(loaded.ToneMappingMode).toBe(Postprocessing.ToneMappingMode);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.__YORISHIRO_REACT_THREE_POSTPROCESSING__ = originalReactThreePostprocessing;
+      globalThis.__YORISHIRO_POSTPROCESSING__ = originalPostprocessing;
+    }
+  });
+
+  it("rejects an unrelated bare import through the runtime transpile path", async () => {
+    const entryPath = "/Users/me/.yorishiro/packs/my-room/scene.tsx";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response('import value from "unrelated-package"; export default value;', {
+        status: 200,
+      })) as typeof fetch;
+
+    try {
+      await expect(
+        transpileUiTsxEntry(entryPath, {
+          convertFileSrc: (path) => `https://asset.local${path}`,
+        }),
+      ).rejects.toThrow("unsupported import 'unrelated-package' in runtime-transpiled .tsx entry");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("rejects a relative import that escapes the pack directory", async () => {
+    const entryPath = "/Users/me/.yorishiro/packs/my-room/scene.tsx";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response('import "../other-pack/scene"; export default {};', {
+        status: 200,
+      })) as typeof fetch;
+
+    try {
+      await expect(
+        transpileUiTsxEntry(entryPath, {
+          convertFileSrc: (path) => `https://asset.local${path}`,
+        }),
+      ).rejects.toThrow("relative import '../other-pack/scene' escapes the pack directory");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe("tsxHostShimNamedExports", () => {
@@ -125,6 +211,8 @@ describe("tsxHostShimNamedExports", () => {
     const modules = {
       "@react-three/drei": await import("@react-three/drei"),
       "@react-three/fiber": await import("@react-three/fiber"),
+      "@react-three/postprocessing": await import("@react-three/postprocessing"),
+      postprocessing: await import("postprocessing"),
       three: await import("three"),
     };
 
@@ -135,5 +223,14 @@ describe("tsxHostShimNamedExports", () => {
 
       expect(missing, `${path} shim exports missing from installed module`).toEqual([]);
     }
+  });
+
+  it("exposes the post-processing symbols used by local scene packs", () => {
+    expect(tsxHostShimNamedExports("@react-three/postprocessing")).toEqual(
+      expect.arrayContaining(["EffectComposer", "Bloom", "Noise", "Vignette"]),
+    );
+    expect(tsxHostShimNamedExports("postprocessing")).toEqual(
+      expect.arrayContaining(["BlendFunction", "Effect", "ToneMappingMode"]),
+    );
   });
 });

--- a/src/runtime/user-pack-loader/tsx-transpiler.test.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import * as ReactThreePostprocessing from "@react-three/postprocessing";
 import * as Postprocessing from "postprocessing";
 import { describe, expect, it, vi } from "vitest";
@@ -73,6 +74,22 @@ describe("isSupportedTsxHostImport", () => {
     expect(isSupportedTsxHostImport("@tauri-apps/api/core")).toBe(false);
     expect(isSupportedTsxHostImport("src/runtime/three-runtime/attention-cue-light")).toBe(false);
     expect(isSupportedTsxHostImport("./local-file")).toBe(false);
+  });
+});
+
+describe("local source authoring contract", () => {
+  it("documents every runtime TSX host import and source extension", async () => {
+    const contract = await readFile(
+      new URL("../../../docs/decisions/local-source-authoring-contract.md", import.meta.url),
+      "utf8",
+    );
+
+    for (const path of LOCAL_TSX_HOST_IMPORTS) {
+      expect(contract).toContain(`\`${path}\``);
+    }
+    for (const extension of LOCAL_TSX_SOURCE_EXTENSIONS) {
+      expect(contract).toContain(`\`${extension}\``);
+    }
   });
 });
 

--- a/src/runtime/user-pack-loader/tsx-transpiler.test.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.test.ts
@@ -1,6 +1,7 @@
 import * as ReactThreePostprocessing from "@react-three/postprocessing";
 import * as Postprocessing from "postprocessing";
 import { describe, expect, it, vi } from "vitest";
+import * as YorishiroAttentionCue from "../../sdk/attention-cue";
 
 vi.mock("esbuild-wasm", async (importOriginal) => {
   const actual = await importOriginal<typeof import("esbuild-wasm")>();
@@ -54,6 +55,7 @@ describe("isSupportedTsxHostImport", () => {
     expect(isSupportedTsxHostImport("@react-three/fiber")).toBe(true);
     expect(isSupportedTsxHostImport("@react-three/drei")).toBe(true);
     expect(isSupportedTsxHostImport("three")).toBe(true);
+    expect(isSupportedTsxHostImport("@yorishiro/sdk/attention-cue")).toBe(true);
     expect(isSupportedTsxHostImport("@yorishiro/sdk/controls")).toBe(true);
     expect(isSupportedTsxHostImport("@react-three/postprocessing")).toBe(true);
     expect(isSupportedTsxHostImport("postprocessing")).toBe(true);
@@ -62,6 +64,7 @@ describe("isSupportedTsxHostImport", () => {
   it("keeps unrelated imports unsupported", () => {
     expect(isSupportedTsxHostImport("fs")).toBe(false);
     expect(isSupportedTsxHostImport("@tauri-apps/api/core")).toBe(false);
+    expect(isSupportedTsxHostImport("src/runtime/three-runtime/attention-cue-light")).toBe(false);
     expect(isSupportedTsxHostImport("./local-file")).toBe(false);
   });
 });
@@ -200,6 +203,32 @@ describe("transpileUiTsxEntry", () => {
     }
   });
 
+  it("compiles and loads the public attention cue surface through the host bridge", async () => {
+    const entryPath = "/Users/me/.yorishiro/packs/attention-room/scene.tsx";
+    const source = `
+      import { AttentionCueLight, useClaimAttentionCue } from "@yorishiro/sdk/attention-cue";
+      export { AttentionCueLight, useClaimAttentionCue };
+    `;
+    const originalFetch = globalThis.fetch;
+    const originalAttentionCue = globalThis.__YORISHIRO_SDK_ATTENTION_CUE__;
+    globalThis.fetch = (async () => new Response(source, { status: 200 })) as typeof fetch;
+    globalThis.__YORISHIRO_SDK_ATTENTION_CUE__ = YorishiroAttentionCue;
+
+    try {
+      const code = await transpileUiTsxEntry(entryPath, {
+        convertFileSrc: (path) => `https://asset.local${path}`,
+      });
+      const moduleUrl = `data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`;
+      const loaded = await import(/* @vite-ignore */ moduleUrl);
+
+      expect(loaded.AttentionCueLight).toBe(YorishiroAttentionCue.AttentionCueLight);
+      expect(loaded.useClaimAttentionCue).toBe(YorishiroAttentionCue.useClaimAttentionCue);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.__YORISHIRO_SDK_ATTENTION_CUE__ = originalAttentionCue;
+    }
+  });
+
   it("rejects an unrelated bare import through the runtime transpile path", async () => {
     const entryPath = "/Users/me/.yorishiro/packs/my-room/scene.tsx";
     const originalFetch = globalThis.fetch;
@@ -256,6 +285,13 @@ describe("tsxHostShimNamedExports", () => {
 
       expect(missing, `${path} shim exports missing from installed module`).toEqual([]);
     }
+  });
+
+  it("only exposes the stable attention cue contract", () => {
+    expect(tsxHostShimNamedExports("@yorishiro/sdk/attention-cue")).toEqual([
+      "AttentionCueLight",
+      "useClaimAttentionCue",
+    ]);
   });
 
   it("exposes the post-processing symbols used by local scene packs", () => {

--- a/src/runtime/user-pack-loader/tsx-transpiler.test.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.test.ts
@@ -123,6 +123,39 @@ describe("transpileUiTsxEntry", () => {
     }
   });
 
+  it("bundles an ambient-ui.tsx entry with a nested relative source", async () => {
+    const entryPath = "/Users/me/.yorishiro/packs/my-overlay/ambient-ui.tsx";
+    const sources = new Map([
+      [
+        entryPath,
+        'import { label } from "./lib/overlay"; export default { id: "my-overlay", type: "ambient-ui", label, mount() { return { dispose() {} }; } };',
+      ],
+      [
+        "/Users/me/.yorishiro/packs/my-overlay/lib/overlay.tsx",
+        'export const label = "ambient-ready";',
+      ],
+    ]);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const path = new URL(String(input)).pathname;
+      const source = sources.get(path);
+      return source === undefined
+        ? new Response("not found", { status: 404 })
+        : new Response(source, { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const code = await transpileUiTsxEntry(entryPath, {
+        convertFileSrc: (path) => `https://asset.local${path}`,
+      });
+
+      expect(code).toContain("ambient-ready");
+      expect(code).toContain("my-overlay");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("compiles and loads the post-processing authoring surface through host bridges", async () => {
     const entryPath = "/Users/me/.yorishiro/packs/post-processing-room/scene.tsx";
     const source = `

--- a/src/runtime/user-pack-loader/tsx-transpiler.test.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import * as ReactThreePostprocessing from "@react-three/postprocessing";
 import * as Postprocessing from "postprocessing";
+import * as ReactDomClient from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 import * as YorishiroAttentionCue from "../../sdk/attention-cue";
 
@@ -180,6 +181,30 @@ describe("transpileUiTsxEntry", () => {
       expect(code).toContain("my-overlay");
     } finally {
       globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("loads the bundled-reference default import from react-dom/client", async () => {
+    const entryPath = "/Users/me/.yorishiro/packs/my-overlay/ambient-ui.tsx";
+    const source = `
+      import ReactDOM from "react-dom/client";
+      export const createRoot = ReactDOM.createRoot;
+    `;
+    const originalFetch = globalThis.fetch;
+    const originalReactDomClient = globalThis.__YORISHIRO_REACT_DOM_CLIENT__;
+    globalThis.fetch = (async () => new Response(source, { status: 200 })) as typeof fetch;
+    globalThis.__YORISHIRO_REACT_DOM_CLIENT__ = ReactDomClient;
+
+    try {
+      const code = await transpileUiTsxEntry(entryPath, {
+        convertFileSrc: (path) => `https://asset.local${path}`,
+      });
+      const moduleUrl = `data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`;
+      const loaded = await import(/* @vite-ignore */ moduleUrl);
+      expect(loaded.createRoot).toBe(ReactDomClient.createRoot);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.__YORISHIRO_REACT_DOM_CLIENT__ = originalReactDomClient;
     }
   });
 

--- a/src/runtime/user-pack-loader/tsx-transpiler.test.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.test.ts
@@ -15,6 +15,8 @@ import {
   buildTsxEntryUrl,
   isSupportedTsxHostImport,
   isTsxEntryPath,
+  LOCAL_TSX_HOST_IMPORTS,
+  LOCAL_TSX_SOURCE_EXTENSIONS,
   resolveRelativeTsxImport,
   transpileUiTsxEntry,
   tsxHostShimNamedExports,
@@ -50,6 +52,11 @@ describe("buildTsxEntryUrl", () => {
 });
 
 describe("isSupportedTsxHostImport", () => {
+  it("keeps the exported authoring contract list in sync with the resolver", () => {
+    expect(LOCAL_TSX_HOST_IMPORTS.every((path) => isSupportedTsxHostImport(path))).toBe(true);
+    expect(LOCAL_TSX_SOURCE_EXTENSIONS).toEqual([".tsx", ".ts", ".jsx", ".js"]);
+  });
+
   it("allows host modules needed by scene.tsx R3F components", () => {
     expect(isSupportedTsxHostImport("@yorishiro/sdk/r3f")).toBe(true);
     expect(isSupportedTsxHostImport("@react-three/fiber")).toBe(true);
@@ -262,6 +269,29 @@ describe("transpileUiTsxEntry", () => {
           convertFileSrc: (path) => `https://asset.local${path}`,
         }),
       ).rejects.toThrow("relative import '../other-pack/scene' escapes the pack directory");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it.each([
+    ["JSON", "./data.json", "unsupported source extension '.json'"],
+    ["raw text", "./prompt.md?raw", "Vite ?raw/?url loaders are unavailable"],
+    ["asset", "./assets/model.glb", "unsupported source extension '.glb'"],
+  ])("reports an explicit diagnostic for unsupported %s imports", async (_kind, specifier, error) => {
+    const entryPath = "/Users/me/.yorishiro/packs/my-room/scene.tsx";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(`import value from "${specifier}"; export default value;`, {
+        status: 200,
+      })) as typeof fetch;
+
+    try {
+      await expect(
+        transpileUiTsxEntry(entryPath, {
+          convertFileSrc: (path) => `https://asset.local${path}`,
+        }),
+      ).rejects.toThrow(error);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/runtime/user-pack-loader/tsx-transpiler.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.ts
@@ -224,6 +224,7 @@ const ReactDomClient = globalThis.__YORISHIRO_REACT_DOM_CLIENT__;
 if (!ReactDomClient) throw new Error("Yorishiro React DOM client host bridge is not initialized");
 export const createRoot = ReactDomClient.createRoot;
 export const hydrateRoot = ReactDomClient.hydrateRoot;
+export default ReactDomClient;
 `;
 
 const jsxRuntimeShim = `

--- a/src/runtime/user-pack-loader/tsx-transpiler.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.ts
@@ -2,7 +2,7 @@
  * user pack TSX transpiler.
  *
  * `.tsx` entry を runtime で esbuild-wasm transpile し、React / JSX runtime は
- * host 側の shim に解決する。現在は ui.tsx と scene.tsx がこの経路を使う。
+ * host 側の shim に解決する。ui.tsx / scene.tsx / ambient-ui.tsx がこの経路を使う。
  * Relative imports は pack directory 内の source file に限定して inline bundle する。
  * Persistent `.build` output は follow-up。
  */

--- a/src/runtime/user-pack-loader/tsx-transpiler.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.ts
@@ -17,6 +17,7 @@ import type * as React from "react";
 import type * as ReactJsxRuntime from "react/jsx-runtime";
 import type * as ReactDomClient from "react-dom/client";
 import type * as THREE from "three";
+import type * as YorishiroAttentionCue from "../../sdk/attention-cue";
 import type * as YorishiroControls from "../../sdk/controls";
 import type * as YorishiroR3f from "../../sdk/r3f";
 
@@ -25,6 +26,7 @@ const USER_SOURCE_NAMESPACE = "yorishiro-user-source";
 const UNSUPPORTED_NAMESPACE = "yorishiro-unsupported";
 const SUPPORTED_HOST_IMPORTS = new Set([
   "@yorishiro/sdk",
+  "@yorishiro/sdk/attention-cue",
   "@yorishiro/sdk/controls",
   "@yorishiro/sdk/r3f",
   "@react-three/drei",
@@ -46,6 +48,7 @@ declare global {
   var __YORISHIRO_REACT_THREE_POSTPROCESSING__: typeof ReactThreePostprocessing | undefined;
   var __YORISHIRO_POSTPROCESSING__: typeof Postprocessing | undefined;
   var __YORISHIRO_THREE__: typeof THREE | undefined;
+  var __YORISHIRO_SDK_ATTENTION_CUE__: typeof YorishiroAttentionCue | undefined;
   var __YORISHIRO_SDK_CONTROLS__: typeof YorishiroControls | undefined;
   var __YORISHIRO_SDK_R3F__: typeof YorishiroR3f | undefined;
 }
@@ -227,6 +230,15 @@ const sdkShim = `
 export {};
 `;
 
+const attentionCueShim = `
+const AttentionCue = globalThis.__YORISHIRO_SDK_ATTENTION_CUE__;
+if (!AttentionCue) throw new Error("Yorishiro attention cue host bridge is not initialized");
+export const {
+  AttentionCueLight,
+  useClaimAttentionCue,
+} = AttentionCue;
+`;
+
 const r3fShim = `
 const Fiber = globalThis.__YORISHIRO_REACT_THREE_FIBER__;
 const SdkR3F = globalThis.__YORISHIRO_SDK_R3F__;
@@ -344,6 +356,7 @@ export function tsxHostShimNamedExports(path: string): readonly string[] {
     return Object.keys(Postprocessing).filter(isModuleExportIdentifier).sort();
   }
   if (path === "@react-three/drei") return extractNamedExports(dreiShim);
+  if (path === "@yorishiro/sdk/attention-cue") return extractNamedExports(attentionCueShim);
   if (path === "@yorishiro/sdk/r3f" || path === "@react-three/fiber") {
     return extractNamedExports(r3fShim);
   }
@@ -409,6 +422,9 @@ function createPlan4MvpPlugin(
         }
         if (args.path === "postprocessing") {
           return { contents: postprocessingShim, loader: "js" };
+        }
+        if (args.path === "@yorishiro/sdk/attention-cue") {
+          return { contents: attentionCueShim, loader: "js" };
         }
         if (args.path === "@yorishiro/sdk/r3f" || args.path === "@react-three/fiber") {
           return { contents: r3fShim, loader: "js" };

--- a/src/runtime/user-pack-loader/tsx-transpiler.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.ts
@@ -24,7 +24,7 @@ import type * as YorishiroR3f from "../../sdk/r3f";
 const HOST_NAMESPACE = "yorishiro-host";
 const USER_SOURCE_NAMESPACE = "yorishiro-user-source";
 const UNSUPPORTED_NAMESPACE = "yorishiro-unsupported";
-const SUPPORTED_HOST_IMPORTS = new Set([
+export const LOCAL_TSX_HOST_IMPORTS = [
   "@yorishiro/sdk",
   "@yorishiro/sdk/attention-cue",
   "@yorishiro/sdk/controls",
@@ -37,7 +37,8 @@ const SUPPORTED_HOST_IMPORTS = new Set([
   "react-dom/client",
   "react/jsx-runtime",
   "three",
-]);
+] as const;
+const SUPPORTED_HOST_IMPORTS = new Set<string>(LOCAL_TSX_HOST_IMPORTS);
 
 declare global {
   var __YORISHIRO_REACT__: typeof React | undefined;
@@ -62,7 +63,7 @@ export interface TsxTranspilerOptions {
 }
 
 let initializePromise: Promise<void> | null = null;
-const RELATIVE_IMPORT_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"] as const;
+export const LOCAL_TSX_SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"] as const;
 
 type SourceLoader = "tsx" | "ts" | "jsx" | "js";
 
@@ -124,6 +125,13 @@ function sourceLoaderForPath(path: string): SourceLoader | null {
   if (path.endsWith(".jsx")) return "jsx";
   if (path.endsWith(".js")) return "js";
   return null;
+}
+
+function explicitRelativeImportExtension(path: string): string | null {
+  const pathWithoutQuery = path.split("?", 1)[0] ?? path;
+  const basename = pathWithoutQuery.slice(pathWithoutQuery.lastIndexOf("/") + 1);
+  const dotIndex = basename.lastIndexOf(".");
+  return dotIndex <= 0 ? null : basename.slice(dotIndex).toLowerCase();
 }
 
 async function readUserSource(
@@ -394,6 +402,26 @@ function createPlan4MvpPlugin(
             pluginData: `relative import '${args.path}' escapes the pack directory`,
           };
         }
+        if (args.path.includes("?")) {
+          return {
+            path: args.path,
+            namespace: UNSUPPORTED_NAMESPACE,
+            pluginData: `query import '${args.path}' is unsupported in runtime-transpiled .tsx; Vite ?raw/?url loaders are unavailable`,
+          };
+        }
+        const extension = explicitRelativeImportExtension(args.path);
+        if (
+          extension !== null &&
+          !LOCAL_TSX_SOURCE_EXTENSIONS.includes(
+            extension as (typeof LOCAL_TSX_SOURCE_EXTENSIONS)[number],
+          )
+        ) {
+          return {
+            path: args.path,
+            namespace: UNSUPPORTED_NAMESPACE,
+            pluginData: `relative import '${args.path}' uses unsupported source extension '${extension}'; supported extensions: ${LOCAL_TSX_SOURCE_EXTENSIONS.join(", ")}`,
+          };
+        }
         return {
           path: resolved,
           namespace: USER_SOURCE_NAMESPACE,
@@ -440,7 +468,7 @@ function createPlan4MvpPlugin(
       build.onLoad({ filter: /.*/, namespace: USER_SOURCE_NAMESPACE }, async (args) => {
         const candidates =
           sourceLoaderForPath(args.path) === null
-            ? RELATIVE_IMPORT_EXTENSIONS.map((ext) => `${args.path}${ext}`)
+            ? LOCAL_TSX_SOURCE_EXTENSIONS.map((ext) => `${args.path}${ext}`)
             : [args.path];
         for (const sourcePath of candidates) {
           const loader = sourceLoaderForPath(sourcePath);

--- a/src/runtime/user-pack-loader/tsx-transpiler.ts
+++ b/src/runtime/user-pack-loader/tsx-transpiler.ts
@@ -9,8 +9,10 @@
 
 import type * as ReactThreeDrei from "@react-three/drei";
 import type * as ReactThreeFiber from "@react-three/fiber";
+import * as ReactThreePostprocessing from "@react-three/postprocessing";
 import * as esbuild from "esbuild-wasm";
 import esbuildWasmUrl from "esbuild-wasm/esbuild.wasm?url";
+import * as Postprocessing from "postprocessing";
 import type * as React from "react";
 import type * as ReactJsxRuntime from "react/jsx-runtime";
 import type * as ReactDomClient from "react-dom/client";
@@ -27,6 +29,8 @@ const SUPPORTED_HOST_IMPORTS = new Set([
   "@yorishiro/sdk/r3f",
   "@react-three/drei",
   "@react-three/fiber",
+  "@react-three/postprocessing",
+  "postprocessing",
   "react",
   "react-dom/client",
   "react/jsx-runtime",
@@ -39,6 +43,8 @@ declare global {
   var __YORISHIRO_REACT_JSX_RUNTIME__: typeof ReactJsxRuntime | undefined;
   var __YORISHIRO_REACT_THREE_DREI__: typeof ReactThreeDrei | undefined;
   var __YORISHIRO_REACT_THREE_FIBER__: typeof ReactThreeFiber | undefined;
+  var __YORISHIRO_REACT_THREE_POSTPROCESSING__: typeof ReactThreePostprocessing | undefined;
+  var __YORISHIRO_POSTPROCESSING__: typeof Postprocessing | undefined;
   var __YORISHIRO_THREE__: typeof THREE | undefined;
   var __YORISHIRO_SDK_CONTROLS__: typeof YorishiroControls | undefined;
   var __YORISHIRO_SDK_R3F__: typeof YorishiroR3f | undefined;
@@ -278,6 +284,37 @@ export const {
 } = Controls;
 `;
 
+function isModuleExportIdentifier(name: string): boolean {
+  return /^[$A-Z_a-z][$\w]*$/.test(name) && name !== "default" && name !== "__esModule";
+}
+
+function createCompleteHostModuleShim(
+  globalName: string,
+  moduleName: string,
+  moduleExports: object,
+): string {
+  const names = Object.keys(moduleExports).filter(isModuleExportIdentifier).sort();
+  const exports = names.map((name) => `export const ${name} = HostModule.${name};`).join("\n");
+  return `
+const HostModule = globalThis.${globalName};
+if (!HostModule) throw new Error("Yorishiro ${moduleName} host bridge is not initialized");
+${exports}
+export default HostModule;
+`;
+}
+
+const reactThreePostprocessingShim = createCompleteHostModuleShim(
+  "__YORISHIRO_REACT_THREE_POSTPROCESSING__",
+  "@react-three/postprocessing",
+  ReactThreePostprocessing,
+);
+
+const postprocessingShim = createCompleteHostModuleShim(
+  "__YORISHIRO_POSTPROCESSING__",
+  "postprocessing",
+  Postprocessing,
+);
+
 const threeShim = `
 const THREE = globalThis.__YORISHIRO_THREE__;
 if (!THREE) throw new Error("Yorishiro Three.js host bridge is not initialized");
@@ -300,6 +337,12 @@ function extractNamedExports(shim: string): string[] {
 }
 
 export function tsxHostShimNamedExports(path: string): readonly string[] {
+  if (path === "@react-three/postprocessing") {
+    return Object.keys(ReactThreePostprocessing).filter(isModuleExportIdentifier).sort();
+  }
+  if (path === "postprocessing") {
+    return Object.keys(Postprocessing).filter(isModuleExportIdentifier).sort();
+  }
   if (path === "@react-three/drei") return extractNamedExports(dreiShim);
   if (path === "@yorishiro/sdk/r3f" || path === "@react-three/fiber") {
     return extractNamedExports(r3fShim);
@@ -360,6 +403,12 @@ function createPlan4MvpPlugin(
         }
         if (args.path === "@react-three/drei") {
           return { contents: dreiShim, loader: "js" };
+        }
+        if (args.path === "@react-three/postprocessing") {
+          return { contents: reactThreePostprocessingShim, loader: "js" };
+        }
+        if (args.path === "postprocessing") {
+          return { contents: postprocessingShim, loader: "js" };
         }
         if (args.path === "@yorishiro/sdk/r3f" || args.path === "@react-three/fiber") {
           return { contents: r3fShim, loader: "js" };

--- a/src/runtime/user-pack-loader/user-pack-loader.test.ts
+++ b/src/runtime/user-pack-loader/user-pack-loader.test.ts
@@ -443,7 +443,11 @@ describe("loadUserPacks", () => {
     const ambientUiRegistry = makeFakeAmbientUiPackRegistry();
     const { subsystem } = makeDevLog();
     const entries: UserPackEntry[] = [
-      { id: "user-ambient", kind: "ambient-ui", entryPath: "/p/user-ambient/ui.js" },
+      {
+        id: "user-ambient",
+        kind: "ambient-ui",
+        entryPath: "/p/user-ambient/ambient-ui.tsx",
+      },
     ];
 
     const result = await loadUserPacks({
@@ -465,7 +469,7 @@ describe("loadUserPacks", () => {
     expect(ambientUiRegistry.entries[0]).toMatchObject({
       id: "user-ambient",
       origin: "user",
-      manifest: { id: "user-ambient", type: "ambient-ui", entry: "ui.js" },
+      manifest: { id: "user-ambient", type: "ambient-ui", entry: "ambient-ui.tsx" },
     });
   });
 
@@ -478,7 +482,7 @@ describe("loadUserPacks", () => {
     const ambientUiRegistry = makeFakeAmbientUiPackRegistry();
     const { subsystem } = makeDevLog();
     const entries: UserPackEntry[] = [
-      { id: "user-ambient", kind: "ambient-ui", entryPath: "/p/user-ambient/ui.js" },
+      { id: "user-ambient", kind: "ambient-ui", entryPath: "/p/user-ambient/ambient-ui.js" },
     ];
 
     await loadUserPacks({

--- a/src/runtime/user-pack-loader/user-pack-loader.ts
+++ b/src/runtime/user-pack-loader/user-pack-loader.ts
@@ -4,8 +4,8 @@
  * 起動時に一度だけ ~/.yorishiro/packs/ を scan し、見つかった entry を dynamic
  * import → validator で shape を確認 → 対応する registrar に register する。
  *
- * effect / persona / scene は Path A + BYOC 方針の `.js` entry。UI pack は
- * Plan 4 MVP で `ui.tsx` を runtime transpile できる。
+ * effect / persona / scene は Path A + BYOC 方針の `.js` entry。UI / scene /
+ * ambient-ui pack は trusted local source として `.tsx` を runtime transpile できる。
  *
  * Philosophy: docs/philosophy/PHILOSOPHY.md「生きた系」
  * Internal design-record: 2026-04-18-user-layer-runtime.md Section 「結論: Path A + BYOC」
@@ -171,6 +171,11 @@ export type LoadSingleResult =
     };
 
 const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+export const userPackEntryFilename = (entryPath: string): string => {
+  const normalized = entryPath.replace(/\\/g, "/");
+  return normalized.slice(normalized.lastIndexOf("/") + 1);
+};
 
 const extractDefault = (mod: unknown): unknown => {
   if (mod === null || typeof mod !== "object") return undefined;
@@ -348,7 +353,7 @@ export async function loadSingleUserPack(
           type: "ui",
           version: "0.0.0",
           yorishiroVersion: "*",
-          entry: entry.entryPath.endsWith(".tsx") ? "ui.tsx" : "ui.js",
+          entry: userPackEntryFilename(entry.entryPath),
         },
         origin: "user",
         pack: {
@@ -370,7 +375,7 @@ export async function loadSingleUserPack(
           type: "ambient-ui",
           version: "0.0.0",
           yorishiroVersion: "*",
-          entry: entry.entryPath.endsWith(".tsx") ? "ui.tsx" : "ui.js",
+          entry: userPackEntryFilename(entry.entryPath),
         },
         pack: { mount: pack.mount },
       });

--- a/src/runtime/user-pack-loader/watcher-logic.test.ts
+++ b/src/runtime/user-pack-loader/watcher-logic.test.ts
@@ -5,11 +5,57 @@
  * test できないので、ここでは pure な分解結果のみを verify する。
  */
 
+import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
+import {
+  DISCOVERED_ONLY_PACK_KINDS,
+  SUPPORTED_PACK_KINDS,
+  TSX_ENTRY_KINDS,
+} from "./supported-kinds";
 import type { YorishiroLayerEvent } from "./watcher-logic";
 import { mapEventToAction, parseLayerPath } from "./watcher-logic";
 
 const HOME = "/Users/sample/.yorishiro";
+
+function quotedValues(source: string): string[] {
+  return Array.from(source.matchAll(/"([a-z-]+)"/g), (match) => match[1]).sort();
+}
+
+describe("Rust discovery contract conformance", () => {
+  it("keeps discovery kinds and TSX entry mapping aligned with the TS runtime", async () => {
+    const rustSource = await readFile(
+      new URL("../../../src-tauri/src/lib.rs", import.meta.url),
+      "utf8",
+    );
+    const rustPackKinds = rustSource.match(/const PACK_KINDS: &\[&str\] = &\[([\s\S]*?)\];/)?.[1];
+    const rustEntryMapping = rustSource.match(
+      /fn entry_file_for_kind\([\s\S]*?\n}\n\nfn read_user_pack_manifest_summary/,
+    )?.[0];
+
+    expect(rustPackKinds, "Rust PACK_KINDS declaration").toBeDefined();
+    expect(rustEntryMapping, "Rust entry_file_for_kind declaration").toBeDefined();
+
+    const tsDiscoveryKinds = [...SUPPORTED_PACK_KINDS, ...DISCOVERED_ONLY_PACK_KINDS].sort();
+    expect(quotedValues(rustPackKinds ?? "")).toEqual(tsDiscoveryKinds);
+
+    const rustTsxKinds = Array.from(
+      (rustEntryMapping ?? "").matchAll(/kind == "([a-z-]+)"/g),
+      (match) => match[1],
+    ).sort();
+    expect(rustTsxKinds).toEqual([...TSX_ENTRY_KINDS].sort());
+
+    for (const kind of tsDiscoveryKinds) {
+      const expectedJs = SUPPORTED_PACK_KINDS.has(kind)
+        ? { type: "pack", id: "contract", kind }
+        : { type: "ignore" };
+      const expectedTsx = TSX_ENTRY_KINDS.has(kind)
+        ? { type: "pack", id: "contract", kind }
+        : { type: "ignore" };
+      expect(parseLayerPath(`${HOME}/packs/contract/${kind}.js`, HOME)).toEqual(expectedJs);
+      expect(parseLayerPath(`${HOME}/packs/contract/${kind}.tsx`, HOME)).toEqual(expectedTsx);
+    }
+  });
+});
 
 describe("parseLayerPath", () => {
   it("recognizes a supported pack kind inside packs/<id>/", () => {

--- a/src/runtime/user-pack-loader/watcher-logic.test.ts
+++ b/src/runtime/user-pack-loader/watcher-logic.test.ts
@@ -33,6 +33,11 @@ describe("parseLayerPath", () => {
       id: "my-room",
       kind: "scene",
     });
+    expect(parseLayerPath(`${HOME}/packs/my-overlay/ambient-ui.tsx`, HOME)).toEqual({
+      type: "pack",
+      id: "my-overlay",
+      kind: "ambient-ui",
+    });
     expect(parseLayerPath(`${HOME}/packs/my-ui/ui.js`, HOME)).toEqual({
       type: "pack",
       id: "my-ui",
@@ -48,16 +53,14 @@ describe("parseLayerPath", () => {
     expect(parseLayerPath("/tmp/elsewhere.js", HOME)).toEqual({ type: "ignore" });
   });
 
-  it("maps nested source files to their owner scene pack", () => {
+  it("maps nested source files to an owner-resolution trigger", () => {
     expect(parseLayerPath(`${HOME}/packs/my-room/lib/lights.tsx`, HOME)).toEqual({
-      type: "pack",
+      type: "pack-source",
       id: "my-room",
-      kind: "scene",
     });
     expect(parseLayerPath(`${HOME}/packs/my-room/lib/palette.ts`, HOME)).toEqual({
-      type: "pack",
+      type: "pack-source",
       id: "my-room",
-      kind: "scene",
     });
   });
 
@@ -129,6 +132,25 @@ describe("mapEventToAction", () => {
     });
   });
 
+  it("maps a modified ambient-ui.tsx file to reload-pack", () => {
+    expect(
+      mapEventToAction(
+        {
+          path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+          kind: "modified",
+          mtimeMs: 1700000000007,
+        },
+        HOME,
+      ),
+    ).toEqual({
+      type: "reload-pack",
+      id: "my-overlay",
+      kind: "ambient-ui",
+      entryPath: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      mtimeMs: 1700000000007,
+    });
+  });
+
   it("maps modified and removed scene.tsx files to scene actions", () => {
     expect(
       mapEventToAction(
@@ -155,17 +177,16 @@ describe("mapEventToAction", () => {
     });
   });
 
-  it("maps nested scene source changes to the owning scene.tsx reload", () => {
+  it("maps nested source changes to runtime owner resolution", () => {
     expect(
       mapEventToAction(
         { path: `${HOME}/packs/my-room/lib/lights.tsx`, kind: "modified", mtimeMs: 1700000000004 },
         HOME,
       ),
     ).toEqual({
-      type: "reload-pack",
+      type: "reload-pack-source",
       id: "my-room",
-      kind: "scene",
-      entryPath: `${HOME}/packs/my-room/scene.tsx`,
+      sourcePath: `${HOME}/packs/my-room/lib/lights.tsx`,
       mtimeMs: 1700000000004,
     });
 
@@ -175,10 +196,9 @@ describe("mapEventToAction", () => {
         HOME,
       ),
     ).toEqual({
-      type: "reload-pack",
+      type: "reload-pack-source",
       id: "my-room",
-      kind: "scene",
-      entryPath: `${HOME}/packs/my-room/scene.tsx`,
+      sourcePath: `${HOME}/packs/my-room/lib/scene.tsx`,
       mtimeMs: 1700000000006,
     });
 
@@ -188,10 +208,9 @@ describe("mapEventToAction", () => {
         HOME,
       ),
     ).toEqual({
-      type: "reload-pack",
+      type: "reload-pack-source",
       id: "my-room",
-      kind: "scene",
-      entryPath: `${HOME}/packs/my-room/scene.tsx`,
+      sourcePath: `${HOME}/packs/my-room/lib/lights.tsx`,
       mtimeMs: 1700000000005,
     });
   });

--- a/src/runtime/user-pack-loader/watcher-logic.ts
+++ b/src/runtime/user-pack-loader/watcher-logic.ts
@@ -10,7 +10,7 @@
  * Internal design-record: 2026-04-18-user-layer-runtime.md「Phase 1-b」Section B4
  */
 
-import { SUPPORTED_PACK_KINDS } from "./supported-kinds";
+import { SUPPORTED_PACK_KINDS, TSX_ENTRY_KINDS } from "./supported-kinds";
 
 export interface YorishiroLayerEvent {
   readonly path: string;
@@ -48,7 +48,6 @@ export type WatcherAction =
   | { readonly type: "ignore"; readonly reason: string };
 
 const stripTrailingSlash = (p: string): string => (p.endsWith("/") ? p.slice(0, -1) : p);
-const TSX_ENTRY_KINDS = new Set(["ui", "scene", "ambient-ui"]);
 const PACK_SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"] as const;
 
 const isPackSourceFile = (path: string): boolean =>

--- a/src/runtime/user-pack-loader/watcher-logic.ts
+++ b/src/runtime/user-pack-loader/watcher-logic.ts
@@ -3,8 +3,8 @@
  *
  * Tauri invoke / dynamic import の impure 部分を持たないので、そのまま vitest
  * で検証できる。`~/.yorishiro/packs/<id>/<kind>.js` convention の parse と、
- * runtime-transpiled `~/.yorishiro/packs/<id>/{ui,scene}.tsx` の parse、
- * scene.tsx が relative import する nested source file の owner entry mapping、
+ * runtime-transpiled `~/.yorishiro/packs/<id>/{ui,scene,ambient-ui}.tsx` の parse、
+ * TSX entry が relative import する nested source file の owner resolution trigger、
  * file event → 何をすべきかの mapping に責任を限定する。
  *
  * Internal design-record: 2026-04-18-user-layer-runtime.md「Phase 1-b」Section B4
@@ -21,6 +21,7 @@ export interface YorishiroLayerEvent {
 /** ~/.yorishiro/ 配下の path を意味ある unit にマップした結果。 */
 export type ParsedLayerPath =
   | { readonly type: "pack"; readonly id: string; readonly kind: string }
+  | { readonly type: "pack-source"; readonly id: string }
   | { readonly type: "init" }
   | { readonly type: "ignore" };
 
@@ -36,12 +37,18 @@ export type WatcherAction =
       readonly entryPath: string;
       readonly mtimeMs: number;
     }
+  | {
+      readonly type: "reload-pack-source";
+      readonly id: string;
+      readonly sourcePath: string;
+      readonly mtimeMs: number;
+    }
   | { readonly type: "remove-pack"; readonly id: string; readonly kind: string }
   | { readonly type: "init-changed"; readonly path: string }
   | { readonly type: "ignore"; readonly reason: string };
 
 const stripTrailingSlash = (p: string): string => (p.endsWith("/") ? p.slice(0, -1) : p);
-const TSX_ENTRY_KINDS = new Set(["ui", "scene"]);
+const TSX_ENTRY_KINDS = new Set(["ui", "scene", "ambient-ui"]);
 const PACK_SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"] as const;
 
 const isPackSourceFile = (path: string): boolean =>
@@ -73,7 +80,7 @@ function isTopLevelEntryPath(
  * `/Users/x/.yorishiro/packs/my-ui/ui.tsx` → { type: "pack", id, kind: "ui" }
  * `/Users/x/.yorishiro/packs/my-room/scene.tsx` → { type: "pack", id, kind: "scene" }
  * `/Users/x/.yorishiro/init.js` → { type: "init" }
- * nested source file → owner scene.tsx の reload action（mapEventToAction で処理）
+ * nested source file → owning TSX entries の reload action（mapEventToAction で処理）
  * その他 → { type: "ignore" }
  *
  * yorishiroHome は trailing slash の有無を問わない。
@@ -105,7 +112,7 @@ export function parseLayerPath(absPath: string, yorishiroHome: string): ParsedLa
   if (segments.length > 2) {
     const leaf = segments[segments.length - 1] ?? "";
     if (isPackSourceFile(leaf)) {
-      return { type: "pack", id, kind: "scene" };
+      return { type: "pack-source", id };
     }
     return { type: "ignore" };
   }
@@ -137,6 +144,14 @@ export function mapEventToAction(event: YorishiroLayerEvent, yorishiroHome: stri
   }
   if (parsed.type === "init") {
     return { type: "init-changed", path: event.path };
+  }
+  if (parsed.type === "pack-source") {
+    return {
+      type: "reload-pack-source",
+      id: parsed.id,
+      sourcePath: event.path,
+      mtimeMs: event.mtimeMs,
+    };
   }
   if (event.kind === "removed") {
     if (!isTopLevelEntryPath(event.path, yorishiroHome, parsed.id, parsed.kind)) {

--- a/src/runtime/user-pack-loader/watcher.test.ts
+++ b/src/runtime/user-pack-loader/watcher.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  channelHandler: null as ((event: unknown) => void) | null,
+  importTsx: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: class {
+    set onmessage(handler: (event: unknown) => void) {
+      mocks.channelHandler = handler;
+    }
+  },
+  convertFileSrc: (path: string) => `https://asset.local${path}`,
+  invoke: mocks.invoke,
+}));
+
+vi.mock("./tsx-transpiler", () => ({
+  importUiTsxEntry: mocks.importTsx,
+}));
+
+import { UserPackRegistry } from "./user-pack-registry";
+import { type StartPackWatcherDeps, startPackWatcher } from "./watcher";
+
+const HOME = "/Users/sample/.yorishiro";
+
+function makeDeps(packReloadEnabled = true) {
+  const ambientRegister = vi.fn(() => ({ dispose: vi.fn() }));
+  const userPackLog = { write: vi.fn() };
+  const deps = {
+    effectPackRunner: { register: vi.fn() },
+    personaRegistry: { register: vi.fn() },
+    scenePackRegistry: {},
+    uiPackRegistry: {},
+    ambientUiPackRegistry: { register: ambientRegister },
+    amenityPackRegistry: {},
+    packRegistry: new UserPackRegistry(),
+    userPackLog,
+    initScriptLog: { write: vi.fn() },
+    packReloadEnabled,
+  } as unknown as StartPackWatcherDeps;
+  return { ambientRegister, deps, userPackLog };
+}
+
+async function startAndEmit(deps: StartPackWatcherDeps, event: unknown): Promise<void> {
+  await startPackWatcher(deps);
+  expect(mocks.channelHandler).not.toBeNull();
+  mocks.channelHandler?.(event);
+}
+
+describe("startPackWatcher ambient-ui TSX reload", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    mocks.channelHandler = null;
+    mocks.importTsx.mockReset();
+    mocks.invoke.mockReset();
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "yorishiro_home_dir") return HOME;
+      if (command === "watch_yorishiro_layer") return undefined;
+      if (command === "list_user_packs") {
+        return [
+          {
+            id: "my-overlay",
+            kind: "ambient-ui",
+            entryPath: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+            source: "local",
+          },
+        ];
+      }
+      throw new Error(`unexpected invoke: ${command}`);
+    });
+    globalThis.fetch = vi.fn(async () => new Response("not found", { status: 404 }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("reloads the discovered ambient-ui.tsx owner after a nested source edit", async () => {
+    const pack = {
+      id: "my-overlay",
+      type: "ambient-ui",
+      mount: () => ({ dispose: () => {} }),
+    };
+    mocks.importTsx.mockResolvedValue({ default: pack });
+    const { ambientRegister, deps } = makeDeps();
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/lib/overlay.tsx`,
+      kind: "modified",
+      mtimeMs: 1700000000100,
+    });
+
+    await vi.waitFor(() => expect(ambientRegister).toHaveBeenCalledTimes(1));
+    expect(mocks.importTsx).toHaveBeenCalledWith(
+      `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      expect.any(Object),
+      { cacheKey: 1700000000100 },
+    );
+    expect(ambientRegister).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "my-overlay",
+        origin: "user",
+        manifest: expect.objectContaining({ entry: "ambient-ui.tsx" }),
+      }),
+    );
+  });
+
+  it("keeps pack imports and registration disabled in safe mode", async () => {
+    const { ambientRegister, deps } = makeDeps(false);
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "modified",
+      mtimeMs: 1700000000200,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.importTsx).not.toHaveBeenCalled();
+    expect(ambientRegister).not.toHaveBeenCalled();
+  });
+
+  it("reports TSX hot-reload import failures without replacing the active pack", async () => {
+    mocks.importTsx.mockRejectedValue(new Error("synthetic compile failure"));
+    const { ambientRegister, deps, userPackLog } = makeDeps();
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "modified",
+      mtimeMs: 1700000000300,
+    });
+
+    await vi.waitFor(() =>
+      expect(userPackLog.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: "reload",
+          note: expect.stringContaining("dynamic import failed"),
+          data: expect.objectContaining({ error: "synthetic compile failure" }),
+        }),
+      ),
+    );
+    expect(ambientRegister).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/user-pack-loader/watcher.ts
+++ b/src/runtime/user-pack-loader/watcher.ts
@@ -39,6 +39,7 @@ import { registerScenePack } from "./scene-pack-integration";
 import {
   type EffectRegistrar,
   type PersonaRegistrar,
+  type UserPackEntry,
   userPackEntryFilename,
 } from "./user-pack-loader";
 import type { UserPackRegistry } from "./user-pack-registry";
@@ -58,6 +59,8 @@ export interface StartPackWatcherDeps {
   readonly initScriptLog: SubsystemLog;
   readonly onInitChanged?: () => void;
   readonly executionEnvironment?: PackExecutionEnvironment;
+  /** safe mode では false。watch は維持するが user pack の import / register は行わない。 */
+  readonly packReloadEnabled?: boolean;
   /**
    * init.js hot reload 用の deps と、現在 active な init scope の holder。
    * 未指定なら従来通り「変更を log + onInitChanged のみ」（reload しない）。
@@ -154,6 +157,15 @@ async function handleLayerEvent(
 ): Promise<void> {
   const action = mapEventToAction(event, yorishiroHome);
 
+  if (
+    deps.packReloadEnabled === false &&
+    (action.type === "reload-pack" ||
+      action.type === "reload-pack-source" ||
+      action.type === "remove-pack")
+  ) {
+    return;
+  }
+
   switch (action.type) {
     case "ignore":
       return;
@@ -177,6 +189,54 @@ async function handleLayerEvent(
     case "reload-pack":
       await reloadPack(action, deps, tauri);
       return;
+
+    case "reload-pack-source":
+      await reloadPackSourceOwners(action, deps, tauri);
+      return;
+  }
+}
+
+async function reloadPackSourceOwners(
+  action: Extract<WatcherAction, { type: "reload-pack-source" }>,
+  deps: StartPackWatcherDeps,
+  tauri: TauriBindings,
+): Promise<void> {
+  let entries: UserPackEntry[];
+  try {
+    entries = await tauri.invoke<UserPackEntry[]>("list_user_packs");
+  } catch (err) {
+    deps.userPackLog.write({
+      phase: "reload",
+      note: `failed to resolve TSX owner for nested source in '${action.id}'`,
+      data: { sourcePath: action.sourcePath, error: errorMessage(err) },
+    });
+    return;
+  }
+
+  const owners = entries.filter(
+    (entry) => entry.id === action.id && entry.entryPath.endsWith(".tsx"),
+  );
+  if (owners.length === 0) {
+    deps.userPackLog.write({
+      phase: "reload",
+      note: `nested source changed for '${action.id}', but no runtime-transpiled TSX owner was found`,
+      data: { sourcePath: action.sourcePath },
+    });
+    return;
+  }
+
+  for (const owner of owners) {
+    await reloadPack(
+      {
+        type: "reload-pack",
+        id: owner.id,
+        kind: owner.kind,
+        entryPath: owner.entryPath,
+        mtimeMs: action.mtimeMs,
+      },
+      deps,
+      tauri,
+    );
   }
 }
 

--- a/src/runtime/user-pack-loader/watcher.ts
+++ b/src/runtime/user-pack-loader/watcher.ts
@@ -36,7 +36,11 @@ import {
 import { applyPersonaDefaults } from "./persona-defaults";
 import { injectPersonaPrompt } from "./persona-md-injection";
 import { registerScenePack } from "./scene-pack-integration";
-import type { EffectRegistrar, PersonaRegistrar } from "./user-pack-loader";
+import {
+  type EffectRegistrar,
+  type PersonaRegistrar,
+  userPackEntryFilename,
+} from "./user-pack-loader";
 import type { UserPackRegistry } from "./user-pack-registry";
 import { mapEventToAction, type WatcherAction, type YorishiroLayerEvent } from "./watcher-logic";
 
@@ -375,7 +379,7 @@ async function reloadPack(
           type: "ui",
           version: "0.0.0",
           yorishiroVersion: "*",
-          entry: action.entryPath.endsWith(".tsx") ? "ui.tsx" : "ui.js",
+          entry: userPackEntryFilename(action.entryPath),
         },
         origin: "user",
         pack: {
@@ -399,7 +403,7 @@ async function reloadPack(
           type: "ambient-ui",
           version: "0.0.0",
           yorishiroVersion: "*",
-          entry: action.entryPath.endsWith(".tsx") ? "ui.tsx" : "ui.js",
+          entry: userPackEntryFilename(action.entryPath),
         },
         pack: { mount: pack.mount },
       });

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -210,7 +210,7 @@ export default {
 
 ### lifecycle と cleanup
 
-`activate(ctx)` は `AmenityHandle`（`{ tools, dispose }`）を返す。
+`activate(ctx)` は `AmenityHandle`（`{ tools, service?, dispose }`）を返す。
 `ctx.signal` は pack disable 時に abort される。`activate` 内で起動した非同期処理は
 この signal を監視して cleanup すること。`dispose()` は disable / 終了で必ず呼ばれる。
 
@@ -219,6 +219,21 @@ Ambient UI に state / 操作を公開する amenity は、handle に任意の `
 `tools` は MCP / host routing 専用であり、Ambient UI には渡らない。必要な command だけを
 別 namespace で実装し、未知の command は reject する。bundled の pomodoro は state と
 `"stop"` のみを service に公開する。
+
+#### Amenity service の stability boundary
+
+通常の public API として SDK が安定保証する共通 envelope は次の4点だけ：
+
+- `ctx.amenities.get(id)` で service を解決できる
+- `service.getState()` が state snapshot を返す
+- `service.execute(command, params?)` が command を実行する
+- amenity が inactive、未登録、または service 非公開なら `get(id)` は `null` を返す
+
+各 amenity 固有の state shape、command 名、params / result shape は、その amenity の
+manifest version に属する contract であり、SDK 全体の共通 stable contract ではない。
+subscribe API、typed helper、community / isolated amenity の permission model も現時点の
+共通 contract には含めない。consumer は対象 amenity の docs と version を確認し、`unknown`
+の state / result を境界で検証する。
 
 ### 環境 event への反応
 
@@ -693,6 +708,9 @@ active amenity が公開した UI 向け service は `ctx.amenities.get(id)` で
 `getState()` と `execute(command, params?)` だけを持ち、registry の列挙・enable/disable や
 MCP tool handlers には触れられない。handle は呼び出しごとに active service を再解決するため、
 長時間 cache しても disable 後の service を操作できない。
+
+SDK 共通で安定保証されるのはこの resolver / `getState` / `execute` envelope と inactive 時の
+非利用可能性まで。state / command の具体的 shape は各 amenity の docs と version に従う。
 
 `ambient-ui.tsx` は Yorishiro が runtime transpile する trusted local source である。
 `react`、`react/jsx-runtime`、`react-dom/client` は host bridge に解決され、host と同じ

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -557,18 +557,20 @@ MCP `get_ui_state` / `set_ui_state` の両方から同じ値を読み書きで�
    `AttentionCueLight` を明示的に mount する。mount している間、default は
    自動で退く（同じ光が二重に点灯することはない）。
    ```tsx
-   // bundled scene.tsx（bundled-packs/scenes/<id>/scene.tsx）からの相対 import 例。
-   // useControlsBridge と同じく src/ を直接参照する（@yorishiro/sdk に相当する
-   // 公開 alias はまだ無い）。
-   import { AttentionCueLight } from '../../../src/runtime/three-runtime/attention-cue-light';
+   import { AttentionCueLight } from '@yorishiro/sdk/attention-cue';
 
    <AttentionCueLight color="#ffb08a" intensityScale={1.8} position={[0, 1.9, 0.6]} />
    ```
    `position` を省略するとキャラの head 位置から自動配置される。明るい scene
    （directional / ambient が強い）では `intensityScale` を上げないと埋もれる。
 3. **完全に消したい**：光そのものを不要とする scene は `useClaimAttentionCue()`
-   だけを呼ぶ（描画は一切しない）。default が退くだけで、attention の通知手段を
-   scene から取り除きたい場合に使う。
+   だけを同じ `@yorishiro/sdk/attention-cue` から import して呼ぶ（描画は一切
+   しない）。default が退くだけで、attention の通知手段を scene から取り除きたい
+   場合に使う。
+
+`@yorishiro/sdk/attention-cue` は local trusted `scene.tsx` の host bridge に含まれる。
+runtime 内部の default component、claim registry、cue store は public contract ではなく、
+Pack から直接 import できない。
 
 ### Bundled scene の参考
 

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -2,6 +2,10 @@
 
 このドキュメントは Yorishiro Pack を書く creator（あるいはその依頼を受けた AI）が読むための API リファレンス。**Pack を書く前に必ず読む**。
 
+`~/.yorishiro/packs/`でlocal sourceを直接書く場合は、先に
+[`docs/decisions/local-source-authoring-contract.md`](../../docs/decisions/local-source-authoring-contract.md)
+を読む。Bundled PackのVite importをlocal Packへそのままコピーできるとは限らない。
+
 ---
 
 ## UGC の Pack 種別（6 種類）

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -627,6 +627,12 @@ export default {
 - `ctx.history.list()` / `snapshot(label?)` / `restore(seq)` — rollback history。
   `restore` は destructive command を Pack に渡さず、host-owned confirmation UX を必ず経由する。
 
+`openExternal` の HTTPS / credential / length validation は、`ctx.app.openExternal()` という
+**supported authoring contract** の保証である。現状の local UI Pack は app と同じ WebView
+realm で実行されるため、これは sandbox や raw Tauri access の runtime enforcement ではない。
+local trusted code は技術的には Tauri opener / IPC へ直接到達でき、この SDK method の追加で
+その到達性や Tauri 側の既存 permission が狭まったとは扱わない。
+
 Tauri API/plugin、`window.__TAURI_INTERNALS__`、`src/bindings/**` は supported authoring
 surface ではない。必要な capability が `ctx` に無ければ raw IPC へ迂回せず、host API と
 permission boundary を先に設計する。

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -19,9 +19,9 @@ Yorishiro の UGC は 6 種類の Pack に分かれる。**どれを書きたい
 | **Effect Pack** | runtime-active（短命） | rendering 実装 | renderer / audio | 最小 API のみ、state を持たない |
 | **Scene Pack** | declarative | 住人の居る場（layer stack）の宣言 | **無し**（pure data） | single-active（同時に 1 つ）、active 選択は config で picks |
 | **UI Pack** | primary UI | Yorishiro の操作面を定義 | three / claim / scene / state / layout / app | single-active（同時に 1 つ）。本体 layout を変更できる |
-| **Ambient UI Pack** | overlay | primary UI を占有せず重ねる視覚 overlay（attention aura など） | renderer / attention | multi-active（複数同時 enable）。`ambient-ui-pack-registry` で管理 |
+| **Ambient UI Pack** | overlay | primary UI を占有せず重ねる視覚 overlay（attention aura など） | attention / amenity services | multi-active（複数同時 enable）。host が lifecycle を管理 |
 
-- `ambient-ui`: overlay 系 pack。`AmbientUiContext.attention` で attention runtime を読み、`#ambient-layer` 内の自身の container に描画する。bundled 例: `attention-aura` (v2 attention のデフォルト visual)。
+- `ambient-ui`: overlay 系 pack。`AmbientUiContext.attention` で attention runtime を読み、必要なら `AmbientUiContext.amenities` から amenity が opt-in した service を使う。`#ambient-layer` 内の自身の container に描画する。
 
 **迷ったら**：
 
@@ -213,6 +213,12 @@ export default {
 `activate(ctx)` は `AmenityHandle`（`{ tools, dispose }`）を返す。
 `ctx.signal` は pack disable 時に abort される。`activate` 内で起動した非同期処理は
 この signal を監視して cleanup すること。`dispose()` は disable / 終了で必ず呼ばれる。
+
+Ambient UI に state / 操作を公開する amenity は、handle に任意の `service` を追加できる。
+`service.getState()` と `service.execute(command, params?)` は UI 向けの明示的な public contract。
+`tools` は MCP / host routing 専用であり、Ambient UI には渡らない。必要な command だけを
+別 namespace で実装し、未知の command は reject する。bundled の pomodoro は state と
+`"stop"` のみを service に公開する。
 
 ### 環境 event への反応
 
@@ -682,6 +688,12 @@ export default {
 } satisfies AmbientUiPackDefinition;
 ```
 
+active amenity が公開した UI 向け service は `ctx.amenities.get(id)` で解決する。inactive、
+未登録、または service を opt-in していない amenity では `null`。返る handle は
+`getState()` と `execute(command, params?)` だけを持ち、registry の列挙・enable/disable や
+MCP tool handlers には触れられない。handle は呼び出しごとに active service を再解決するため、
+長時間 cache しても disable 後の service を操作できない。
+
 `ambient-ui.tsx` は Yorishiro が runtime transpile する trusted local source である。
 `react`、`react/jsx-runtime`、`react-dom/client` は host bridge に解決され、host と同じ
 instance を共有する。SDK の型は `@yorishiro/sdk` から type import する。pack 内の
@@ -694,9 +706,11 @@ relative import は同じ pack directory 内に閉じる。任意の npm package
 reload のどちらも user code を import しない。
 
 `mount` は同期的に `Disposable` を返し、`dispose` で React root、timer、RAF、listener を
-すべて解放する。Ambient UI に渡される attention API は read-only で、persona / system /
-raw Tauri API は持たない。bundled の参考実装は
-`bundled-packs/ambient-ui/attention-aura/ui.tsx`。
+すべて解放する。Ambient UI に渡される attention API は read-only。amenity service は
+amenity 側が明示公開した state / command に限定され、persona / system / raw Tauri API や
+internal registry は持たない。bundled の参考実装は attention observation の
+`bundled-packs/ambient-ui/attention-aura/ui.tsx` と amenity service consumer の
+`bundled-packs/ambient-ui/pomodoro-ui/ui.tsx`。
 
 ---
 

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -28,6 +28,19 @@ Yorishiro の UGC は 6 種類の Pack に分かれる。**どれを書きたい
 - 「操作パネルや layout を差し替えたい」→ UI Pack
 - 「注目状態などを overlay で常時可視化したい」→ Ambient UI Pack
 
+### Bundled settings は authoring sample ではない
+
+`bundled-packs/ui/yorishiro-settings` は app 更新、VRM import、復元 UI を所有する
+system-owned bundled UI であり、通常の UI Pack がコピーできる権限の見本ではない。
+通常の Pack は Tauri API/plugin、`window.__TAURI_INTERNALS__`、`src/bindings/**`、
+app component/runtime、別 bundled Pack の manifest を直接 import せず、
+`@yorishiro/sdk` と明示された host shim だけを supported surface として使う。
+
+settings に残る例外の完全な監査表と SDK 昇格基準は
+[`docs/decisions/system-settings-privileged-boundary.md`](../../docs/decisions/system-settings-privileged-boundary.md)
+を参照。local trusted Pack は現在同じ WebView realm で動くため、これは sandbox の説明ではなく
+authoring contract である。
+
 ---
 
 ## Persona Pack の書き方

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -339,12 +339,18 @@ bundled-packs/scenes/<pack-id>/
 └── README.md
 ```
 
-**user**（flat layout、`.js` 強制）：
+**user**（flat layout）：
 
 ```
 ~/.yorishiro/packs/<pack-id>/
 ├── manifest.json
-└── scene.js               # user が TS から transpile した JS
+└── scene.js               # declarative scene
+
+# R3F component を使う local trusted scene は代わりに：
+~/.yorishiro/packs/<pack-id>/
+├── manifest.json
+├── scene.tsx              # manifest.entry に指定
+└── lib/                   # pack 内の .ts/.tsx は相対 import 可
 ```
 
 > bundled と user で layout が**意図的に非対称**：bundled は本体の一部として種類別、user は flat。混同しない。詳細は `bundled-packs/README.md` および memory `feedback_user_pack_layout`。
@@ -471,6 +477,38 @@ R3F primitive の re-export entry。Scene pack が R3F component を export す�
 本 entry から import することで、Yorishiro 本体と同じ `@react-three/fiber` version を共有する。
 
 詳細: specs/2026-05-03-scene-pack-r3f-component.md §3.2
+
+### Local trusted `scene.tsx` の post-processing
+
+`~/.yorishiro/packs/<id>/scene.tsx` では、次の 2 module を host bridge 経由で import できる。
+
+- `@react-three/postprocessing` — `EffectComposer` / `EffectComposerContext` / `Bloom` / `Noise` / `Vignette` / `ChromaticAberration` / `Scanline` / `ToneMapping` など
+- `postprocessing` — `BlendFunction` / `Effect` / `EffectPass` / `ToneMappingMode` などの low-level API
+
+```tsx
+import { Bloom, EffectComposer, Noise, Vignette } from '@react-three/postprocessing';
+import { BlendFunction, type NoiseEffect } from 'postprocessing';
+
+function PostEffects() {
+  return (
+    <EffectComposer>
+      <Bloom intensity={0.8} blendFunction={BlendFunction.ADD} />
+      <Noise opacity={0.12} />
+      <Vignette darkness={0.45} />
+    </EffectComposer>
+  );
+}
+```
+
+これらは pack 側に dependency を bundle せず、host が保持する React / R3F / Three.js /
+post-processing の同一 instance に解決される。`import type` または named import 内の
+`type` modifier（上例の `NoiseEffect`）は transpile 時に消去され、runtime value にはならない。
+`Effect` や `BlendFunction` など runtime で使う symbol は通常の value import にする。
+
+この経路は任意の npm dependency を許可する仕組みではない。supported host import
+以外の bare import は引き続き reject され、pack 外へ出る relative import も使えない。
+実用例は [`abandoned-factory` の post-process pipeline](../../bundled-packs/scenes/abandoned-factory/lib/post-process.tsx)
+を参照。
 
 ### `@yorishiro/sdk/controls`
 

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -578,6 +578,65 @@ MCP `get_ui_state` / `set_ui_state` の両方から同じ値を読み書きで�
 
 ---
 
+## Ambient UI Pack の書き方
+
+local user ambient-ui pack は `~/.yorishiro/packs/<id>/` に次の形で置く。
+
+```
+~/.yorishiro/packs/my-overlay/
+├── manifest.json
+├── ambient-ui.tsx
+└── lib/
+    └── overlay.tsx
+```
+
+`manifest.json` の `type` は `ambient-ui`、`entry` は `ambient-ui.tsx` とする。
+
+```json
+{
+  "id": "my-overlay",
+  "type": "ambient-ui",
+  "version": "0.1.0",
+  "yorishiroVersion": "^0.1.0",
+  "executionClass": "trusted-main-thread-js",
+  "entry": "ambient-ui.tsx"
+}
+```
+
+```tsx
+import type { AmbientUiPackDefinition } from '@yorishiro/sdk';
+import ReactDOM from 'react-dom/client';
+import { Overlay } from './lib/overlay';
+
+export default {
+  id: 'my-overlay',
+  type: 'ambient-ui',
+  mount(ctx, container) {
+    const root = ReactDOM.createRoot(container);
+    root.render(<Overlay attention={ctx.attention} />);
+    return { dispose: () => root.unmount() };
+  },
+} satisfies AmbientUiPackDefinition;
+```
+
+`ambient-ui.tsx` は Yorishiro が runtime transpile する trusted local source である。
+`react`、`react/jsx-runtime`、`react-dom/client` は host bridge に解決され、host と同じ
+instance を共有する。SDK の型は `@yorishiro/sdk` から type import する。pack 内の
+`.tsx` / `.ts` / `.jsx` / `.js` へ相対 import
+して分割でき、nested source の保存・削除も owning TSX entry の hot reload を起動する。
+
+relative import は同じ pack directory 内に閉じる。任意の npm package、raw Tauri API、
+別 pack への relative import は許可されず、compile/load error は `pack_diagnose` と dev log
+に残る。hot reload に失敗した場合は直前の登録を維持する。safe mode 中は discovery と
+reload のどちらも user code を import しない。
+
+`mount` は同期的に `Disposable` を返し、`dispose` で React root、timer、RAF、listener を
+すべて解放する。Ambient UI に渡される attention API は read-only で、persona / system /
+raw Tauri API は持たない。bundled の参考実装は
+`bundled-packs/ambient-ui/attention-aura/ui.tsx`。
+
+---
+
 ## Asset 参照の規約
 
 ### Shared ref（共有 asset）

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -593,6 +593,44 @@ Pack から直接 import できない。
 
 ---
 
+## UI Pack の host capability
+
+UI Pack の `mount(ctx, container)` に渡される `ctx` では、app metadata、外部 link、
+rollback history を raw Tauri import なしで利用できる。
+
+```tsx
+export default {
+  id: 'about-panel',
+  type: 'ui',
+  layout: {},
+  mount(ctx, container) {
+    const link = document.createElement('button');
+    link.textContent = 'Project website';
+    link.addEventListener('click', () => {
+      void ctx.app.openExternal('https://example.com/project');
+    });
+    container.append(link);
+
+    void ctx.app.getVersion().then((version) => {
+      container.dataset.appVersion = version;
+    });
+
+    return { dispose: () => link.remove() };
+  },
+} satisfies UiPackDefinition;
+```
+
+- `ctx.app.getVersion()` — 実行中 app の version を read-only で返す。
+- `ctx.app.openExternal(url)` — absolute HTTPS URL のみ既定 browser で開く。credentials、
+  relative URL、custom scheme、oversized input は host が reject する。明示的な user gesture
+  からだけ呼び、mount / timer から自動で開かない。
+- `ctx.history.list()` / `snapshot(label?)` / `restore(seq)` — rollback history。
+  `restore` は destructive command を Pack に渡さず、host-owned confirmation UX を必ず経由する。
+
+Tauri API/plugin、`window.__TAURI_INTERNALS__`、`src/bindings/**` は supported authoring
+surface ではない。必要な capability が `ctx` に無ければ raw IPC へ迂回せず、host API と
+permission boundary を先に設計する。
+
 ## Ambient UI Pack の書き方
 
 local user ambient-ui pack は `~/.yorishiro/packs/<id>/` に次の形で置く。

--- a/src/sdk/ambient-ui-pack.d.ts
+++ b/src/sdk/ambient-ui-pack.d.ts
@@ -36,6 +36,8 @@ import type { Disposable } from "./context";
  *
  * `amenities` は active amenity が明示公開した service だけを解決する。
  * registry / activation state mutation / MCP tool handle は公開しない。
+ * SDK が共通で保証するのは resolver と state / command envelope のみで、
+ * 固有 payload shape は対象 amenity の versioned contract に従う。
  */
 export interface AmbientUiContext {
   readonly attention: AttentionAPI;

--- a/src/sdk/ambient-ui-pack.d.ts
+++ b/src/sdk/ambient-ui-pack.d.ts
@@ -28,16 +28,18 @@
  */
 
 import type { AttentionAPI } from "./attention";
+import type { AmenityServicesAPI } from "./amenity-service";
 import type { Disposable } from "./context";
 
 /**
  * Ambient UI pack の mount context。
  *
- * v2 MVP では `attention` のみ。Phase 2 で persona pack の auraAffinity を
- * 読む経路を追加するときに `getActivePersonaAffinity()` 等を生やす。
+ * `amenities` は active amenity が明示公開した service だけを解決する。
+ * registry / activation state mutation / MCP tool handle は公開しない。
  */
 export interface AmbientUiContext {
   readonly attention: AttentionAPI;
+  readonly amenities: AmenityServicesAPI;
 }
 
 /** Ambient UI pack の manifest。kind は文字列上は "ambient-ui"。 */

--- a/src/sdk/ambient-ui-pack.d.ts
+++ b/src/sdk/ambient-ui-pack.d.ts
@@ -2,7 +2,8 @@
  * @yorishiro/sdk/ambient-ui-pack
  *
  * Ambient UI Pack の定義型（5 つ目の pack kind、v2 で追加）。
- * packs/ambient-ui/<id>/ui.tsx では `satisfies AmbientUiPackDefinition` を
+ * local user pack は `~/.yorishiro/packs/<id>/ambient-ui.tsx`、bundled pack は
+ * `bundled-packs/ambient-ui/<id>/ui.tsx` で `satisfies AmbientUiPackDefinition` を
  * 使って export default する。
  *
  * Ambient UI は primary UI を上書きしない overlay layer に出る pack。

--- a/src/sdk/ambient-ui-pack.d.ts
+++ b/src/sdk/ambient-ui-pack.d.ts
@@ -48,6 +48,10 @@ export interface AmbientUiPackManifest {
   readonly type: "ambient-ui";
   readonly version: string;
   readonly yorishiroVersion: string;
+  /** local Pack の import 前に検証する最小 app version（exact SemVer）。 */
+  readonly minClientVersion?: string;
+  /** local Pack の load を許可する platform。 */
+  readonly platform?: ReadonlyArray<"macos" | "windows" | "linux">;
   readonly description?: string;
   readonly executionClass?: "declarative" | "isolated-js" | "trusted-main-thread-js";
   readonly artifact?: {

--- a/src/sdk/amenity-service-authoring-guidance.test.ts
+++ b/src/sdk/amenity-service-authoring-guidance.test.ts
@@ -1,0 +1,35 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+const resource = (language: "en" | "ja", command: "create" | "help" | "update") =>
+  new URL(
+    `../../src-tauri/resources/yorishiro-plugin/commands-${language}/${command}.md`,
+    import.meta.url,
+  );
+
+describe("Amenity service authoring guidance", () => {
+  it.each([
+    "en",
+    "ja",
+  ] as const)("routes %s Ambient UI authoring through the public service boundary", async (language) => {
+    const [create, help, update] = await Promise.all([
+      readFile(resource(language, "create"), "utf8"),
+      readFile(resource(language, "help"), "utf8"),
+      readFile(resource(language, "update"), "utf8"),
+    ]);
+
+    expect(create).toContain("AmenityHandle.service");
+    expect(create).toContain("ctx.amenities");
+    expect(create).toContain("getState()");
+    expect(create).toContain("execute()");
+    expect(create).toContain("globalThis");
+    expect(create).toContain("pomodoro-ui");
+    expect(help).toContain("ctx.amenities");
+    expect(update).toContain("AmenityHandle.service");
+    expect(update).toContain("ctx.amenities");
+    expect(update).toContain("getState()");
+    expect(update).toContain("execute(command, params?)");
+    expect(update).toContain("globalThis");
+    expect(update).toContain("pomodoro-ui");
+  });
+});

--- a/src/sdk/amenity-service-bundled-conformance.test.ts
+++ b/src/sdk/amenity-service-bundled-conformance.test.ts
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const pomodoroUiPath = join(
+  import.meta.dirname,
+  "../../bundled-packs/ambient-ui/pomodoro-ui/ui.tsx",
+);
+
+describe("bundled ambient UI amenity service contract", () => {
+  it("pomodoro-ui consumes the public mount context without an internal registry import", async () => {
+    const source = await readFile(pomodoroUiPath, "utf8");
+
+    expect(source).toContain('from "@yorishiro/sdk"');
+    expect(source).toContain('amenities.get("pomodoro")');
+    expect(source).not.toContain("getAmenityPackRegistry");
+    expect(source).not.toContain("src/runtime/");
+  });
+});

--- a/src/sdk/amenity-service-bundled-conformance.test.ts
+++ b/src/sdk/amenity-service-bundled-conformance.test.ts
@@ -6,6 +6,10 @@ const pomodoroUiPath = join(
   import.meta.dirname,
   "../../bundled-packs/ambient-ui/pomodoro-ui/ui.tsx",
 );
+const pomodoroAmenityPath = join(
+  import.meta.dirname,
+  "../../bundled-packs/amenities/pomodoro/amenity.ts",
+);
 
 describe("bundled ambient UI amenity service contract", () => {
   it("pomodoro-ui consumes the public mount context without an internal registry import", async () => {
@@ -15,5 +19,15 @@ describe("bundled ambient UI amenity service contract", () => {
     expect(source).toContain('amenities.get("pomodoro")');
     expect(source).not.toContain("getAmenityPackRegistry");
     expect(source).not.toContain("src/runtime/");
+    expect(source).not.toContain("globalThis");
+  });
+
+  it("pomodoro exposes a narrow service separately from MCP tools", async () => {
+    const source = await readFile(pomodoroAmenityPath, "utf8");
+
+    expect(source).toContain("service: {");
+    expect(source).toContain("getState: async () => timer.status()");
+    expect(source).toContain('command === "stop"');
+    expect(source).not.toContain("globalThis");
   });
 });

--- a/src/sdk/amenity-service.d.ts
+++ b/src/sdk/amenity-service.d.ts
@@ -3,11 +3,17 @@
  *
  * Ambient UI が active amenity の明示的に公開された state / command を使うための
  * public capability boundary。AmenityPackRegistry や MCP tool handle は公開しない。
+ *
+ * Stable な共通 contract は `ctx.amenities.get(id)`、`getState()`、
+ * `execute(command, params)` と、inactive 時に `get` が `null` を返すことだけ。
+ * state shape、command 名・params・result は各 amenity が version 管理する。
+ * subscribe、typed helper、community / isolated pack の permission model は
+ * この共通 contract に含めない。
  */
 
 /** Ambient UI に公開してよい state / command だけを持つ amenity 側 surface。 */
 export interface AmenityServiceHandle {
-  /** 現在の state snapshot を返す。shape は amenity ごとの public contract。 */
+  /** 現在の state snapshot。shape と互換性は amenity ごとの versioned contract。 */
   readonly getState: () => Promise<unknown>;
 
   /**
@@ -17,8 +23,8 @@ export interface AmenityServiceHandle {
   readonly execute: (command: string, params?: unknown) => Promise<unknown>;
 }
 
-/** AmbientUiContext に注入される、active amenity service の read-only resolver。 */
+/** AmbientUiContext に注入される active amenity service resolver。 */
 export interface AmenityServicesAPI {
-  /** active かつ service を公開している amenity の handle。該当しなければ null。 */
+  /** active かつ service を公開している amenity の handle。inactive 等では null。 */
   get(id: string): AmenityServiceHandle | null;
 }

--- a/src/sdk/amenity-service.d.ts
+++ b/src/sdk/amenity-service.d.ts
@@ -1,0 +1,24 @@
+/**
+ * @yorishiro/sdk/amenity-service
+ *
+ * Ambient UI が active amenity の明示的に公開された state / command を使うための
+ * public capability boundary。AmenityPackRegistry や MCP tool handle は公開しない。
+ */
+
+/** Ambient UI に公開してよい state / command だけを持つ amenity 側 surface。 */
+export interface AmenityServiceHandle {
+  /** 現在の state snapshot を返す。shape は amenity ごとの public contract。 */
+  readonly getState: () => Promise<unknown>;
+
+  /**
+   * amenity が Ambient UI 向けに明示公開した command を実行する。
+   * MCP tool 名・handler とは別 namespace で、未知の command は reject する。
+   */
+  readonly execute: (command: string, params?: unknown) => Promise<unknown>;
+}
+
+/** AmbientUiContext に注入される、active amenity service の read-only resolver。 */
+export interface AmenityServicesAPI {
+  /** active かつ service を公開している amenity の handle。該当しなければ null。 */
+  get(id: string): AmenityServiceHandle | null;
+}

--- a/src/sdk/amenity.d.ts
+++ b/src/sdk/amenity.d.ts
@@ -26,6 +26,8 @@ export interface AmenityHandle {
   /**
    * Ambient UI 向けの opt-in public surface。
    * tools は MCP / host routing 専用であり Ambient UI には公開されない。
+   * state / command の固有 shape はこの amenity の versioned contract であり、
+   * SDK 共通の stable envelope には含まれない。
    */
   readonly service?: AmenityServiceHandle;
   /** pack disable / アプリ終了時に呼ばれる後片付け。 */

--- a/src/sdk/amenity.d.ts
+++ b/src/sdk/amenity.d.ts
@@ -104,6 +104,10 @@ export interface AmenityPackManifest {
   readonly type: "amenity";
   readonly version: string;
   readonly yorishiroVersion: string;
+  /** local Pack の import 前に検証する最小 app version（exact SemVer）。 */
+  readonly minClientVersion?: string;
+  /** local Pack の load を許可する platform。 */
+  readonly platform?: ReadonlyArray<"macos" | "windows" | "linux">;
   readonly entry: string;
   readonly description?: string;
   readonly executionClass?: "declarative" | "isolated-js" | "trusted-main-thread-js";

--- a/src/sdk/amenity.d.ts
+++ b/src/sdk/amenity.d.ts
@@ -14,6 +14,7 @@
  */
 
 import type { AmenityContext } from "./context";
+import type { AmenityServiceHandle } from "./amenity-service";
 import type { Trigger } from "./reaction";
 
 // ─── AmenityHandle ───────────────────────────────────────
@@ -22,6 +23,11 @@ import type { Trigger } from "./reaction";
 export interface AmenityHandle {
   /** この amenity が提供する tool handler。key は tool 名。 */
   readonly tools: Readonly<Record<string, AmenityToolHandler>>;
+  /**
+   * Ambient UI 向けの opt-in public surface。
+   * tools は MCP / host routing 専用であり Ambient UI には公開されない。
+   */
+  readonly service?: AmenityServiceHandle;
   /** pack disable / アプリ終了時に呼ばれる後片付け。 */
   readonly dispose: () => void;
 }

--- a/src/sdk/attention-cue-bundled-conformance.test.ts
+++ b/src/sdk/attention-cue-bundled-conformance.test.ts
@@ -1,0 +1,15 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const bundledScenesRoot = join(import.meta.dirname, "../../bundled-packs/scenes");
+const attentionCueScenes = ["abandoned-factory", "misty-grasslands", "simple-room"] as const;
+
+describe("bundled attention cue authoring contract", () => {
+  it.each(attentionCueScenes)("%s uses the same public SDK entry as local scenes", async (id) => {
+    const source = await readFile(join(bundledScenesRoot, id, "scene.tsx"), "utf8");
+
+    expect(source).toContain('from "@yorishiro/sdk/attention-cue"');
+    expect(source).not.toContain("src/runtime/three-runtime/attention-cue-light");
+  });
+});

--- a/src/sdk/attention-cue.test.ts
+++ b/src/sdk/attention-cue.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  DefaultAttentionCueLight,
+  AttentionCueLight as RuntimeAttentionCueLight,
+  useClaimAttentionCue as useRuntimeClaimAttentionCue,
+} from "../runtime/three-runtime/attention-cue-light";
+import * as AttentionCueSdk from "./attention-cue";
+
+describe("@yorishiro/sdk/attention-cue", () => {
+  it("reuses the host runtime component and claim hook", () => {
+    expect(AttentionCueSdk.AttentionCueLight).toBe(RuntimeAttentionCueLight);
+    expect(AttentionCueSdk.useClaimAttentionCue).toBe(useRuntimeClaimAttentionCue);
+  });
+
+  it("does not expose the runtime-owned default component", () => {
+    expect(Object.values(AttentionCueSdk)).not.toContain(DefaultAttentionCueLight);
+    expect(Object.keys(AttentionCueSdk).sort()).toEqual([
+      "AttentionCueLight",
+      "useClaimAttentionCue",
+    ]);
+  });
+});

--- a/src/sdk/attention-cue.ts
+++ b/src/sdk/attention-cue.ts
@@ -1,0 +1,28 @@
+/**
+ * @yorishiro/sdk/attention-cue
+ *
+ * Scene Pack が runtime の attention cue を描画・claim するための public entry。
+ * runtime の registry / default light / test injection surface は公開せず、Pack 作者に
+ * 必要な component と hook だけを選択して公開する。
+ */
+
+import type { ComponentType } from "react";
+import {
+  AttentionCueLight as RuntimeAttentionCueLight,
+  useClaimAttentionCue as useRuntimeClaimAttentionCue,
+} from "../runtime/three-runtime/attention-cue-light";
+
+export interface AttentionCueLightProps {
+  /** 未指定なら cue 開始時のキャラクター head 位置から自動配置する。 */
+  readonly position?: readonly [number, number, number];
+  readonly color?: string;
+  readonly intensityScale?: number;
+}
+
+/**
+ * Scene 所有の attention cue light。mount 中は runtime の yielding default を退かせる。
+ */
+export const AttentionCueLight: ComponentType<AttentionCueLightProps> = RuntimeAttentionCueLight;
+
+/** 描画せずに yielding default だけを退かせる。 */
+export const useClaimAttentionCue: () => void = useRuntimeClaimAttentionCue;

--- a/src/sdk/bundled-scene-authoring-contract.test.ts
+++ b/src/sdk/bundled-scene-authoring-contract.test.ts
@@ -1,0 +1,39 @@
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const bundledScenesRoot = join(import.meta.dirname, "../../bundled-packs/scenes");
+
+async function collectSourcePaths(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const paths = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) return collectSourcePaths(path);
+      return [".ts", ".tsx"].includes(extname(entry.name)) ? [path] : [];
+    }),
+  );
+  return paths.flat();
+}
+
+describe("bundled scene authoring contract", () => {
+  it("imports useControlsBridge from the public controls SDK", async () => {
+    const sourcePaths = await collectSourcePaths(bundledScenesRoot);
+    const failures: string[] = [];
+
+    for (const sourcePath of sourcePaths) {
+      const source = await readFile(sourcePath, "utf8");
+      if (!source.includes("useControlsBridge(")) continue;
+
+      const importsPublicBridge =
+        /import\s*\{[^}]*\buseControlsBridge\b[^}]*\}\s*from\s*["']@yorishiro\/sdk\/controls["']/.test(
+          source,
+        );
+      if (!importsPublicBridge) {
+        failures.push(relative(bundledScenesRoot, sourcePath));
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/src/sdk/bundled-sdk-dts.test.ts
+++ b/src/sdk/bundled-sdk-dts.test.ts
@@ -94,5 +94,5 @@ describe("distributed sdk.d.ts", () => {
     } finally {
       await rm(tempDir, { force: true, recursive: true });
     }
-  });
+  }, 20_000);
 });

--- a/src/sdk/bundled-sdk-dts.test.ts
+++ b/src/sdk/bundled-sdk-dts.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(import.meta.dirname, "../..");
+const rustSourcePath = join(repoRoot, "src-tauri/src/lib.rs");
+
+function isModuleStatementStart(line: string): boolean {
+  const trimmed = line.trimStart();
+  return (
+    trimmed.startsWith("import ") ||
+    trimmed.startsWith("export *") ||
+    trimmed.startsWith("export type {") ||
+    trimmed.startsWith("export {")
+  );
+}
+
+function flattenSdkPart(source: string): string {
+  const output: string[] = [];
+  let statement: string[] | null = null;
+
+  for (const line of source.split("\n")) {
+    if (statement !== null) {
+      statement.push(line);
+      if (line.trimEnd().endsWith(";")) {
+        const joined = statement.join("\n");
+        if (!joined.includes('from "./') && !joined.includes("from './")) output.push(joined);
+        statement = null;
+      }
+      continue;
+    }
+    if (isModuleStatementStart(line)) {
+      if (line.trimEnd().endsWith(";")) {
+        if (!line.includes('from "./') && !line.includes("from './")) output.push(line);
+      } else {
+        statement = [line];
+      }
+      continue;
+    }
+    output.push(line);
+  }
+  if (statement !== null) output.push(statement.join("\n"));
+  return output.join("\n");
+}
+
+async function buildDistributedSdkDts(): Promise<string> {
+  const rustSource = await readFile(rustSourcePath, "utf8");
+  const partsBlock = rustSource.match(
+    /const SDK_DTS_PARTS: &\[\(&str, &str\)\] = &\[([\s\S]*?)\n\];/,
+  )?.[1];
+  expect(partsBlock, "SDK_DTS_PARTS must be present").toBeDefined();
+
+  const partNames = Array.from(
+    partsBlock?.matchAll(/include_str!\("\.\.\/\.\.\/src\/sdk\/([^"\n]+)"\)/g) ?? [],
+    (match) => match[1],
+  );
+  expect(partNames).toContain("amenity-service.d.ts");
+
+  const chunks: string[] = [];
+  for (const partName of partNames) {
+    const source = await readFile(join(repoRoot, "src/sdk", partName), "utf8");
+    chunks.push(flattenSdkPart(source));
+  }
+  return chunks.join("\n\n");
+}
+
+describe("distributed sdk.d.ts", () => {
+  it("includes the amenity service envelope without unresolved type references", async () => {
+    const bundle = await buildDistributedSdkDts();
+    const tempDir = await mkdtemp(join(repoRoot, ".sdk-dts-test-"));
+    const bundlePath = join(tempDir, "sdk.d.ts");
+
+    try {
+      await writeFile(bundlePath, bundle);
+      const program = ts.createProgram([bundlePath], {
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        noEmit: true,
+        skipLibCheck: false,
+        strict: true,
+        target: ts.ScriptTarget.ES2020,
+      });
+      const diagnostics = ts
+        .getPreEmitDiagnostics(program)
+        .filter((diagnostic) => diagnostic.file?.fileName === bundlePath);
+      const messages = diagnostics.map((diagnostic) =>
+        ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+      );
+
+      expect(bundle).toContain("export interface AmenityServiceHandle");
+      expect(bundle).toContain("export interface AmenityServicesAPI");
+      expect(messages).toEqual([]);
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/src/sdk/index.d.ts
+++ b/src/sdk/index.d.ts
@@ -23,6 +23,7 @@ export type {
   AmenityToolHandler,
   AmenityToolMeta,
 } from "./amenity";
+export type { AmenityServiceHandle, AmenityServicesAPI } from "./amenity-service";
 export type {
   AmbientUiContext,
   AmbientUiPackDefinition,

--- a/src/sdk/persona-pack.d.ts
+++ b/src/sdk/persona-pack.d.ts
@@ -37,6 +37,10 @@ export interface PersonaPackManifest {
   readonly type: "persona";
   readonly version: string;
   readonly yorishiroVersion: string;
+  /** local Pack の import 前に検証する最小 app version（exact SemVer）。 */
+  readonly minClientVersion?: string;
+  /** local Pack の load を許可する platform。 */
+  readonly platform?: ReadonlyArray<"macos" | "windows" | "linux">;
   readonly description?: string;
   readonly executionClass?: "declarative" | "isolated-js" | "trusted-main-thread-js";
   readonly artifact?: {

--- a/src/sdk/scene-pack.d.ts
+++ b/src/sdk/scene-pack.d.ts
@@ -47,6 +47,10 @@ export interface ScenePackManifest {
   readonly type: "scene";
   readonly version: string;
   readonly yorishiroVersion: string;
+  /** local Pack の import 前に検証する最小 app version（exact SemVer）。 */
+  readonly minClientVersion?: string;
+  /** local Pack の load を許可する platform。 */
+  readonly platform?: ReadonlyArray<"macos" | "windows" | "linux">;
   readonly description?: string;
   readonly executionClass?: "declarative" | "isolated-js" | "trusted-main-thread-js";
   readonly artifact?: {

--- a/src/sdk/settings-privileged-boundary.test.ts
+++ b/src/sdk/settings-privileged-boundary.test.ts
@@ -1,0 +1,64 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const settingsRoot = join(import.meta.dirname, "../../bundled-packs/ui/yorishiro-settings");
+
+async function readSettingsSource(): Promise<string> {
+  return readFile(join(settingsRoot, "ui.tsx"), "utf8");
+}
+
+function importedModuleIds(source: string): string[] {
+  return Array.from(source.matchAll(/(?:from\s+|import\()["']([^"']+)["']/g), (match) => match[1])
+    .filter((value): value is string => value !== undefined)
+    .sort();
+}
+
+describe("system settings privileged boundary", () => {
+  it("marks the bundled settings UI as trusted main-thread code", async () => {
+    const manifest = JSON.parse(await readFile(join(settingsRoot, "manifest.json"), "utf8"));
+    expect(manifest.executionClass).toBe("trusted-main-thread-js");
+  });
+
+  it("keeps raw Tauri and app-internal imports on the reviewed allowlist", async () => {
+    const source = await readSettingsSource();
+    const privilegedImports = importedModuleIds(source).filter(
+      (moduleId) =>
+        moduleId.startsWith("@tauri-apps/") ||
+        moduleId.startsWith("../../../src/") ||
+        moduleId === "../../scenes/simple-room/manifest.json",
+    );
+
+    expect(privilegedImports).toEqual([
+      "../../../src/i18n/strings",
+      "../../../src/runtime/history/describe-snapshot",
+      "../../../src/runtime/language/language",
+      "../../../src/runtime/updater/app-updater",
+      "../../../src/runtime/user-pack-loader/config",
+      "../../scenes/simple-room/manifest.json",
+      "@tauri-apps/api/core",
+      "@tauri-apps/plugin-dialog",
+    ]);
+  });
+
+  it("uses raw invoke only for the reviewed VRM import command", async () => {
+    const source = await readSettingsSource();
+    const invokedCommands = Array.from(
+      source.matchAll(/\binvoke(?:<[^>]+>)?\(\s*["']([^"']+)["']/g),
+      (match) => match[1],
+    );
+    expect(invokedCommands).toEqual(["import_vrm"]);
+  });
+
+  it("uses public capabilities for generic app metadata, links, and history", async () => {
+    const source = await readSettingsSource();
+
+    expect(source).toMatch(/ctx\.app\s*\.\s*getVersion\(\)/);
+    expect(source).toMatch(/ctx\.app\s*\.\s*openExternal\(/);
+    expect(source).toMatch(/ctx\.history\s*\.\s*list\(\)/);
+    expect(source).toMatch(/ctx\.history\s*\.\s*restore\(seq\)/);
+    expect(source).not.toContain("src/bindings/");
+    expect(source).not.toContain("src/components/");
+    expect(source).not.toContain("src/sdk/");
+  });
+});

--- a/src/sdk/ui-pack.d.ts
+++ b/src/sdk/ui-pack.d.ts
@@ -19,6 +19,7 @@
 import type { VRM } from "@pixiv/three-vrm";
 import type * as THREE from "three";
 import type { CharacterAPI, Disposable, LogAPI, SpaceAPI, Time, TweenAPI } from "./context";
+import type { HistoryAPI } from "./history";
 import type { LayerRole, SceneSpec } from "./scene";
 
 export type AppLanguage = "auto" | "en" | "ja";
@@ -206,6 +207,17 @@ export type FixedTerminalPromptKey = "help" | "tutorial" | "shortcut" | "create-
  * 将来 app-level の他 state を expose する余地を残すため namespace を切る。
  */
 export interface UiAppAPI {
+  /** Read the version of the running Yorishiro app. */
+  getVersion(): Promise<string>;
+  /**
+   * Open an absolute HTTPS URL in the user's default browser.
+   *
+   * The host rejects other schemes, relative URLs, embedded credentials, and
+   * oversized values. Call this only from an explicit user gesture such as a
+   * link or button; opening a URL during mount or from a timer violates the
+   * UI Pack authoring contract.
+   */
+  openExternal(url: string): Promise<void>;
   /**
    * VRM body を切り替える。localStorage 永続化と App-level vrmPath state への
    * 反映を行う。`null` で custom VRM の選択を解除し、同梱 Yori に戻す。
@@ -318,6 +330,11 @@ export interface UiContext {
   readonly state: UiStateAPI;
   readonly time: Time;
   readonly log: LogAPI;
+  /**
+   * Pack rollback history. Restore always goes through host-owned confirmation
+   * UX; a UI Pack cannot invoke the raw destructive restore command.
+   */
+  readonly history: HistoryAPI;
   readonly signal: AbortSignal;
   readonly layout: UiLayoutAPI;
   /** App-level state への bridge（VRM 切替など）。 */

--- a/src/sdk/ui-pack.d.ts
+++ b/src/sdk/ui-pack.d.ts
@@ -109,6 +109,10 @@ export interface UiPackManifest {
   readonly type: "ui";
   readonly version: string;
   readonly yorishiroVersion: string;
+  /** local Pack の import 前に検証する最小 app version（exact SemVer）。 */
+  readonly minClientVersion?: string;
+  /** local Pack の load を許可する platform。 */
+  readonly platform?: ReadonlyArray<"macos" | "windows" | "linux">;
   readonly description?: string;
   readonly executionClass?: "declarative" | "isolated-js" | "trusted-main-thread-js";
   readonly artifact?: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,14 @@ export default defineConfig(async () => ({
     // Scene packs and the custom R3F host must always resolve the same module
     // instances. This is especially important in dev, where Vite can otherwise
     // keep an older optimized dependency generation alive across HMR updates.
-    dedupe: ["react", "react-dom", "@react-three/fiber", "three"],
+    dedupe: [
+      "react",
+      "react-dom",
+      "@react-three/fiber",
+      "@react-three/postprocessing",
+      "postprocessing",
+      "three",
+    ],
   },
 
   // Discover the complete R3F graph before the WebView starts. A late

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,10 @@ export default defineConfig(async () => ({
   resolve: {
     alias: [
       {
+        find: /^@yorishiro\/sdk\/attention-cue$/,
+        replacement: new URL("./src/sdk/attention-cue.ts", import.meta.url).pathname,
+      },
+      {
         find: /^@yorishiro\/sdk\/controls$/,
         replacement: new URL("./src/sdk/controls.ts", import.meta.url).pathname,
       },


### PR DESCRIPTION
## Summary

- expose shared-instance `@react-three/postprocessing` and `postprocessing` host bridges for local Scene TSX
- add local `ambient-ui.tsx` discovery, runtime compilation, hot reload, diagnostics, and authoring types
- migrate bundled controls and attention-cue usage to public SDK contracts
- add a minimal stable Amenity-to-Ambient-UI service envelope and migrate Pomodoro away from the internal registry
- define the system-owned Settings exception while promoting narrowly mediated version, HTTPS link, and confirmed history capabilities
- document and test the local source authoring contract, including Pack containment, version/platform gates, asset resolution, and distributed SDK declarations

## Why

Issue #121 exposed a broader contract problem: bundled Packs and local user Packs used different build paths, while the supported authoring capabilities, ownership, exceptions, and update policy were not maintained as one explicit contract. The result was repeated silent drift even when bundled Packs demonstrated the desired capability.

This change provides user-visible semantic capabilities through stable public host APIs without exposing internal registries, raw Tauri APIs, arbitrary npm imports, or cross-Pack relative imports.

Closes #121.

## User and developer impact

- local Scene authors can use the same post-processing packages and host instances as bundled scenes
- local Ambient UI authors can use TSX and receive the same reload/diagnostic behavior as other TSX Pack kinds
- bundled reference Packs now dogfood the public controls and attention-cue contracts
- user Amenities can publish an explicit state/command service for Ambient UI without exposing the Amenity registry or MCP handlers
- authoring documentation now distinguishes third-party host-module bridges, curated host-internal capabilities, and system-owned exceptions

The common stable Amenity service guarantee is intentionally limited to lookup, state read, command execution, and inactive-service failure. Amenity-specific payload shapes and future subscription/permission mechanisms remain separate versioned contracts.

## Bounded GPU E2E

A dedicated app instance used an isolated test home and ports, leaving the normal app untouched. A real local Scene exercised GLSL `ShaderMaterial` particles, `InstancedMesh`, `WebGLRenderTarget`, the shared R3F renderer, `EffectComposer`, `Bloom`, `Noise`, `Vignette`, and lower-level `BlendFunction`.

After a v1-to-v2 hot reload and a full scene switch away/back, diagnostics reported:

```json
{
  "version": "v2",
  "renderer": "WebGLRenderer",
  "mounts": 4,
  "disposals": 3,
  "mounted": true,
  "resourcesDisposed": true
}
```

`list_load_errors` returned no errors. This is bounded evidence for the tested macOS/runtime configuration, not a broad GPU compatibility or resource-budget guarantee.

## Validation

- `npm run test:run` — 188 files / 2,401 tests passed
- `npm run test:rust` — 309 tests passed
- `npm run check` — TypeScript, Biome, rustfmt, and clippy passed
- `npm run build` — passed; existing large-chunk warning only
- pre-push TypeScript, Biome, rustfmt, clippy, and TypeDoc validation — passed

One intentionally concurrent cold Rust build caused the distributed-SDK compiler test to exceed its 20-second timeout without a type error. The complete frontend suite passed when rerun under its normal aggregate-test conditions.

## Deliberately retained boundaries

- local TSX/JS remains `trusted-main-thread-js`; this PR is not a sandbox claim
- safe mode remains recovery behavior, not an attack boundary
- raw Tauri, arbitrary npm dependencies, and cross-Pack relative imports remain unsupported
- `three/addons/*`, `GPUComputationRenderer`, long-duration performance guarantees, and GPU resource policy remain out of scope

## Review

The implementation strategy and resulting design records received independent Sol and Fable reviews. Fable's final documentation review was `approve with changes`; all requested precision changes were applied in the companion design-record PR.
