### PR TITLE
Restore active Ambient UI after hot reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1765,6 +1765,11 @@ function App() {
             initScriptLog: createSubsystemLog(devLog, "InitScript"),
             tweenManager: getThreeRuntime().getTweenManager(),
             createAmenityContext,
+            // watcher の再登録は旧 handle の dispose で active membership も外す。
+            // register 完了後に config を唯一の正として再同期し、選択済みだけを
+            // 即時 mount 対象へ戻す（inactive pack は有効化しない）。
+            onAmbientUiRegistered: () =>
+              resyncAmbientUiActiveSetFromConfig("ambient-ui-hot-reload"),
             // init.js は hot reload される。成功したら error marker を外し、
             // 失敗時だけ marker を付けて、前の init scope が維持されていることを可視化する。
             onInitReloaded: ({ ran, missing }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,7 +126,10 @@ import {
 import { useReloadCurtain } from "./reload-curtain";
 import { createBodyStateExpressionAdapter } from "./runtime/agent-state-expression";
 import { type AmbientAudioRuntime, initAmbientAudio } from "./runtime/ambient-audio";
-import { getAmbientUiPackRegistry } from "./runtime/ambient-ui-pack-registry";
+import {
+  type AmbientUiPackEntry,
+  getAmbientUiPackRegistry,
+} from "./runtime/ambient-ui-pack-registry";
 import { getAmenityPackRegistry } from "./runtime/amenity-pack-registry";
 import { createAmenityServices } from "./runtime/amenity-services";
 import {
@@ -302,7 +305,12 @@ import {
   type StageSurfaces,
 } from "./runtime/ui-pack-transition/stage-transition";
 import { getUiStateStore } from "./runtime/ui-state-store";
-import { loadUserLayer, reloadSingleUserPack, UserPackRegistry } from "./runtime/user-pack-loader";
+import {
+  loadUserLayer,
+  reconcileAmbientUiRegistration,
+  reloadSingleUserPack,
+  UserPackRegistry,
+} from "./runtime/user-pack-loader";
 import { createUserAmenityContextFactory } from "./runtime/user-pack-loader/amenity-activation";
 import {
   listCodexRealtimeVoiceCandidatesForPersona,
@@ -326,6 +334,7 @@ import {
   readLastStartupReport,
   readSessionPersonasText,
   readYorishiroConfigText,
+  readYorishiroConfigTextStrict,
   writeSessionPersonasText,
   writeYorishiroConfigText,
 } from "./runtime/user-pack-loader/yorishiro-io";
@@ -1765,11 +1774,21 @@ function App() {
             initScriptLog: createSubsystemLog(devLog, "InitScript"),
             tweenManager: getThreeRuntime().getTweenManager(),
             createAmenityContext,
-            // watcher の再登録は旧 handle の dispose で active membership も外す。
-            // register 完了後に config を唯一の正として再同期し、選択済みだけを
-            // 即時 mount 対象へ戻す（inactive pack は有効化しない）。
-            onAmbientUiRegistered: () =>
-              resyncAmbientUiActiveSetFromConfig("ambient-ui-hot-reload"),
+            onAmbientUiRegistered: async (event) => {
+              const reconciliation = await reconcileAmbientUiRegistration(event, {
+                registry: getAmbientUiPackRegistry(),
+                readConfigText: readYorishiroConfigTextStrict,
+                // Presence は aura だけを抑止する。pomodoro 等、他 overlay の
+                // selection/runtime state はこの判定に巻き込まない。
+                isRuntimeSuppressed: (id) =>
+                  id === "attention-aura" && getPresenceState().level === "closed",
+              });
+              appLog.write({
+                phase: "ambient-ui-hot-reload",
+                note: `reconciled ambient-ui '${event.id}' (${reconciliation.status})`,
+                data: reconciliation,
+              });
+            },
             // init.js は hot reload される。成功したら error marker を外し、
             // 失敗時だけ marker を付けて、前の init scope が維持されていることを可視化する。
             onInitReloaded: ({ ran, missing }) => {
@@ -4234,7 +4253,11 @@ function App() {
     ambientLayer.style.zIndex = "20";
     document.body.appendChild(ambientLayer);
 
-    type Mounted = { container: HTMLDivElement; disposable: Disposable };
+    type Mounted = {
+      container: HTMLDivElement;
+      disposable: Disposable;
+      packEntry: AmbientUiPackEntry;
+    };
     const mounted = new Map<string, Mounted>();
 
     const reconcile = (activeIds: ReadonlyArray<string>): void => {
@@ -4249,9 +4272,11 @@ function App() {
       }
 
       for (const id of activeIds) {
-        if (mounted.has(id)) continue;
         const packEntry = ambientUiRegistry.listEntries().find((e) => e.id === id);
         if (packEntry === undefined) continue;
+
+        const current = mounted.get(id);
+        if (current?.packEntry === packEntry) continue;
 
         const container = document.createElement("div");
         container.className = "ambient-ui-container";
@@ -4259,8 +4284,27 @@ function App() {
         ambientLayer.appendChild(container);
 
         const ctx: AmbientUiContext = { attention, amenities };
-        const disposable = packEntry.pack.mount(ctx, container);
-        mounted.set(id, { container, disposable });
+        let disposable: Disposable;
+        try {
+          // 新実装を mount できてから旧 mount を畳む。mount failure でも、動いて
+          // いた overlay を巻き添えにしない。
+          disposable = packEntry.pack.mount(ctx, container);
+        } catch (err) {
+          container.remove();
+          devLog.write({
+            subsystem: "AmbientUiPack",
+            phase: "mount",
+            note: `mount failed for '${id}'; preserving previous mount`,
+            data: { error: err instanceof Error ? err.message : String(err) },
+          });
+          continue;
+        }
+        if (current !== undefined) {
+          current.disposable.dispose();
+          current.container.remove();
+          mounted.delete(id);
+        }
+        mounted.set(id, { container, disposable, packEntry });
       }
     };
 
@@ -4276,7 +4320,7 @@ function App() {
       mounted.clear();
       ambientLayer.remove();
     };
-  }, []);
+  }, [devLog]);
 
   // terminal 非依存の attention producer（mouse / dev / focused-dom）。初回のみ起動。
   useEffect(() => {

--- a/src/runtime/ambient-ui-pack-registry/ambient-ui-pack-registry.test.ts
+++ b/src/runtime/ambient-ui-pack-registry/ambient-ui-pack-registry.test.ts
@@ -114,4 +114,22 @@ describe("AmbientUiPackRegistry", () => {
     expect(registry.listEntries()[0].origin).toBe("user");
     expect(registry.getActiveSet()).toEqual(["attention-aura"]);
   });
+
+  it("notifies subscribers when an active entry is replaced without changing membership", () => {
+    const registry = createAmbientUiPackRegistry();
+    const first = entry({ id: "attention-aura", origin: "user" });
+    const second = entry({ id: "attention-aura", origin: "user" });
+    registry.register(first);
+    registry.enable("attention-aura");
+    const listener = vi.fn();
+    registry.subscribeActiveSet(listener);
+    listener.mockClear();
+
+    registry.register(second);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(["attention-aura"]);
+    expect(registry.getActiveSet()).toEqual(["attention-aura"]);
+    expect(registry.listEntries()).toEqual([second]);
+  });
 });

--- a/src/runtime/ambient-ui-pack-registry/ambient-ui-pack-registry.ts
+++ b/src/runtime/ambient-ui-pack-registry/ambient-ui-pack-registry.ts
@@ -25,7 +25,11 @@ export class AmbientUiPackRegistryImpl implements AmbientUiPackRegistry {
   private readonly subscribers = new Set<InternalSubscriber>();
 
   register(entry: AmbientUiPackEntry) {
+    const replacedActiveEntry = this.entries.has(entry.id) && this.activeSet.has(entry.id);
     this.entries.set(entry.id, entry);
+    // active membership は維持したまま entry identity の変更を通知する。mount 側は
+    // identity を比較して対象 id だけを新実装へ差し替える。
+    if (replacedActiveEntry) this.publish();
     return {
       dispose: () => {
         const current = this.entries.get(entry.id);

--- a/src/runtime/ambient-ui-pack-registry/types.ts
+++ b/src/runtime/ambient-ui-pack-registry/types.ts
@@ -26,6 +26,7 @@ export interface AmbientUiPackRegistry {
    * entry を登録する。同 id の origin 違いは "user-over-bundled" で
    * override する semantic。同 id 同 origin の重複登録は同様に replace
    * (旧 entry は dispose せず entries map から落ちる、active 集合 membership は維持)。
+   * active entry の replace は subscriber へ同じ active 集合を再通知する。
    */
   register(entry: AmbientUiPackEntry): Disposable;
 

--- a/src/runtime/user-pack-loader/ambient-ui-activation.test.ts
+++ b/src/runtime/user-pack-loader/ambient-ui-activation.test.ts
@@ -29,16 +29,32 @@ describe("reconcileAmbientUiRegistration", () => {
     expect(activeSet).toEqual(new Set(["new-overlay"]));
   });
 
-  it("keeps a selected replacement inactive when runtime state suppresses it", async () => {
+  it("keeps a selected replacement inactive when runtime state explicitly suppresses it", async () => {
     const { value, activeSet } = registry();
     const result = await reconcileAmbientUiRegistration(
       { id: "attention-aura", replaced: true },
-      { registry: value, readConfigText: async () => config(["attention-aura"]) },
+      {
+        registry: value,
+        readConfigText: async () => config(["attention-aura"]),
+        isRuntimeSuppressed: (id) => id === "attention-aura",
+      },
     );
 
-    expect(result).toEqual({ status: "unchanged" });
+    expect(result).toEqual({ status: "disabled" });
     expect(value.enable).not.toHaveBeenCalled();
     expect(activeSet.size).toBe(0);
+  });
+
+  it("activates a selected inactive replacement when no current suppression exists", async () => {
+    const { value, activeSet } = registry();
+    const result = await reconcileAmbientUiRegistration(
+      { id: "my-overlay", replaced: true },
+      { registry: value, readConfigText: async () => config(["my-overlay"]) },
+    );
+
+    expect(result).toEqual({ status: "enabled" });
+    expect(value.enable).toHaveBeenCalledWith("my-overlay");
+    expect(activeSet).toEqual(new Set(["my-overlay"]));
   });
 
   it("honors explicit host suppression for a newly re-created selected entry", async () => {
@@ -87,6 +103,29 @@ describe("reconcileAmbientUiRegistration", () => {
     expect(value.enable).not.toHaveBeenCalled();
     expect(value.disable).not.toHaveBeenCalled();
     expect(activeSet).toEqual(new Set(["my-overlay", "other-overlay"]));
+  });
+
+  it("converges from a prior config read failure on the next registration", async () => {
+    const { value, activeSet } = registry();
+    let attempt = 0;
+    const readConfigText = async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error("temporary read failure");
+      return config(["my-overlay"]);
+    };
+
+    const first = await reconcileAmbientUiRegistration(
+      { id: "my-overlay", replaced: true },
+      { registry: value, readConfigText },
+    );
+    const second = await reconcileAmbientUiRegistration(
+      { id: "my-overlay", replaced: true },
+      { registry: value, readConfigText },
+    );
+
+    expect(first.status).toBe("skipped");
+    expect(second).toEqual({ status: "enabled" });
+    expect(activeSet).toEqual(new Set(["my-overlay"]));
   });
 
   it.each([

--- a/src/runtime/user-pack-loader/ambient-ui-activation.test.ts
+++ b/src/runtime/user-pack-loader/ambient-ui-activation.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AmbientUiPackRegistry } from "../ambient-ui-pack-registry";
+import { reconcileAmbientUiRegistration } from "./ambient-ui-activation";
+
+function registry(active: readonly string[] = []) {
+  const activeSet = new Set(active);
+  return {
+    value: {
+      enable: vi.fn((id: string) => activeSet.add(id)),
+      disable: vi.fn((id: string) => activeSet.delete(id)),
+      getActiveSet: vi.fn(() => [...activeSet]),
+    } as unknown as AmbientUiPackRegistry,
+    activeSet,
+  };
+}
+
+const config = (activeAmbientUi: readonly string[], disabledPacks: readonly string[] = []) =>
+  JSON.stringify({ activeAmbientUi, disabledPacks });
+
+describe("reconcileAmbientUiRegistration", () => {
+  it("enables a newly added selected entry", async () => {
+    const { value, activeSet } = registry();
+    const result = await reconcileAmbientUiRegistration(
+      { id: "new-overlay", replaced: false },
+      { registry: value, readConfigText: async () => config(["new-overlay"]) },
+    );
+
+    expect(result).toEqual({ status: "enabled" });
+    expect(activeSet).toEqual(new Set(["new-overlay"]));
+  });
+
+  it("keeps a selected replacement inactive when runtime state suppresses it", async () => {
+    const { value, activeSet } = registry();
+    const result = await reconcileAmbientUiRegistration(
+      { id: "attention-aura", replaced: true },
+      { registry: value, readConfigText: async () => config(["attention-aura"]) },
+    );
+
+    expect(result).toEqual({ status: "unchanged" });
+    expect(value.enable).not.toHaveBeenCalled();
+    expect(activeSet.size).toBe(0);
+  });
+
+  it("honors explicit host suppression for a newly re-created selected entry", async () => {
+    const { value, activeSet } = registry();
+    await reconcileAmbientUiRegistration(
+      { id: "attention-aura", replaced: false },
+      {
+        registry: value,
+        readConfigText: async () => config(["attention-aura"]),
+        isRuntimeSuppressed: (id) => id === "attention-aura",
+      },
+    );
+
+    expect(value.disable).toHaveBeenCalledWith("attention-aura");
+    expect(activeSet.size).toBe(0);
+  });
+
+  it("disables only the target when it is disabled in config", async () => {
+    const { value, activeSet } = registry(["my-overlay", "other-overlay"]);
+    await reconcileAmbientUiRegistration(
+      { id: "my-overlay", replaced: true },
+      {
+        registry: value,
+        readConfigText: async () => config(["my-overlay", "other-overlay"], ["my-overlay"]),
+      },
+    );
+
+    expect(activeSet).toEqual(new Set(["other-overlay"]));
+    expect(value.disable).toHaveBeenCalledTimes(1);
+    expect(value.disable).toHaveBeenCalledWith("my-overlay");
+  });
+
+  it("does not mutate active state when config I/O fails", async () => {
+    const { value, activeSet } = registry(["my-overlay", "other-overlay"]);
+    const result = await reconcileAmbientUiRegistration(
+      { id: "my-overlay", replaced: true },
+      {
+        registry: value,
+        readConfigText: async () => {
+          throw new Error("temporary read failure");
+        },
+      },
+    );
+
+    expect(result).toEqual({ status: "skipped", reason: "temporary read failure" });
+    expect(value.enable).not.toHaveBeenCalled();
+    expect(value.disable).not.toHaveBeenCalled();
+    expect(activeSet).toEqual(new Set(["my-overlay", "other-overlay"]));
+  });
+
+  it.each([
+    "",
+    "{ not json",
+    "null",
+    "[]",
+  ])("does not apply defaults for invalid config %j", async (text) => {
+    const { value, activeSet } = registry(["other-overlay"]);
+    const result = await reconcileAmbientUiRegistration(
+      { id: "attention-aura", replaced: false },
+      { registry: value, readConfigText: async () => text },
+    );
+
+    expect(result.status).toBe("skipped");
+    expect(value.enable).not.toHaveBeenCalled();
+    expect(value.disable).not.toHaveBeenCalled();
+    expect(activeSet).toEqual(new Set(["other-overlay"]));
+  });
+});

--- a/src/runtime/user-pack-loader/ambient-ui-activation.ts
+++ b/src/runtime/user-pack-loader/ambient-ui-activation.ts
@@ -1,0 +1,80 @@
+/**
+ * Hot-reloaded ambient UI の activation reconciliation。
+ *
+ * `activeAmbientUi` は user の永続 selection、registry の active set は Presence
+ * 等の runtime suppression を反映した実効状態であり、同じものではない。
+ * そのため既存 entry の reload では active set を config から作り直さず、対象
+ * id が明示的に非選択 / disabled / runtime-suppressed の場合だけ disable する。
+ * 新規 entry だけは、現在の config で選択済みなら enable する。
+ */
+
+import type { AmbientUiPackRegistry } from "../ambient-ui-pack-registry";
+import { parseConfig } from "./config";
+
+export interface AmbientUiRegistrationEvent {
+  readonly id: string;
+  /** 同じ filesystem pack id の registration を置き換えた場合に true。 */
+  readonly replaced: boolean;
+}
+
+export interface ReconcileAmbientUiRegistrationDeps {
+  readonly registry: AmbientUiPackRegistry;
+  /** I/O failure を空 config に変換せず reject する reader を渡す。 */
+  readonly readConfigText: () => Promise<string>;
+  /** Presence closed 等、config とは別の host/runtime suppression。 */
+  readonly isRuntimeSuppressed?: (id: string) => boolean;
+}
+
+export type AmbientUiRegistrationReconcileResult =
+  | { readonly status: "enabled" | "disabled" | "unchanged" }
+  | { readonly status: "skipped"; readonly reason: string };
+
+function parseCurrentConfig(text: string) {
+  if (text.trim() === "") return null;
+  try {
+    const raw: unknown = JSON.parse(text);
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
+  } catch {
+    return null;
+  }
+  return parseConfig(text);
+}
+
+/**
+ * 対象 id だけを、現在の authoritative state から reconcile する。
+ * config を読めない / parse できない場合は active set を一切変更しない。
+ */
+export async function reconcileAmbientUiRegistration(
+  event: AmbientUiRegistrationEvent,
+  deps: ReconcileAmbientUiRegistrationDeps,
+): Promise<AmbientUiRegistrationReconcileResult> {
+  let text: string;
+  try {
+    text = await deps.readConfigText();
+  } catch (err) {
+    return {
+      status: "skipped",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const config = parseCurrentConfig(text);
+  if (config === null) {
+    return { status: "skipped", reason: "config is empty or malformed" };
+  }
+
+  const selected = config.activeAmbientUi.includes(event.id);
+  const disabled = config.disabledPacks.includes(event.id);
+  const runtimeSuppressed = deps.isRuntimeSuppressed?.(event.id) === true;
+  if (!selected || disabled || runtimeSuppressed) {
+    deps.registry.disable(event.id);
+    return { status: "disabled" };
+  }
+
+  // register() preserves active membership on same-id replacement. Enabling an
+  // existing-but-inactive entry here would undo a runtime suppression.
+  if (event.replaced) return { status: "unchanged" };
+
+  deps.registry.enable(event.id);
+  return { status: "enabled" };
+}

--- a/src/runtime/user-pack-loader/ambient-ui-activation.ts
+++ b/src/runtime/user-pack-loader/ambient-ui-activation.ts
@@ -3,9 +3,9 @@
  *
  * `activeAmbientUi` は user の永続 selection、registry の active set は Presence
  * 等の runtime suppression を反映した実効状態であり、同じものではない。
- * そのため既存 entry の reload では active set を config から作り直さず、対象
- * id が明示的に非選択 / disabled / runtime-suppressed の場合だけ disable する。
- * 新規 entry だけは、現在の config で選択済みなら enable する。
+ * active set 全体を config から作り直さず、対象 id だけを現在の selection / disabled /
+ * runtime suppression から導出する。registration history や直前の active 結果は
+ * suppression とみなさない。
  */
 
 import type { AmbientUiPackRegistry } from "../ambient-ui-pack-registry";
@@ -26,7 +26,7 @@ export interface ReconcileAmbientUiRegistrationDeps {
 }
 
 export type AmbientUiRegistrationReconcileResult =
-  | { readonly status: "enabled" | "disabled" | "unchanged" }
+  | { readonly status: "enabled" | "disabled" }
   | { readonly status: "skipped"; readonly reason: string };
 
 function parseCurrentConfig(text: string) {
@@ -70,10 +70,6 @@ export async function reconcileAmbientUiRegistration(
     deps.registry.disable(event.id);
     return { status: "disabled" };
   }
-
-  // register() preserves active membership on same-id replacement. Enabling an
-  // existing-but-inactive entry here would undo a runtime suppression.
-  if (event.replaced) return { status: "unchanged" };
 
   deps.registry.enable(event.id);
   return { status: "enabled" };

--- a/src/runtime/user-pack-loader/index.ts
+++ b/src/runtime/user-pack-loader/index.ts
@@ -7,6 +7,12 @@
  */
 
 export {
+  type AmbientUiRegistrationEvent,
+  type AmbientUiRegistrationReconcileResult,
+  type ReconcileAmbientUiRegistrationDeps,
+  reconcileAmbientUiRegistration,
+} from "./ambient-ui-activation";
+export {
   EMPTY_CONFIG,
   parseConfig,
   serializeConfig,
@@ -66,6 +72,7 @@ export {
   fetchSafeModeFlag,
   readLastStartupReport,
   readYorishiroConfigText,
+  readYorishiroConfigTextStrict,
   writeLastStartupReport,
   writeYorishiroConfigText,
 } from "./yorishiro-io";

--- a/src/runtime/user-pack-loader/runtime-wire.ts
+++ b/src/runtime/user-pack-loader/runtime-wire.ts
@@ -63,6 +63,8 @@ export interface LoadUserLayerDeps {
   readonly initScriptLog: SubsystemLog;
   readonly tweenManager?: TweenManager;
   readonly onInitChanged?: () => void;
+  /** ambient-ui の watcher 登録後に config 選択を active set へ再反映する hook。 */
+  readonly onAmbientUiRegistered?: (id: string) => void | Promise<void>;
   /**
    * init.js hot reload の成否を通知する。`ran` が true なら新 shortcut が有効に
    * なったので reload 待ち marker を外す、false ならエラー表示、等の用途。
@@ -208,6 +210,7 @@ export async function loadUserLayer(deps: LoadUserLayerDeps): Promise<LoadUserLa
     userPackLog: deps.userPackLog,
     initScriptLog: deps.initScriptLog,
     onInitChanged: deps.onInitChanged,
+    onAmbientUiRegistered: deps.onAmbientUiRegistered,
     executionEnvironment,
     packReloadEnabled: !safeMode,
     // safe mode は recovery 契約として user packs と init.js を実行しない。

--- a/src/runtime/user-pack-loader/runtime-wire.ts
+++ b/src/runtime/user-pack-loader/runtime-wire.ts
@@ -25,6 +25,7 @@ import type { AmbientUiPackRegistry } from "../ambient-ui-pack-registry";
 import type { AmenityPackRegistry } from "../amenity-pack-registry";
 import type { ScenePackRegistry } from "../scene-pack-registry";
 import type { UiPackRegistry } from "../ui-pack-registry";
+import type { AmbientUiRegistrationEvent } from "./ambient-ui-activation";
 import type { AmenityContextFactory } from "./amenity-activation";
 import { parseConfig } from "./config";
 import { InitScope } from "./init-scope";
@@ -63,8 +64,8 @@ export interface LoadUserLayerDeps {
   readonly initScriptLog: SubsystemLog;
   readonly tweenManager?: TweenManager;
   readonly onInitChanged?: () => void;
-  /** ambient-ui の watcher 登録後に config 選択を active set へ再反映する hook。 */
-  readonly onAmbientUiRegistered?: (id: string) => void | Promise<void>;
+  /** ambient-ui watcher の atomic registration 後に対象 id だけを reconcile する hook。 */
+  readonly onAmbientUiRegistered?: (event: AmbientUiRegistrationEvent) => void | Promise<void>;
   /**
    * init.js hot reload の成否を通知する。`ran` が true なら新 shortcut が有効に
    * なったので reload 待ち marker を外す、false ならエラー表示、等の用途。

--- a/src/runtime/user-pack-loader/watcher.test.ts
+++ b/src/runtime/user-pack-loader/watcher.test.ts
@@ -114,6 +114,9 @@ async function startAndEmit(deps: StartPackWatcherDeps, event: unknown): Promise
   mocks.channelHandler?.(event);
 }
 
+const waitMs = async (ms: number): Promise<void> =>
+  await new Promise((resolve) => setTimeout(resolve, ms));
+
 describe("startPackWatcher ambient-ui TSX reload", () => {
   const originalFetch = globalThis.fetch;
 
@@ -415,7 +418,7 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
     expect(onAmbientUiRegistered).not.toHaveBeenCalled();
   });
 
-  it("serializes an atomic remove then create sequence for the same pack", async () => {
+  it("coalesces an atomic remove then successful create delayed beyond one Rust drain", async () => {
     const { ambientUiPackRegistry, deps, packRegistry, onAmbientUiRegistered } =
       makeAmbientLifecycleDeps(new Set(["my-overlay"]));
     registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "my-overlay");
@@ -434,6 +437,9 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
       kind: "removed",
       mtimeMs: 1700000000690,
     });
+    await waitMs(200);
+    expect(ambientUiPackRegistry.listEntries()).toHaveLength(1);
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
     mocks.channelHandler?.({
       path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
       kind: "created",
@@ -446,7 +452,7 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
     expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
   });
 
-  it("preserves the old registration when atomic-save recreation fails to import", async () => {
+  it("preserves the old registration when delayed atomic-save recreation fails to import", async () => {
     const { ambientUiPackRegistry, deps, packRegistry, onAmbientUiRegistered } =
       makeAmbientLifecycleDeps(new Set(["my-overlay"]));
     const oldMount = vi.fn(() => ({ dispose: () => {} }));
@@ -472,6 +478,9 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
       kind: "removed",
       mtimeMs: 1700000000692,
     });
+    await waitMs(200);
+    expect(ambientUiPackRegistry.listEntries()[0]?.pack.mount).toBe(oldMount);
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
     mocks.channelHandler?.({
       path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
       kind: "created",
@@ -492,7 +501,7 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
     expect(onAmbientUiRegistered).not.toHaveBeenCalled();
   });
 
-  it("preserves the old registration when atomic-save recreation fails validation", async () => {
+  it("preserves the old registration when delayed atomic-save recreation fails validation", async () => {
     const { ambientUiPackRegistry, deps, packRegistry, onAmbientUiRegistered } =
       makeAmbientLifecycleDeps(new Set(["my-overlay"]));
     const oldMount = vi.fn(() => ({ dispose: () => {} }));
@@ -520,6 +529,9 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
       kind: "removed",
       mtimeMs: 1700000000694,
     });
+    await waitMs(200);
+    expect(ambientUiPackRegistry.listEntries()[0]?.pack.mount).toBe(oldMount);
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
     mocks.channelHandler?.({
       path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
       kind: "created",

--- a/src/runtime/user-pack-loader/watcher.test.ts
+++ b/src/runtime/user-pack-loader/watcher.test.ts
@@ -22,6 +22,10 @@ vi.mock("./tsx-transpiler", () => ({
 
 import type { AmbientUiPackRegistry } from "../ambient-ui-pack-registry";
 import { createAmbientUiPackRegistry } from "../ambient-ui-pack-registry";
+import {
+  type AmbientUiRegistrationEvent,
+  reconcileAmbientUiRegistration,
+} from "./ambient-ui-activation";
 import { UserPackRegistry } from "./user-pack-registry";
 import { type StartPackWatcherDeps, startPackWatcher } from "./watcher";
 
@@ -45,12 +49,29 @@ function makeDeps(packReloadEnabled = true) {
   return { ambientRegister, deps, userPackLog };
 }
 
-function makeAmbientLifecycleDeps(selectedIds: ReadonlySet<string>) {
+function makeAmbientLifecycleDeps(
+  selectedIds: ReadonlySet<string>,
+  options: {
+    readonly disabledIds?: ReadonlySet<string>;
+    readonly readConfigText?: () => Promise<string>;
+    readonly isRuntimeSuppressed?: (id: string) => boolean;
+  } = {},
+) {
   const ambientUiPackRegistry = createAmbientUiPackRegistry();
   const packRegistry = new UserPackRegistry();
-  const onAmbientUiRegistered = vi.fn((id: string) => {
-    if (selectedIds.has(id)) ambientUiPackRegistry.enable(id);
-  });
+  const onAmbientUiRegistered = vi.fn((event: AmbientUiRegistrationEvent) =>
+    reconcileAmbientUiRegistration(event, {
+      registry: ambientUiPackRegistry,
+      readConfigText:
+        options.readConfigText ??
+        (async () =>
+          JSON.stringify({
+            activeAmbientUi: [...selectedIds],
+            disabledPacks: [...(options.disabledIds ?? [])],
+          })),
+      isRuntimeSuppressed: options.isRuntimeSuppressed,
+    }),
+  );
   const userPackLog = { write: vi.fn() };
   const deps = {
     effectPackRunner: { register: vi.fn() },
@@ -207,10 +228,10 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
     });
 
     await vi.waitFor(() => expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]));
-    expect(onAmbientUiRegistered).toHaveBeenCalledWith("my-overlay");
+    expect(onAmbientUiRegistered).toHaveBeenCalledWith({ id: "my-overlay", replaced: false });
   });
 
-  it("restores an active ambient-ui after its code is re-registered", async () => {
+  it("preserves an active ambient-ui while atomically replacing its code", async () => {
     const selectedIds = new Set(["my-overlay"]);
     const { ambientUiPackRegistry, deps, onAmbientUiRegistered, packRegistry } =
       makeAmbientLifecycleDeps(selectedIds);
@@ -230,15 +251,17 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
       mtimeMs: 1700000000500,
     });
 
-    await vi.waitFor(() => expect(onAmbientUiRegistered).toHaveBeenCalledWith("my-overlay"));
+    await vi.waitFor(() =>
+      expect(onAmbientUiRegistered).toHaveBeenCalledWith({ id: "my-overlay", replaced: true }),
+    );
     expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
     expect(ambientUiPackRegistry.listEntries()).toHaveLength(1);
   });
 
-  it("keeps an inactive ambient-ui inactive after its code is re-registered", async () => {
-    const selectedIds = new Set<string>();
+  it("keeps a config-selected but runtime-suppressed ambient-ui inactive after reload", async () => {
+    const selectedIds = new Set(["my-overlay"]);
     const { ambientUiPackRegistry, deps, onAmbientUiRegistered, packRegistry } =
-      makeAmbientLifecycleDeps(selectedIds);
+      makeAmbientLifecycleDeps(selectedIds, { isRuntimeSuppressed: () => true });
     registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "my-overlay");
     mocks.importTsx.mockResolvedValue({
       default: {
@@ -254,9 +277,173 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
       mtimeMs: 1700000000600,
     });
 
-    await vi.waitFor(() => expect(onAmbientUiRegistered).toHaveBeenCalledWith("my-overlay"));
+    await vi.waitFor(() =>
+      expect(onAmbientUiRegistered).toHaveBeenCalledWith({ id: "my-overlay", replaced: true }),
+    );
     expect(ambientUiPackRegistry.getActiveSet()).toEqual([]);
     expect(ambientUiPackRegistry.listEntries()).toHaveLength(1);
+  });
+
+  it("keeps a disabled ambient-ui inactive without changing another overlay", async () => {
+    const { ambientUiPackRegistry, deps, packRegistry } = makeAmbientLifecycleDeps(
+      new Set(["my-overlay", "other-overlay"]),
+      { disabledIds: new Set(["my-overlay"]) },
+    );
+    registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "my-overlay");
+    registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "other-overlay");
+    ambientUiPackRegistry.enable("my-overlay");
+    ambientUiPackRegistry.enable("other-overlay");
+    mocks.importTsx.mockResolvedValue({
+      default: {
+        id: "my-overlay",
+        type: "ambient-ui",
+        mount: () => ({ dispose: () => {} }),
+      },
+    });
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "modified",
+      mtimeMs: 1700000000650,
+    });
+
+    await vi.waitFor(() => expect(ambientUiPackRegistry.getActiveSet()).toEqual(["other-overlay"]));
+    expect(
+      ambientUiPackRegistry
+        .listEntries()
+        .map((entry) => entry.id)
+        .sort(),
+    ).toEqual(["my-overlay", "other-overlay"]);
+  });
+
+  it("does not mutate active overlays when the activation config read fails", async () => {
+    const { ambientUiPackRegistry, deps, packRegistry, onAmbientUiRegistered } =
+      makeAmbientLifecycleDeps(new Set(["my-overlay"]), {
+        readConfigText: async () => {
+          throw new Error("synthetic config read failure");
+        },
+      });
+    registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "my-overlay");
+    registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "other-overlay");
+    ambientUiPackRegistry.enable("my-overlay");
+    ambientUiPackRegistry.enable("other-overlay");
+    mocks.importTsx.mockResolvedValue({
+      default: {
+        id: "my-overlay",
+        type: "ambient-ui",
+        mount: () => ({ dispose: () => {} }),
+      },
+    });
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "modified",
+      mtimeMs: 1700000000660,
+    });
+
+    await vi.waitFor(() => expect(onAmbientUiRegistered).toHaveBeenCalledTimes(1));
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay", "other-overlay"]);
+  });
+
+  it("preserves the old registration on validation failure", async () => {
+    const { ambientUiPackRegistry, deps, packRegistry, onAmbientUiRegistered } =
+      makeAmbientLifecycleDeps(new Set(["my-overlay"]));
+    const oldMount = vi.fn(() => ({ dispose: () => {} }));
+    const oldHandle = ambientUiPackRegistry.register({
+      id: "my-overlay",
+      origin: "user",
+      manifest: {
+        id: "my-overlay",
+        type: "ambient-ui",
+        version: "0.0.0",
+        yorishiroVersion: "*",
+        entry: "ambient-ui.tsx",
+      },
+      pack: { mount: oldMount },
+    });
+    packRegistry.register("my-overlay", "ambient-ui", oldHandle);
+    ambientUiPackRegistry.enable("my-overlay");
+    mocks.importTsx.mockResolvedValue({
+      default: { id: "my-overlay", type: "ambient-ui" },
+    });
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "modified",
+      mtimeMs: 1700000000670,
+    });
+
+    await vi.waitFor(() =>
+      expect(deps.userPackLog.write).toHaveBeenCalledWith(
+        expect.objectContaining({ note: expect.stringContaining("reload failed") }),
+      ),
+    );
+    expect(ambientUiPackRegistry.listEntries()[0]?.pack.mount).toBe(oldMount);
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
+    expect(onAmbientUiRegistered).not.toHaveBeenCalled();
+  });
+
+  it("rejects a module id mismatch and preserves the old registration", async () => {
+    const { ambientUiPackRegistry, deps, packRegistry, onAmbientUiRegistered } =
+      makeAmbientLifecycleDeps(new Set(["my-overlay"]));
+    registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "my-overlay");
+    ambientUiPackRegistry.enable("my-overlay");
+    mocks.importTsx.mockResolvedValue({
+      default: {
+        id: "renamed-overlay",
+        type: "ambient-ui",
+        mount: () => ({ dispose: () => {} }),
+      },
+    });
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "modified",
+      mtimeMs: 1700000000680,
+    });
+
+    await vi.waitFor(() =>
+      expect(deps.userPackLog.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          note: expect.stringContaining("reload failed"),
+          data: expect.objectContaining({ error: expect.stringContaining("does not match") }),
+        }),
+      ),
+    );
+    expect(ambientUiPackRegistry.listEntries().map((entry) => entry.id)).toEqual(["my-overlay"]);
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
+    expect(onAmbientUiRegistered).not.toHaveBeenCalled();
+  });
+
+  it("serializes an atomic remove then create sequence for the same pack", async () => {
+    const { ambientUiPackRegistry, deps, packRegistry, onAmbientUiRegistered } =
+      makeAmbientLifecycleDeps(new Set(["my-overlay"]));
+    registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "my-overlay");
+    ambientUiPackRegistry.enable("my-overlay");
+    mocks.importTsx.mockResolvedValue({
+      default: {
+        id: "my-overlay",
+        type: "ambient-ui",
+        mount: () => ({ dispose: () => {} }),
+      },
+    });
+    await startPackWatcher(deps);
+
+    mocks.channelHandler?.({
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "removed",
+      mtimeMs: 1700000000690,
+    });
+    mocks.channelHandler?.({
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "created",
+      mtimeMs: 1700000000691,
+    });
+
+    await vi.waitFor(() => expect(onAmbientUiRegistered).toHaveBeenCalledTimes(1));
+    expect(onAmbientUiRegistered).toHaveBeenCalledWith({ id: "my-overlay", replaced: false });
+    expect(ambientUiPackRegistry.listEntries()).toHaveLength(1);
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
   });
 
   it("removes an ambient-ui without restoring active state", async () => {

--- a/src/runtime/user-pack-loader/watcher.test.ts
+++ b/src/runtime/user-pack-loader/watcher.test.ts
@@ -20,6 +20,8 @@ vi.mock("./tsx-transpiler", () => ({
   importUiTsxEntry: mocks.importTsx,
 }));
 
+import type { AmbientUiPackRegistry } from "../ambient-ui-pack-registry";
+import { createAmbientUiPackRegistry } from "../ambient-ui-pack-registry";
 import { UserPackRegistry } from "./user-pack-registry";
 import { type StartPackWatcherDeps, startPackWatcher } from "./watcher";
 
@@ -41,6 +43,48 @@ function makeDeps(packReloadEnabled = true) {
     packReloadEnabled,
   } as unknown as StartPackWatcherDeps;
   return { ambientRegister, deps, userPackLog };
+}
+
+function makeAmbientLifecycleDeps(selectedIds: ReadonlySet<string>) {
+  const ambientUiPackRegistry = createAmbientUiPackRegistry();
+  const packRegistry = new UserPackRegistry();
+  const onAmbientUiRegistered = vi.fn((id: string) => {
+    if (selectedIds.has(id)) ambientUiPackRegistry.enable(id);
+  });
+  const userPackLog = { write: vi.fn() };
+  const deps = {
+    effectPackRunner: { register: vi.fn() },
+    personaRegistry: { register: vi.fn() },
+    scenePackRegistry: {},
+    uiPackRegistry: {},
+    ambientUiPackRegistry,
+    amenityPackRegistry: {},
+    packRegistry,
+    userPackLog,
+    initScriptLog: { write: vi.fn() },
+    onAmbientUiRegistered,
+  } as unknown as StartPackWatcherDeps;
+  return { ambientUiPackRegistry, deps, onAmbientUiRegistered, packRegistry };
+}
+
+function registerExistingAmbientUi(
+  registry: AmbientUiPackRegistry,
+  packRegistry: UserPackRegistry,
+  id: string,
+): void {
+  const handle = registry.register({
+    id,
+    origin: "user",
+    manifest: {
+      id,
+      type: "ambient-ui",
+      version: "0.0.0",
+      yorishiroVersion: "*",
+      entry: "ambient-ui.tsx",
+    },
+    pack: { mount: () => ({ dispose: () => {} }) },
+  });
+  packRegistry.register(id, "ambient-ui", handle);
 }
 
 async function startAndEmit(deps: StartPackWatcherDeps, event: unknown): Promise<void> {
@@ -142,5 +186,94 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
       ),
     );
     expect(ambientRegister).not.toHaveBeenCalled();
+  });
+
+  it("activates a newly registered ambient-ui when config selects it", async () => {
+    const selectedIds = new Set(["my-overlay"]);
+    const { ambientUiPackRegistry, deps, onAmbientUiRegistered } =
+      makeAmbientLifecycleDeps(selectedIds);
+    mocks.importTsx.mockResolvedValue({
+      default: {
+        id: "my-overlay",
+        type: "ambient-ui",
+        mount: () => ({ dispose: () => {} }),
+      },
+    });
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "created",
+      mtimeMs: 1700000000400,
+    });
+
+    await vi.waitFor(() => expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]));
+    expect(onAmbientUiRegistered).toHaveBeenCalledWith("my-overlay");
+  });
+
+  it("restores an active ambient-ui after its code is re-registered", async () => {
+    const selectedIds = new Set(["my-overlay"]);
+    const { ambientUiPackRegistry, deps, onAmbientUiRegistered, packRegistry } =
+      makeAmbientLifecycleDeps(selectedIds);
+    registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "my-overlay");
+    ambientUiPackRegistry.enable("my-overlay");
+    mocks.importTsx.mockResolvedValue({
+      default: {
+        id: "my-overlay",
+        type: "ambient-ui",
+        mount: () => ({ dispose: () => {} }),
+      },
+    });
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "modified",
+      mtimeMs: 1700000000500,
+    });
+
+    await vi.waitFor(() => expect(onAmbientUiRegistered).toHaveBeenCalledWith("my-overlay"));
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
+    expect(ambientUiPackRegistry.listEntries()).toHaveLength(1);
+  });
+
+  it("keeps an inactive ambient-ui inactive after its code is re-registered", async () => {
+    const selectedIds = new Set<string>();
+    const { ambientUiPackRegistry, deps, onAmbientUiRegistered, packRegistry } =
+      makeAmbientLifecycleDeps(selectedIds);
+    registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "my-overlay");
+    mocks.importTsx.mockResolvedValue({
+      default: {
+        id: "my-overlay",
+        type: "ambient-ui",
+        mount: () => ({ dispose: () => {} }),
+      },
+    });
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "modified",
+      mtimeMs: 1700000000600,
+    });
+
+    await vi.waitFor(() => expect(onAmbientUiRegistered).toHaveBeenCalledWith("my-overlay"));
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual([]);
+    expect(ambientUiPackRegistry.listEntries()).toHaveLength(1);
+  });
+
+  it("removes an ambient-ui without restoring active state", async () => {
+    const selectedIds = new Set(["my-overlay"]);
+    const { ambientUiPackRegistry, deps, onAmbientUiRegistered, packRegistry } =
+      makeAmbientLifecycleDeps(selectedIds);
+    registerExistingAmbientUi(ambientUiPackRegistry, packRegistry, "my-overlay");
+    ambientUiPackRegistry.enable("my-overlay");
+
+    await startAndEmit(deps, {
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "removed",
+      mtimeMs: 1700000000700,
+    });
+
+    await vi.waitFor(() => expect(ambientUiPackRegistry.listEntries()).toEqual([]));
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual([]);
+    expect(onAmbientUiRegistered).not.toHaveBeenCalled();
   });
 });

--- a/src/runtime/user-pack-loader/watcher.test.ts
+++ b/src/runtime/user-pack-loader/watcher.test.ts
@@ -441,9 +441,100 @@ describe("startPackWatcher ambient-ui TSX reload", () => {
     });
 
     await vi.waitFor(() => expect(onAmbientUiRegistered).toHaveBeenCalledTimes(1));
-    expect(onAmbientUiRegistered).toHaveBeenCalledWith({ id: "my-overlay", replaced: false });
+    expect(onAmbientUiRegistered).toHaveBeenCalledWith({ id: "my-overlay", replaced: true });
     expect(ambientUiPackRegistry.listEntries()).toHaveLength(1);
     expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
+  });
+
+  it("preserves the old registration when atomic-save recreation fails to import", async () => {
+    const { ambientUiPackRegistry, deps, packRegistry, onAmbientUiRegistered } =
+      makeAmbientLifecycleDeps(new Set(["my-overlay"]));
+    const oldMount = vi.fn(() => ({ dispose: () => {} }));
+    const oldHandle = ambientUiPackRegistry.register({
+      id: "my-overlay",
+      origin: "user",
+      manifest: {
+        id: "my-overlay",
+        type: "ambient-ui",
+        version: "0.0.0",
+        yorishiroVersion: "*",
+        entry: "ambient-ui.tsx",
+      },
+      pack: { mount: oldMount },
+    });
+    packRegistry.register("my-overlay", "ambient-ui", oldHandle);
+    ambientUiPackRegistry.enable("my-overlay");
+    mocks.importTsx.mockRejectedValue(new Error("atomic-save compile failure"));
+    await startPackWatcher(deps);
+
+    mocks.channelHandler?.({
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "removed",
+      mtimeMs: 1700000000692,
+    });
+    mocks.channelHandler?.({
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "created",
+      mtimeMs: 1700000000693,
+    });
+
+    await vi.waitFor(() =>
+      expect(deps.userPackLog.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          note: expect.stringContaining("dynamic import failed"),
+          data: expect.objectContaining({ error: "atomic-save compile failure" }),
+        }),
+      ),
+    );
+    expect(ambientUiPackRegistry.listEntries()[0]?.pack.mount).toBe(oldMount);
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
+    expect(packRegistry.has("my-overlay", "ambient-ui")).toBe(true);
+    expect(onAmbientUiRegistered).not.toHaveBeenCalled();
+  });
+
+  it("preserves the old registration when atomic-save recreation fails validation", async () => {
+    const { ambientUiPackRegistry, deps, packRegistry, onAmbientUiRegistered } =
+      makeAmbientLifecycleDeps(new Set(["my-overlay"]));
+    const oldMount = vi.fn(() => ({ dispose: () => {} }));
+    const oldHandle = ambientUiPackRegistry.register({
+      id: "my-overlay",
+      origin: "user",
+      manifest: {
+        id: "my-overlay",
+        type: "ambient-ui",
+        version: "0.0.0",
+        yorishiroVersion: "*",
+        entry: "ambient-ui.tsx",
+      },
+      pack: { mount: oldMount },
+    });
+    packRegistry.register("my-overlay", "ambient-ui", oldHandle);
+    ambientUiPackRegistry.enable("my-overlay");
+    mocks.importTsx.mockResolvedValue({
+      default: { id: "my-overlay", type: "ambient-ui" },
+    });
+    await startPackWatcher(deps);
+
+    mocks.channelHandler?.({
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "removed",
+      mtimeMs: 1700000000694,
+    });
+    mocks.channelHandler?.({
+      path: `${HOME}/packs/my-overlay/ambient-ui.tsx`,
+      kind: "created",
+      mtimeMs: 1700000000695,
+    });
+
+    await vi.waitFor(() =>
+      expect(deps.userPackLog.write).toHaveBeenCalledWith(
+        expect.objectContaining({ note: expect.stringContaining("reload failed") }),
+      ),
+    );
+    expect(ambientUiPackRegistry.listEntries()[0]?.pack.mount).toBe(oldMount);
+    expect(ambientUiPackRegistry.getActiveSet()).toEqual(["my-overlay"]);
+    expect(packRegistry.has("my-overlay", "ambient-ui")).toBe(true);
+    expect(onAmbientUiRegistered).not.toHaveBeenCalled();
   });
 
   it("removes an ambient-ui without restoring active state", async () => {

--- a/src/runtime/user-pack-loader/watcher.ts
+++ b/src/runtime/user-pack-loader/watcher.ts
@@ -25,6 +25,7 @@ import type { AmenityPackRegistry } from "../amenity-pack-registry";
 import type { PersonaEntry } from "../persona-registry";
 import type { ScenePackRegistry } from "../scene-pack-registry";
 import type { UiPackRegistry } from "../ui-pack-registry";
+import type { AmbientUiRegistrationEvent } from "./ambient-ui-activation";
 import { type AmenityContextFactory, activateAndRegisterAmenity } from "./amenity-activation";
 import type { InitScope } from "./init-scope";
 import { type LoadInitScriptDeps, reloadInitScript } from "./init-script";
@@ -59,11 +60,10 @@ export interface StartPackWatcherDeps {
   readonly initScriptLog: SubsystemLog;
   readonly onInitChanged?: () => void;
   /**
-   * ambient-ui の register が完了した直後に通知する。registry の dispose は
-   * active membership も外すため、呼び出し側は config の選択状態から active set
-   * を復元できる。削除時には呼ばない（削除済み entry を再有効化しないため）。
+   * ambient-ui の atomic register が完了した直後に対象 id だけを通知する。
+   * 削除 / import・validation failure 時には呼ばない。
    */
-  readonly onAmbientUiRegistered?: (id: string) => void | Promise<void>;
+  readonly onAmbientUiRegistered?: (event: AmbientUiRegistrationEvent) => void | Promise<void>;
   readonly executionEnvironment?: PackExecutionEnvironment;
   /** safe mode では false。watch は維持するが user pack の import / register は行わない。 */
   readonly packReloadEnabled?: boolean;
@@ -129,8 +129,37 @@ export async function startPackWatcher(deps: StartPackWatcherDeps): Promise<Pack
   }
 
   const channel = new Channel<YorishiroLayerEvent>();
+  const eventQueues = new Map<string, Promise<void>>();
   channel.onmessage = (event) => {
-    void handleLayerEvent(event, yorishiroHome, deps, { invoke, convertFileSrc });
+    const action = mapEventToAction(event, yorishiroHome);
+    const queueKey =
+      action.type === "reload-pack" ||
+      action.type === "reload-pack-source" ||
+      action.type === "remove-pack"
+        ? `pack:${action.id}`
+        : action.type === "init-changed"
+          ? "init"
+          : null;
+    if (queueKey === null) return;
+
+    // Editors using atomic save commonly emit remove -> create back-to-back. Serialize
+    // events per pack id so an older async import cannot win after a newer event.
+    const previous = eventQueues.get(queueKey) ?? Promise.resolve();
+    const run = previous
+      .catch(() => {})
+      .then(() => handleLayerEvent(event, yorishiroHome, deps, { invoke, convertFileSrc }))
+      .catch((err) => {
+        deps.userPackLog.write({
+          phase: "reload",
+          note: `watch event failed for '${event.path}'`,
+          data: { error: errorMessage(err) },
+        });
+      });
+    let queued!: Promise<void>;
+    queued = run.finally(() => {
+      if (eventQueues.get(queueKey) === queued) eventQueues.delete(queueKey);
+    });
+    eventQueues.set(queueKey, queued);
   };
 
   try {
@@ -460,7 +489,15 @@ async function reloadPack(
       });
     } else if (action.kind === "ambient-ui") {
       const pack = validateAmbientUiPackDefinition(def);
-      deps.packRegistry.dispose(action.id, action.kind);
+      if (pack.id !== action.id) {
+        throw new Error(
+          `ambient-ui id '${pack.id}' does not match containing pack id '${action.id}'`,
+        );
+      }
+      const replaced = deps.packRegistry.has(action.id, action.kind);
+      // register(new) -> track(new) の順なら、UserPackRegistry が旧 handle を
+      // dispose しても AmbientUiPackRegistry の stale-handle guard が新 entry を守る。
+      // import / validation はここより前なので、それらの失敗時は旧版が残る。
       const handle = deps.ambientUiPackRegistry.register({
         id: pack.id,
         origin: "user",
@@ -474,7 +511,17 @@ async function reloadPack(
         pack: { mount: pack.mount },
       });
       deps.packRegistry.register(action.id, action.kind, handle);
-      await deps.onAmbientUiRegistered?.(pack.id);
+      try {
+        await deps.onAmbientUiRegistered?.({ id: pack.id, replaced });
+      } catch (err) {
+        // Activation reconciliation の failure で、正常に差し替えた registration
+        // まで failed 扱いにしない。active set は callback 側の責務で不変に保つ。
+        deps.userPackLog.write({
+          phase: "reload",
+          note: `ambient-ui activation reconciliation failed for '${pack.id}'`,
+          data: { error: errorMessage(err) },
+        });
+      }
       deps.userPackLog.write({
         phase: "reload",
         note: `re-registered ambient-ui '${pack.id}'`,

--- a/src/runtime/user-pack-loader/watcher.ts
+++ b/src/runtime/user-pack-loader/watcher.ts
@@ -108,8 +108,12 @@ const extractDefault = (mod: unknown): unknown => {
   return (mod as { default?: unknown }).default;
 };
 
-/** Atomic-save の remove → create burst を同一 replacement とみなす猶予。 */
-const AMBIENT_UI_REMOVE_GRACE_MS = 100;
+/**
+ * Atomic-save の remove → create burst を同一 replacement とみなす猶予。
+ * Rust producer は 150ms 周期で pending events を drain するため、remove/create が
+ * 隣接 drain に分かれても十分吸収できるよう 3 周期超を確保する。
+ */
+const AMBIENT_UI_REMOVE_GRACE_MS = 500;
 
 /**
  * watcher を張って event loop を開始する。`Promise` が resolve した時点で Rust

--- a/src/runtime/user-pack-loader/watcher.ts
+++ b/src/runtime/user-pack-loader/watcher.ts
@@ -58,6 +58,12 @@ export interface StartPackWatcherDeps {
   readonly userPackLog: SubsystemLog;
   readonly initScriptLog: SubsystemLog;
   readonly onInitChanged?: () => void;
+  /**
+   * ambient-ui の register が完了した直後に通知する。registry の dispose は
+   * active membership も外すため、呼び出し側は config の選択状態から active set
+   * を復元できる。削除時には呼ばない（削除済み entry を再有効化しないため）。
+   */
+  readonly onAmbientUiRegistered?: (id: string) => void | Promise<void>;
   readonly executionEnvironment?: PackExecutionEnvironment;
   /** safe mode では false。watch は維持するが user pack の import / register は行わない。 */
   readonly packReloadEnabled?: boolean;
@@ -468,6 +474,7 @@ async function reloadPack(
         pack: { mount: pack.mount },
       });
       deps.packRegistry.register(action.id, action.kind, handle);
+      await deps.onAmbientUiRegistered?.(pack.id);
       deps.userPackLog.write({
         phase: "reload",
         note: `re-registered ambient-ui '${pack.id}'`,

--- a/src/runtime/user-pack-loader/watcher.ts
+++ b/src/runtime/user-pack-loader/watcher.ts
@@ -108,6 +108,9 @@ const extractDefault = (mod: unknown): unknown => {
   return (mod as { default?: unknown }).default;
 };
 
+/** Atomic-save の remove → create burst を同一 replacement とみなす猶予。 */
+const AMBIENT_UI_REMOVE_GRACE_MS = 100;
+
 /**
  * watcher を張って event loop を開始する。`Promise` が resolve した時点で Rust
  * 側 watcher は起動済みで、以降の event は Channel 経由で受け取る。
@@ -130,8 +133,8 @@ export async function startPackWatcher(deps: StartPackWatcherDeps): Promise<Pack
 
   const channel = new Channel<YorishiroLayerEvent>();
   const eventQueues = new Map<string, Promise<void>>();
-  channel.onmessage = (event) => {
-    const action = mapEventToAction(event, yorishiroHome);
+  const pendingAmbientUiRemovals = new Map<string, ReturnType<typeof setTimeout>>();
+  const enqueueEvent = (event: YorishiroLayerEvent, action: WatcherAction): void => {
     const queueKey =
       action.type === "reload-pack" ||
       action.type === "reload-pack-source" ||
@@ -160,6 +163,36 @@ export async function startPackWatcher(deps: StartPackWatcherDeps): Promise<Pack
       if (eventQueues.get(queueKey) === queued) eventQueues.delete(queueKey);
     });
     eventQueues.set(queueKey, queued);
+  };
+  channel.onmessage = (event) => {
+    const action = mapEventToAction(event, yorishiroHome);
+
+    if (
+      deps.packReloadEnabled !== false &&
+      action.type === "remove-pack" &&
+      action.kind === "ambient-ui"
+    ) {
+      const pending = pendingAmbientUiRemovals.get(action.id);
+      if (pending !== undefined) clearTimeout(pending);
+      // Atomic-save の create が来るまで旧 registration を残す。create 側の import /
+      // validation が失敗しても旧版を失わない。create が来なければ通常削除へ収束する。
+      const timeout = setTimeout(() => {
+        pendingAmbientUiRemovals.delete(action.id);
+        enqueueEvent(event, action);
+      }, AMBIENT_UI_REMOVE_GRACE_MS);
+      pendingAmbientUiRemovals.set(action.id, timeout);
+      return;
+    }
+
+    if (action.type === "reload-pack" && action.kind === "ambient-ui") {
+      const pending = pendingAmbientUiRemovals.get(action.id);
+      if (pending !== undefined) {
+        clearTimeout(pending);
+        pendingAmbientUiRemovals.delete(action.id);
+      }
+    }
+
+    enqueueEvent(event, action);
   };
 
   try {

--- a/src/runtime/user-pack-loader/yorishiro-io.ts
+++ b/src/runtime/user-pack-loader/yorishiro-io.ts
@@ -20,6 +20,14 @@ export async function readYorishiroConfigText(): Promise<string> {
   }
 }
 
+/**
+ * config.json を lossless に読む。hot-reload reconciliation のように、一時的な
+ * I/O failure を default config と区別しなければならない経路で使う。
+ */
+export async function readYorishiroConfigTextStrict(): Promise<string> {
+  return await invoke<string>("read_yorishiro_file", { relativePath: "config.json" });
+}
+
 /** config.json を atomic に書く。 */
 export async function writeYorishiroConfigText(text: string): Promise<void> {
   await invoke("write_yorishiro_file_atomic", {


### PR DESCRIPTION
## Summary
- notify App after successful user Ambient UI registration or re-registration
- resync the active set from config so selected packs mount without an Aura toggle
- keep inactive updates inactive and preserve deletion behavior

## Cause
Reload disposes the previous registry handle, which removes the pack ID from the active set. Registration succeeded afterward, but the configured selection was never reapplied.

## Verification
- targeted watcher and registry tests: 14 passed
- related user-pack-loader and registry tests: 324 passed
- full Vitest: 189 files / 2422 tests passed
- npx tsc --noEmit
- npm run check

## Manual verification
No additional Yorishiro app was launched. The existing production process remains untouched. Final no-restart UI verification should use that running environment after integrating this branch.