### PR TITLE
feat: open terminal URLs in the default browser

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -232,7 +232,8 @@ packやinit.jsが変わるたびに、チェックポイントが自動で作ら
 - 反射層によるPTY観察と即時反応
 - 住人の`git push`成功を花火で祝う（同梱Yoriペルソナの反応）
 - Light Alert: agentが入力・許可待ちになると明かりがついて知らせる
-- コンテキスト共有: Voice SummaryとTerminal Reference Marker（Cmd+click / Option+Shift+drag）
+- ターミナルリンク: 表示中のHTTP/HTTPS URLをCmd+clickして既定ブラウザで開く
+- コンテキスト共有: Voice SummaryとTerminal Reference Marker（Cmd+Shift+click / Option+Shift+drag）
 - Journalによる長期記憶と、セッション開始時の想起
 - 復元: pack / init.js / 設定の自動チェックポイントと、可逆な巻き戻し
 - `/yori:*`コマンドによるpackの対話的な作成・編集

--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ What works today:
 - Reflex layer: PTY observation and instant reactions
 - Fireworks celebrate a successful `git push` by the inhabitant (bundled Yori persona)
 - Light Alert: a light comes on when the agent waits for your input or approval
-- Context sharing: Voice Summary and Terminal Reference Markers (Cmd+click / Option+Shift+drag)
+- Terminal links: Cmd+click a visible HTTP/HTTPS URL to open it in the default browser
+- Context sharing: Voice Summary and Terminal Reference Markers (Cmd+Shift+click / Option+Shift+drag)
 - Journal: long-term memory across sessions, with recall at session start
 - Restore: automatic checkpoints for packs / init.js / settings, with reversible rollback
 - `/yori:*` commands for interactive pack creation and editing

--- a/docs/decisions/input-prefill-boundary.md
+++ b/docs/decisions/input-prefill-boundary.md
@@ -10,7 +10,7 @@
 pack/AI に「任意テキストを入力欄/PTY に書く」API は型ごと露出しない（[`critical-constraints.md`](critical-constraints.md) §1 維持）。代わりに 2 経路のみ：
 
 - **(A) 固定文字列 verb**：Yorishiro/bundled 所有の固定文字列テーブルを引く enumerated verb を SDK + MCP に対称公開。pack/AI は文字列を選べず verb 名を呼ぶだけ。
-- **(B) Terminal Reference Marker（既存機構）**：write 経路は固定形 token `[#TermN]`（host 採番、user の Cmd+click gesture でのみ mapping 生成）、可変内容は MCP read tool で AI が要求時に解決（observation channel）。
+- **(B) Terminal Reference Marker（既存機構）**：write 経路は固定形 token `[#TermN]`（host 採番、user の Cmd+Shift+click / Option+Shift+drag gesture でのみ mapping 生成）、可変内容は MCP read tool で AI が要求時に解決（observation channel）。
 
 これにより [`mcp-trust-tiers.md`](mcp-trust-tiers.md)「PTY 系 tool は L1+L2+L3+L4 が揃うまで全 tier 禁止」を精緻化：安全 subset（(A) 固定 verb / (B) 固定 token）は今出せる。任意 `terminal_prefill` / `write_terminal_input` は依然禁止。
 
@@ -21,7 +21,7 @@ pack/AI に「任意テキストを入力欄/PTY に書く」API は型ごと露
 - **固定文字列テーブルは host/bundled (Tier 1) 所有**。user pack は**既存エントリの参照のみ**、テーブルへの登録は不可。登録を許すと*登録時に pack がバイトを選ぶ*ので「呼び出し時は固定」でも実質任意注入になり leak が裏口から復活する。
 - (A) verb は**改行を付けず人間が Enter**（テーブルが reviewed でも cheap な多層防御、現状挙動と一致）。
 - **Symmetry**：(A) verb は SDK (`ctx.*`) と MCP tool に同じものを公開（CLAUDE.md「Symmetry principle」）。MCP 側も任意注入できず固定 verb だけ。
-- **(B)** は既存 Reference Marker 機構を維持。入力欄に入るのは固定形 token `[#TermN]` のみ、可変な実テキストは MCP の resolve tool（read）で AI が要求時に取得。pack/AI は mapping を作れず（user の Cmd+click gesture のみが生成）、capture 機構は host UI affordance であって pack 能力ではない。
+- **(B)** は既存 Reference Marker 機構を維持。入力欄に入るのは固定形 token `[#TermN]` のみ、可変な実テキストは MCP の resolve tool（read）で AI が要求時に取得。pack/AI は mapping を作れず（user の Cmd+Shift+click / Option+Shift+drag gesture だけが生成）、capture 機構は host UI affordance であって pack 能力ではない。
 
 ## なぜそう決めたか
 

--- a/docs/decisions/mcp-trust-tiers.md
+++ b/docs/decisions/mcp-trust-tiers.md
@@ -127,7 +127,7 @@ self-referential MCP は user / 住人 / 外部の 3 surface が同じ tool 体�
 | Category | 例 | Tier 1 | Tier 2 | Tier 3 |
 |---|---|---|---|---|
 | **Read**（低機微 metadata） | `get_state`, `list_packs`, `list_personas`, `list_scenes` | ✅ | ✅ | ✅ default |
-| **Sensitive-read**（user 由来の生データ / command metadata） | terminal reference の解決（user が Cmd+click / Option+Shift+drag で指した端末テキスト、または host が user gesture で reference 化した command run）、`terminal_runs_recent` | ✅ | ✅（reference 解決は user gesture gated） | 明示 grant（default-open にしない） |
+| **Sensitive-read**（user 由来の生データ / command metadata） | terminal reference の解決（user が Cmd+Shift+click / Option+Shift+drag で指した端末テキスト、または host が user gesture で reference 化した command run）、`terminal_runs_recent` | ✅ | ✅（reference 解決は user gesture gated） | 明示 grant（default-open にしない） |
 | **Self-write**（住人の身体・環境） | `set_expression`, `dispatch_effect`, `set_camera`, `set_lighting` | ✅ | ✅ | capability gated |
 | **Runtime-active switch**（registry のみ、persist しない） | `ui.activate` | ✅ | ✅ approval-less | manifest gated |
 | **Yorishiro-write**（config） | `set_primary_persona`, `scene.activate`, `set_terminal_agent`, `set_vrm` | ✅ | ✅ | manifest gated, default reject |
@@ -149,7 +149,7 @@ terminal reference がある run だけに付くため、output text を読む�
 
 [`input-prefill-boundary.md`](input-prefill-boundary.md) (B) の write/read チャネル分離が実装で成立していることを確認した：
 
-- mapping 生成は `TerminalRuntime.addTerminalReference`（**private**）のみ。呼び出しは Cmd+click / Option+Shift+drag / host-owned command-run reference path だけで、public / SDK / MCP に追加経路は無い → pack/AI は mapping を作れない
+- mapping 生成は `TerminalRuntime.addTerminalReference`（**private**）のみ。呼び出しは Cmd+Shift+click / Option+Shift+drag / host-owned command-run reference path だけで、public / SDK / MCP に追加経路は無い → pack/AI は mapping を作れない
 - token は `Term${counter}` の host 採番、入力に入るのは固定形 `[#TermN] ` のみ（host が `session_write` で書く Tier 1、user gesture が gate）
 - 可変な実テキストは private Map に保持され、read 経路（`getTerminalReferences()` → MCP read handler の snapshot）でのみ surface
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -68,10 +68,14 @@ UI pack が terminal を fullscreen / hidden / fixed position にする layout �
 
 ## Terminal context selection
 
-Terminal 上で `Option+Shift+drag` すると、ドラッグした矩形範囲の表示テキストを Yorishiro が
-xterm.js buffer から抽出し、最新の「ユーザーが指し示した terminal context」として
-保持する。これは PTY へ入力を書き込む操作ではなく、住人の perception / MCP 経路に
-「ここを見て」という context を渡すための gesture。
+Terminal 上で表示中の HTTP/HTTPS URL を `Cmd+click` すると、Tauri opener 経由で OS の
+既定ブラウザに開く。クリック位置が URL の文字範囲内にある場合だけ発火し、HTTP/HTTPS
+以外の scheme は受け付けない。
+
+Terminal 上で `Cmd+Shift+click` するとその行全体、`Option+Shift+drag` するとドラッグした
+矩形範囲の表示テキストを Yorishiro が xterm.js buffer から抽出し、最新の「ユーザーが
+指し示した terminal context」として保持する。これは PTY へ入力を書き込む操作ではなく、
+住人の perception / MCP 経路に「ここを見て」という context を渡すための gesture。
 
 AI は MCP tool `terminal_context_get` で最新の選択範囲を読める。未選択または空選択の
 場合は `context: null` を返す。選択完了時には attention source

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -747,9 +747,9 @@ impl Yorishiro {
         emit_to(&self.app_handle, "state.get", json!({})).await
     }
 
-    /// terminal_context_get: user が Command+click や Option+Shift+drag で指し示した terminal text を返す。
+    /// terminal_context_get: user が Command+Shift+click や Option+Shift+drag で指し示した terminal text を返す。
     #[tool(
-        description = "Return terminal text the user pointed at. Supports Cmd+click (line) and Option+Shift+drag (region). Response includes `context` (latest selection) and `references` (all [#TermN] markers in the current session). When the user's message contains [#Term1] etc., call this to resolve the referenced text."
+        description = "Return terminal text the user pointed at. Supports Cmd+Shift+click (line) and Option+Shift+drag (region). Response includes `context` (latest selection) and `references` (all [#TermN] markers in the current session). When the user's message contains [#Term1] etc., call this to resolve the referenced text."
     )]
     async fn terminal_context_get(
         &self,
@@ -1224,7 +1224,7 @@ const SERVER_INSTRUCTIONS: &str = concat!(
                 "## ツール選択ガイド\n",
                 "- 声に出す → voice_say。発話するかどうかは system prompt の Voice セクションに従う\n",
                 "- 現在の状態確認 → state_get\n",
-                "- ユーザーが terminal 上で指し示したテキストを読む → terminal_context_get（Cmd+click で行、Option+Shift+drag で矩形。メッセージに [#TermN] マーカーがあればここで解決する）\n",
+                "- ユーザーが terminal 上で指し示したテキストを読む → terminal_context_get（Cmd+Shift+click で行、Option+Shift+drag で矩形。メッセージに [#TermN] マーカーがあればここで解決する）\n",
                 "- 直近の terminal command run metadata を読む → terminal_runs_recent（output text は返らない。referenceIds がある場合だけ terminal_context_get で user gesture 済み context を解決できる）\n",
                 "- 照明・カメラ等のパラメータ確認 → controls_get（scene pack 依存のパスを確認）\n",
                 "- 照明・カメラ等を変更 → controls_transition（controls_set / controls_set_many は使わず、必ず controls_transition を使う）\n",

--- a/src/runtime/terminal-runtime/terminal-runtime.test.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.test.ts
@@ -12,9 +12,11 @@ interface Deferred<T> {
 }
 
 interface MockBufferLine {
+  readonly isWrapped: boolean;
   translateToString(trimRight?: boolean): string;
   getCell(col: number): {
     getChars(): string;
+    getWidth(): number;
     isFgDefault(): boolean;
     getFgColor(): number;
   };
@@ -50,6 +52,8 @@ const mockState = vi.hoisted(() => {
       textarea: HTMLTextAreaElement;
       customKeyEventHandler?: (event: KeyboardEvent) => boolean;
       dataHandler?: (data: string) => void;
+      bufferLines: Map<number, string>;
+      wrappedLines: Set<number>;
     }>;
     dataHandlers: Array<(data: string) => void>;
     decorations: Array<{ element: HTMLElement; dispose: ReturnType<typeof vi.fn> }>;
@@ -62,6 +66,7 @@ const mockState = vi.hoisted(() => {
     scrollLinesCalls: number[];
     unlisten: ReturnType<typeof vi.fn>;
     listen: ReturnType<typeof vi.fn>;
+    openUrl: ReturnType<typeof vi.fn>;
     sessionAttach: ReturnType<typeof vi.fn>;
     sessionDestroy: ReturnType<typeof vi.fn>;
     sessionRefreshTheme: ReturnType<typeof vi.fn>;
@@ -81,6 +86,7 @@ const mockState = vi.hoisted(() => {
     scrollLinesCalls: [],
     unlisten: vi.fn(),
     listen: vi.fn(),
+    openUrl: vi.fn(),
     sessionAttach: vi.fn(),
     sessionDestroy: vi.fn(),
     sessionRefreshTheme: vi.fn(),
@@ -113,6 +119,10 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: mockState.listen,
 }));
 
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: mockState.openUrl,
+}));
+
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class MockFitAddon {
     fit(): void {
@@ -137,6 +147,7 @@ vi.mock("@xterm/xterm", () => ({
       [1, "$ npm test"],
       [2, "failed output"],
     ]);
+    wrappedLines = new Set<number>();
     private markerId = 0;
     parser = {
       registerOscHandler: (
@@ -163,11 +174,13 @@ vi.mock("@xterm/xterm", () => ({
             const text = this.bufferLines.get(lineIndex);
             if (text === undefined) return undefined;
             return {
+              isWrapped: this.wrappedLines.has(lineIndex),
               translateToString: () => text,
               getCell: (col: number) => {
                 const char = text[col] ?? " ";
                 return {
                   getChars: () => char,
+                  getWidth: () => 1,
                   isFgDefault: () => true,
                   getFgColor: () => 0,
                 };
@@ -272,6 +285,40 @@ function interruptNoticeElement(): HTMLElement {
   return el;
 }
 
+function setTerminalRect(container: HTMLElement): void {
+  container.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 800,
+      bottom: 480,
+      width: 800,
+      height: 480,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+function terminalClick(options: {
+  readonly row: number;
+  readonly col: number;
+  readonly metaKey?: boolean;
+  readonly shiftKey?: boolean;
+  readonly altKey?: boolean;
+}): MouseEvent {
+  return new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    clientX: (options.col + 0.5) * 10,
+    clientY: (options.row + 0.5) * 20,
+    metaKey: options.metaKey,
+    shiftKey: options.shiftKey,
+    altKey: options.altKey,
+  });
+}
+
 describe("TerminalRuntime", () => {
   beforeEach(() => {
     _clearForTest();
@@ -299,6 +346,8 @@ describe("TerminalRuntime", () => {
         return Promise.resolve(mockState.unlisten);
       },
     );
+    mockState.openUrl.mockReset();
+    mockState.openUrl.mockResolvedValue(undefined);
     mockState.sessionAttach.mockReset();
     mockState.sessionAttach.mockResolvedValue({ attached: false, replay: [] });
     mockState.sessionDestroy.mockReset();
@@ -331,6 +380,96 @@ describe("TerminalRuntime", () => {
 
     expect(terminal.clearCalls).toBe(0);
     expect(terminal.writes.filter((write) => write === "\x1b[3J")).toHaveLength(2);
+  });
+
+  it("Cmd-click した HTTP(S) URL を Tauri opener で開く", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    const line = "Docs: https://example.com/path?q=one#intro).";
+    terminal.bufferLines.set(1, line);
+    const container = document.querySelector<HTMLElement>(".xterm-singleton-container");
+    expect(container).not.toBeNull();
+    if (!container) return;
+    setTerminalRect(container);
+
+    const clickedCol = line.indexOf("example") + 2;
+    const event = terminalClick({ metaKey: true, row: 1, col: clickedCol });
+    container.dispatchEvent(event);
+
+    expect(mockState.openUrl).toHaveBeenCalledOnce();
+    expect(mockState.openUrl).toHaveBeenCalledWith("https://example.com/path?q=one#intro");
+    expect(event.defaultPrevented).toBe(true);
+    expect(runtime.getTerminalReferences()).toEqual([]);
+  });
+
+  it("Cmd-click はクリック位置が URL 外なら opener も行参照も発火しない", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    terminal.bufferLines.set(1, "Docs: https://example.com/path");
+    const container = document.querySelector<HTMLElement>(".xterm-singleton-container");
+    expect(container).not.toBeNull();
+    if (!container) return;
+    setTerminalRect(container);
+
+    const event = terminalClick({ metaKey: true, row: 1, col: 2 });
+    container.dispatchEvent(event);
+
+    expect(mockState.openUrl).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    expect(runtime.getTerminalReferences()).toEqual([]);
+  });
+
+  it("Cmd+Shift-click は URL 上でも opener ではなく既存の行参照を作る", () => {
+    const runtime = getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    terminal.bufferLines.set(1, "Docs: https://example.com/path");
+    const container = document.querySelector<HTMLElement>(".xterm-singleton-container");
+    expect(container).not.toBeNull();
+    if (!container) return;
+    setTerminalRect(container);
+
+    const event = terminalClick({ metaKey: true, shiftKey: true, row: 1, col: 15 });
+    container.dispatchEvent(event);
+
+    expect(mockState.openUrl).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+    expect(runtime.getLatestRegionContext()).toMatchObject({
+      text: "Docs: https://example.com/path",
+      gesture: "meta-shift-click",
+      range: { startRow: 1, endRow: 1, startCol: 0, endCol: 29 },
+    });
+    expect(runtime.getTerminalReferences()).toHaveLength(1);
+  });
+
+  it("Cmd-click は viewport 内で折り返された URL の全体を開く", () => {
+    getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    terminal.bufferLines.set(1, `${" ".repeat(70)}https://ex`);
+    terminal.bufferLines.set(2, "ample.com/docs");
+    terminal.wrappedLines.add(2);
+    const container = document.querySelector<HTMLElement>(".xterm-singleton-container");
+    expect(container).not.toBeNull();
+    if (!container) return;
+    setTerminalRect(container);
+
+    container.dispatchEvent(terminalClick({ metaKey: true, row: 2, col: 4 }));
+
+    expect(mockState.openUrl).toHaveBeenCalledWith("https://example.com/docs");
+  });
+
+  it("通常 click と Option+Cmd-click は URL を開かない", () => {
+    getTerminalRuntime("shell-1");
+    const terminal = mockState.terminals[0];
+    terminal.bufferLines.set(1, "https://example.com");
+    const container = document.querySelector<HTMLElement>(".xterm-singleton-container");
+    expect(container).not.toBeNull();
+    if (!container) return;
+    setTerminalRect(container);
+
+    container.dispatchEvent(terminalClick({ row: 1, col: 4 }));
+    container.dispatchEvent(terminalClick({ metaKey: true, altKey: true, row: 1, col: 4 }));
+
+    expect(mockState.openUrl).not.toHaveBeenCalled();
   });
 
   it("region highlight cleanup does not cancel a pending IME commit", async () => {
@@ -383,6 +522,7 @@ describe("TerminalRuntime", () => {
           bubbles: true,
           cancelable: true,
           metaKey: true,
+          shiftKey: true,
           button: 0,
           clientX: 10,
           clientY: 25,

--- a/src/runtime/terminal-runtime/terminal-runtime.ts
+++ b/src/runtime/terminal-runtime/terminal-runtime.ts
@@ -1,4 +1,5 @@
 import { Channel } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { FitAddon } from "@xterm/addon-fit";
 import type { ITheme as XTermTheme } from "@xterm/xterm";
 import { Terminal as XTerm } from "@xterm/xterm";
@@ -25,6 +26,7 @@ import {
 import { decodeOsc633Value } from "./osc633";
 import { extractRegionText, polygonBounds, type RegionPoint } from "./region-selection";
 import { detectTerminalProblems, type TerminalProblem } from "./terminal-problems";
+import { findHttpUrlAtTextOffset } from "./terminal-url";
 import type {
   InterruptProtectionMode,
   PtyParams,
@@ -242,6 +244,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     const regionCtx = this.createRegionCanvas();
     this.regionCanvas = regionCtx?.canvas ?? null;
     this.regionCtx = regionCtx?.context ?? null;
+    this.installTerminalClickHandler();
     if (regionCtx) {
       this.installRegionSelectionHandlers();
     }
@@ -1556,9 +1559,77 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     return { canvas, context };
   }
 
-  private handleMetaClick(event: MouseEvent): void {
+  private handleTerminalClick(event: MouseEvent): void {
     if (this.disposed) return;
-    if (!event.metaKey || event.altKey || event.shiftKey || event.button !== 0) return;
+    if (!event.metaKey || event.altKey || event.button !== 0) return;
+
+    if (event.shiftKey) {
+      this.handleMetaShiftClick(event);
+      return;
+    }
+
+    const url = this.findHttpUrlAtClick(event);
+    if (url === null) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    void openUrl(url).catch((error: unknown) => {
+      console.error("Failed to open terminal URL", error);
+    });
+  }
+
+  private findHttpUrlAtClick(event: MouseEvent): string | null {
+    const buffer = this.term.buffer.active;
+    if (!buffer) return null;
+
+    const containerRect = this.xtermContainer.getBoundingClientRect();
+    if (containerRect.width === 0 || containerRect.height === 0) return null;
+
+    const cellWidth = containerRect.width / this.term.cols;
+    const cellHeight = containerRect.height / this.term.rows;
+    const row = Math.floor((event.clientY - containerRect.top) / cellHeight);
+    const col = Math.floor((event.clientX - containerRect.left) / cellWidth);
+    if (row < 0 || row >= this.term.rows || col < 0 || col >= this.term.cols) return null;
+
+    const clickedBufferRow = buffer.viewportY + row;
+    let logicalStartRow = clickedBufferRow;
+    while (logicalStartRow > 0 && buffer.getLine(logicalStartRow)?.isWrapped) {
+      logicalStartRow--;
+    }
+
+    let text = "";
+    let clickedOffset: number | null = null;
+    for (let bufferRow = logicalStartRow; ; bufferRow++) {
+      const line = buffer.getLine(bufferRow);
+      if (!line || (bufferRow > logicalStartRow && !line.isWrapped)) break;
+
+      for (let cellCol = 0; cellCol < this.term.cols; cellCol++) {
+        const cell = line.getCell(cellCol);
+        const chars = cell?.getChars() ?? "";
+        const width = cell?.getWidth() ?? 1;
+
+        if (bufferRow === clickedBufferRow && cellCol === col) {
+          // A width-zero cell is the continuation half of a wide glyph, never a URL character.
+          if (width === 0) return null;
+          clickedOffset = text.length;
+        }
+
+        if (chars !== "") {
+          text += chars;
+        } else if (width > 0) {
+          text += " ";
+        }
+      }
+
+      if (!buffer.getLine(bufferRow + 1)?.isWrapped) break;
+    }
+
+    return clickedOffset === null ? null : findHttpUrlAtTextOffset(text, clickedOffset);
+  }
+
+  private handleMetaShiftClick(event: MouseEvent): void {
+    if (this.disposed) return;
+    if (!event.metaKey || event.altKey || !event.shiftKey || event.button !== 0) return;
 
     const buffer = this.term.buffer.active;
     if (!buffer) return;
@@ -1611,7 +1682,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
       sessionId: this.sessionId,
       text,
       capturedAt: Date.now(),
-      gesture: "meta-click",
+      gesture: "meta-shift-click",
       viewport: {
         viewportY: buffer.viewportY,
         rows: this.term.rows,
@@ -1638,16 +1709,19 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     }
   }
 
-  private installRegionSelectionHandlers(): void {
+  private installTerminalClickHandler(): void {
     this.xtermContainer.addEventListener(
       "click",
       (event) => {
-        // Cmd+click は 1 行 region context。通常クリックには terminal 側の追加 UI を出さない。
-        this.handleMetaClick(event);
+        // Cmd+click は URL の上だけ opener へ渡し、Cmd+Shift+click は行参照を作る。
+        // それ以外の click は xterm の選択・TUI mouse handling にそのまま任せる。
+        this.handleTerminalClick(event);
       },
       { capture: true },
     );
+  }
 
+  private installRegionSelectionHandlers(): void {
     this.xtermContainer.addEventListener(
       "pointerdown",
       (event) => {
@@ -1851,7 +1925,7 @@ class TerminalRuntimeImpl implements TerminalRuntime {
     ctx.restore();
   }
 
-  /** Command+click 用: 囲み線なしの fill のみハイライト。 */
+  /** Command+Shift+click 用: 囲み線なしの fill のみハイライト。 */
   private drawRegionHighlight(polygon: ReadonlyArray<RegionPoint>): void {
     if (!this.regionCtx) return;
     this.clearRegionCanvasNow();

--- a/src/runtime/terminal-runtime/terminal-url.test.ts
+++ b/src/runtime/terminal-runtime/terminal-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { findHttpUrlAtTextOffset } from "./terminal-url";
+
+describe("findHttpUrlAtTextOffset", () => {
+  it.each([
+    ["Docs: https://example.com/path?q=one#intro", 12, "https://example.com/path?q=one#intro"],
+    ["Local: http://localhost:5173/", 15, "http://localhost:5173/"],
+    ["(https://example.com/docs).", 10, "https://example.com/docs"],
+    ["https://example.com/a_(b)", 22, "https://example.com/a_(b)"],
+  ])("returns the HTTP(S) URL under the clicked offset", (text, offset, expected) => {
+    expect(findHttpUrlAtTextOffset(text, offset)).toBe(expected);
+  });
+
+  it("chooses between multiple links using the clicked offset", () => {
+    const text = "https://one.example or https://two.example/docs";
+
+    expect(findHttpUrlAtTextOffset(text, 10)).toBe("https://one.example");
+    expect(findHttpUrlAtTextOffset(text, 35)).toBe("https://two.example/docs");
+  });
+
+  it.each([
+    ["prefix https://example.com suffix", 2],
+    ["prefix https://example.com suffix", 29],
+    ["javascript:alert(1)", 5],
+    ["file:///tmp/report.html", 10],
+    ["nothttps://example.com", 8],
+    ["https://exa mple.com", 15],
+  ])("rejects non-link offsets and unsupported or malformed URLs", (text, offset) => {
+    expect(findHttpUrlAtTextOffset(text, offset)).toBeNull();
+  });
+});

--- a/src/runtime/terminal-runtime/terminal-url.ts
+++ b/src/runtime/terminal-runtime/terminal-url.ts
@@ -1,0 +1,68 @@
+const HTTP_URL_PATTERN = /https?:\/\/[^\s<>"'`]+/giu;
+const TRAILING_SENTENCE_PUNCTUATION = /[.,;!]+$/u;
+
+const CLOSING_DELIMITERS = [
+  [")", "("],
+  ["]", "["],
+  ["}", "{"],
+] as const;
+
+/**
+ * Return the visible HTTP(S) URL under a text offset.
+ *
+ * Terminal output often surrounds links with prose or Markdown punctuation. We
+ * keep balanced delimiters that belong to the URL and remove only unmatched
+ * closers and sentence punctuation before validating the protocol.
+ */
+export function findHttpUrlAtTextOffset(text: string, offset: number): string | null {
+  if (!Number.isInteger(offset) || offset < 0 || offset >= text.length) return null;
+
+  for (const match of text.matchAll(HTTP_URL_PATTERN)) {
+    const matchStart = match.index;
+    if (matchStart === undefined || hasIdentifierPrefix(text, matchStart)) continue;
+
+    const candidate = trimTerminalUrlPunctuation(match[0]);
+    const matchEnd = matchStart + candidate.length;
+    if (offset < matchStart || offset >= matchEnd) continue;
+
+    try {
+      const parsed = new URL(candidate);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+      return candidate;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function hasIdentifierPrefix(text: string, start: number): boolean {
+  if (start === 0) return false;
+  return /[\p{L}\p{N}_]/u.test(text[start - 1] ?? "");
+}
+
+function trimTerminalUrlPunctuation(raw: string): string {
+  let candidate = raw.replace(TRAILING_SENTENCE_PUNCTUATION, "");
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    for (const [closing, opening] of CLOSING_DELIMITERS) {
+      if (!candidate.endsWith(closing)) continue;
+      if (count(candidate, closing) <= count(candidate, opening)) continue;
+      candidate = candidate.slice(0, -closing.length);
+      changed = true;
+    }
+  }
+
+  return candidate.replace(TRAILING_SENTENCE_PUNCTUATION, "");
+}
+
+function count(value: string, token: string): number {
+  let total = 0;
+  for (const char of value) {
+    if (char === token) total++;
+  }
+  return total;
+}

--- a/src/runtime/terminal-runtime/types.ts
+++ b/src/runtime/terminal-runtime/types.ts
@@ -52,7 +52,7 @@ export interface TerminalLineRect {
 
 /**
  * 参照マーカー付きの terminal text reference。
- * Command+click や Option+Shift+drag で capture → `[#Term<N>]` として入力欄に挿入される。
+ * Command+Shift+click や Option+Shift+drag で capture → `[#Term<N>]` として入力欄に挿入される。
  * `id` は MCP 向けの session-stamped opaque id（例: `session-1:Term1`）。
  */
 export interface TerminalReference {
@@ -75,7 +75,7 @@ export interface TerminalRegionContext {
   readonly sessionId: string;
   readonly text: string;
   readonly capturedAt: number;
-  readonly gesture: "option-shift-drag" | "meta-click" | "command-run-reference";
+  readonly gesture: "option-shift-drag" | "meta-shift-click" | "command-run-reference";
   /** command-run reference だけが持つ。MCP はこの id だけを metadata として見る。 */
   readonly commandRunId?: number;
   readonly viewport: {
@@ -280,20 +280,20 @@ export interface TerminalRuntime {
   readScreenTailText(maxLines?: number): string;
 
   /**
-   * Option+Shift+drag / Command+click で capture した最新 terminal context を返す。
+   * Option+Shift+drag / Command+Shift+click で capture した最新 terminal context を返す。
    * 未選択 / 空選択なら null。
    */
   getLatestRegionContext(): TerminalRegionContext | null;
 
   /**
-   * Option+Shift+drag / Command+click の terminal context 確定時に listener を呼ぶ。
+   * Option+Shift+drag / Command+Shift+click の terminal context 確定時に listener を呼ぶ。
    * attention producer / UI feedback 用。dispose で listener を外す。
    */
   subscribeRegionContext(listener: (context: TerminalRegionContext) => void): Disposable;
 
   /**
    * `[#Term<N>]` マーカー付きで蓄積された terminal text reference の一覧。
-   * Command+click や Option+Shift+drag で capture → 入力に marker 挿入される。
+   * Command+Shift+click や Option+Shift+drag で capture → 入力に marker 挿入される。
    */
   getTerminalReferences(): ReadonlyArray<TerminalReference>;
 


### PR DESCRIPTION
## Summary

- open visible HTTP/HTTPS terminal URLs with Cmd-click through the existing Tauri opener integration
- move whole-line terminal reference capture to Cmd+Shift-click while preserving Option+Shift rectangular capture
- update README, terminal documentation, trust-boundary notes, MCP help text, and gesture types
- cover URL hit testing, punctuation, multiple links, wrapped lines, and gesture precedence

## Why

Terminal URLs currently require copying and pasting, while Cmd-click is occupied by whole-line AI reference capture. This gives direct browser navigation to explicit HTTP/HTTPS link clicks and moves the existing reference gesture to Cmd+Shift-click.

## User impact

Cmd-clicking a visible HTTP/HTTPS URL now opens it in the OS default browser. Cmd+Shift-click creates the same whole-line `[#TermN]` AI reference that Cmd-click created previously. Ordinary terminal interaction and Option+Shift rectangular references remain unchanged.

## Validation

- `npm run check`
- `npm run test:run` (191 files, 2460 tests)
- `npm run test:rust` (309 tests)
- pre-push hooks: TypeScript, Biome, cargo fmt, Clippy, Typedoc validation

Closes #126
