### PR TITLE
Isolate MCP endpoints per Yorishiro instance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,7 @@ Source code 内で参照するときは：
 | `lib.rs` / `main.rs` | Tauri app entry / command 登録 / setup hook | [../src-tauri/README.md](../src-tauri/README.md) |
 | `pty.rs` | Legacy PTY facade / hook server (port 19001) | 同上 |
 | `sessions/` | Per-session PTY lifecycle / registry / shell wrapper / terminal agent adapter | 同上 |
-| `mcp/` | MCP 1.5 server (port 18743 default) / pack diagnostics + self-referential tools | 同上 |
+| `mcp/` | MCP 1.5 server (18743 preferred / per-instance endpoint) / pack diagnostics + self-referential tools | 同上 |
 | User layer commands | `~/.yorishiro/` の watch / atomic write / pack scan | 同上 |
 
 ### 3.4 Bundled packs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,6 @@ Yorishiro は起動時に `~/.yorishiro/config.json` を読み、壊れている
   },
   "activeUi": "minimal-badge",
   "motionIntensity": 1.85,
-  "mcpPort": 18743,
   "disabledPacks": ["broken-pack"]
 }
 ```
@@ -40,7 +39,7 @@ Yorishiro は起動時に `~/.yorishiro/config.json` を読み、壊れている
 | `sceneByProject` | `{ [projectRoot: string]: string }` | `{}` | 正規化された project root ごとの active scene override。現在の project root に entry があれば `activeScene` より優先 |
 | `activeUi` | `string` or `null` | `null` | active UI pack の user pick。`null` なら UI pack なし |
 | `motionIntensity` | `number` (`0.0`–`3.0`) | `1.0` | idle procedural motion（呼吸 / sway / head drift / posture）の振幅ノブ。`1.0` は従来どおり、`0` 付近はほぼ静止、上端は opt-in のオーバーアクション |
-| `mcpPort` | `number` | `18743` | Rust MCP server の listen port |
+| `mcpPort` | `number` | auto（18743 preferred） | Rust MCP server の固定 listen port。未指定なら 18743 を試し、使用中の場合は instance ごとの空き port を自動選択する。指定時は自動 fallback せず、衝突するとその instance の agent 起動を fail closed にする |
 | `disabledPacks` | `string[]` | `[]` | rescue 用。指定 id の user pack を load しない |
 | `journalCallback` | `"normal"`, `"rare"`, or `"off"` | `"normal"` | journal callback（セッション開始時の記憶想起）の頻度ノブ。`rare` は日常の想起をせず節目と久しぶりの起動だけに絞り、`off` で無効化。Rust 側が config.json を直接読む |
 

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -26,7 +26,7 @@ src-tauri/src/
 │       └── opencode.rs — OpenCode adapter
 └── mcp/
     ├── mod.rs     — re-exports (4 lines)
-    ├── server.rs  — MCP HTTP server (port 18743 default) / spawn / round-trip
+    ├── server.rs  — MCP HTTP server (18743 preferred / per-instance endpoint) / spawn / round-trip
     ├── tools.rs   — MCP tool 実装 (pack diagnostics / pack enable-disable / state / controls / presence tools)
     └── types.rs   — DTO 定義（TS と shared shape の document 役割）
 ```
@@ -71,7 +71,7 @@ MCP:
 
 1. State 登録：`PtyState`、`WatcherState`
 2. Hook server 起動：127.0.0.1:**19001**（Claude Code → Yorishiro の signal 受け）
-3. MCP server spawn：`~/.yorishiro/config.json::mcpPort`、default **18743**（失敗しても crash せず stderr に log）
+3. MCP server spawn：`mcpPort` 指定時は固定、未指定時は **18743** preferred + 空き port fallback。runtime endpoint を instance 単位で保持（失敗しても app は crash せず、agent spawn は fail closed）
 4. Plugins setup：opener、dialog
 5. Tauri runloop へ
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,15 +23,6 @@ use tauri::{AppHandle, Emitter, Manager, State};
 /// `Option` は終了時に `take()` して二重 save を防ぐため。
 struct CohabitationStart(std::sync::Mutex<Option<std::time::Instant>>);
 
-#[derive(Clone, Default, serde::Serialize)]
-struct McpServerStatusSnapshot {
-    port: Option<u16>,
-    error: Option<String>,
-}
-
-#[derive(Default)]
-struct McpServerStatus(Mutex<McpServerStatusSnapshot>);
-
 static LOCALIZED_PLUGIN_DIR_LOCK: Mutex<()> = Mutex::new(());
 
 #[cfg(test)]
@@ -1313,13 +1304,9 @@ fn list_supported_agents() -> Vec<sessions::agent_adapter::AgentDescriptor> {
 /// Return the MCP server startup result captured during Tauri setup.
 #[tauri::command]
 async fn mcp_server_status(
-    state: State<'_, McpServerStatus>,
-) -> Result<McpServerStatusSnapshot, String> {
-    state
-        .0
-        .lock()
-        .map(|status| status.clone())
-        .map_err(|_| "mcp status lock poisoned".to_string())
+    state: State<'_, mcp::McpServerStatus>,
+) -> Result<mcp::McpServerStatusSnapshot, String> {
+    state.snapshot()
 }
 
 /// SDK `.d.ts` ファイル一式。compile 時に bundle に含める。
@@ -2498,7 +2485,7 @@ pub fn run() {
         .manage(RealtimeBridgeState::default())
         .manage(WatcherState::new())
         .manage(tts::TtsState::new())
-        .manage(McpServerStatus::default())
+        .manage(mcp::McpServerStatus::default())
         .invoke_handler(tauri::generate_handler![
             prepare_localized_plugin_dir,
             resolve_command_path,
@@ -2569,21 +2556,15 @@ pub fn run() {
             start_hook_server(app.handle().clone());
             let mcp_handle = app.handle().clone();
             match mcp::spawn_server(mcp_handle) {
-                Ok(port) => {
-                    if let Ok(mut status) = app.state::<McpServerStatus>().0.lock() {
-                        *status = McpServerStatusSnapshot {
-                            port: Some(port),
-                            error: None,
-                        };
+                Ok(runtime) => {
+                    if let Err(error) = app.state::<mcp::McpServerStatus>().set_started(&runtime) {
+                        eprintln!("[yorishiro-mcp] status update failed: {error}");
                     }
-                    eprintln!("[yorishiro-mcp] listening on localhost:{}", port);
+                    eprintln!("[yorishiro-mcp] listening at {}", runtime.endpoint);
                 }
                 Err(err) => {
-                    if let Ok(mut status) = app.state::<McpServerStatus>().0.lock() {
-                        *status = McpServerStatusSnapshot {
-                            port: None,
-                            error: Some(err.clone()),
-                        };
+                    if let Err(error) = app.state::<mcp::McpServerStatus>().set_error(err.clone()) {
+                        eprintln!("[yorishiro-mcp] status update failed: {error}");
                     }
                     eprintln!("[yorishiro-mcp] startup skipped: {}", err);
                 }

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -12,4 +12,4 @@ pub mod server;
 pub mod tools;
 pub mod types;
 
-pub use server::spawn_server;
+pub use server::{spawn_server, McpServerStatus, McpServerStatusSnapshot};

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -1,8 +1,9 @@
 //! Yorishiro MCP server の起動と lifecycle、および Rust → TS event channel の
 //! round-trip 管理。
 //!
-//! port は `~/.yorishiro/config.json` の mcpPort か default 18743。bind fail
-//! は log に書いて server 起動を skip、Yorishiro 本体は継続させる。
+//! port は `~/.yorishiro/config.json` の mcpPort が explicit なら固定。未指定なら
+//! default 18743 を試し、使用中なら OS 選択の空き port に退避する。embedded agent
+//! には、この process だけが持つ instance path を含む endpoint を渡す。
 //!
 //! rmcp 1.7.0 の `transport-streamable-http-server` feature を `axum` の
 //! Router に nest してもらい、`tokio::spawn` で background に流す。
@@ -16,6 +17,8 @@
 //! Internal design-record: 2026-04-18-phase-1c-rescue-and-mcp.md Section 4.5 / 4.6
 
 use std::collections::HashMap;
+use std::io::ErrorKind;
+use std::net::TcpListener;
 use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
@@ -29,6 +32,75 @@ use tokio::sync::oneshot;
 use crate::mcp::tools::Yorishiro;
 
 const DEFAULT_PORT: u16 = 18743;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct McpServerRuntime {
+    pub port: u16,
+    pub endpoint: String,
+    pub instance_id: String,
+}
+
+#[derive(Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerStatusSnapshot {
+    pub port: Option<u16>,
+    pub endpoint: Option<String>,
+    pub instance_id: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Default)]
+pub struct McpServerStatus(Mutex<McpServerStatusSnapshot>);
+
+impl McpServerStatus {
+    pub fn snapshot(&self) -> Result<McpServerStatusSnapshot, String> {
+        self.0
+            .lock()
+            .map(|status| status.clone())
+            .map_err(|_| "mcp status lock poisoned".to_string())
+    }
+
+    pub fn set_started(&self, runtime: &McpServerRuntime) -> Result<(), String> {
+        let mut status = self
+            .0
+            .lock()
+            .map_err(|_| "mcp status lock poisoned".to_string())?;
+        *status = McpServerStatusSnapshot {
+            port: Some(runtime.port),
+            endpoint: Some(runtime.endpoint.clone()),
+            instance_id: Some(runtime.instance_id.clone()),
+            error: None,
+        };
+        Ok(())
+    }
+
+    pub fn set_error(&self, error: String) -> Result<(), String> {
+        let mut status = self
+            .0
+            .lock()
+            .map_err(|_| "mcp status lock poisoned".to_string())?;
+        *status = McpServerStatusSnapshot {
+            port: None,
+            endpoint: None,
+            instance_id: None,
+            error: Some(error),
+        };
+        Ok(())
+    }
+
+    pub fn endpoint(&self) -> Result<String, String> {
+        let status = self
+            .0
+            .lock()
+            .map_err(|_| "mcp status lock poisoned".to_string())?;
+        status.endpoint.clone().ok_or_else(|| {
+            status.error.clone().map_or_else(
+                || "MCP server is not ready for this Yorishiro instance".to_string(),
+                |error| format!("MCP server is unavailable for this Yorishiro instance: {error}"),
+            )
+        })
+    }
+}
 
 /// Rust → TS event channel の timeout。5s 以内に response が来なければ諦める。
 const TOOL_EVENT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -80,10 +152,38 @@ fn read_configured_port() -> Option<u16> {
         .get("mcpPort")
         .and_then(|v| v.as_u64())
         .and_then(|n| u16::try_from(n).ok())
+        .filter(|port| *port != 0)
 }
 
-pub(crate) fn resolve_port() -> u16 {
-    read_configured_port().unwrap_or(DEFAULT_PORT)
+fn bind_listener_for_port(
+    configured_port: Option<u16>,
+    preferred_default_port: u16,
+) -> Result<TcpListener, String> {
+    let listener = if let Some(port) = configured_port {
+        TcpListener::bind(("127.0.0.1", port))
+            .map_err(|error| format!("configured MCP port {port} bind failed: {error}"))?
+    } else {
+        match TcpListener::bind(("127.0.0.1", preferred_default_port)) {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == ErrorKind::AddrInUse => {
+                TcpListener::bind(("127.0.0.1", 0))
+                    .map_err(|error| format!("automatic MCP port bind failed: {error}"))?
+            }
+            Err(error) => {
+                return Err(format!(
+                    "default MCP port {preferred_default_port} bind failed: {error}"
+                ));
+            }
+        }
+    };
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| format!("MCP listener nonblocking setup failed: {error}"))?;
+    Ok(listener)
+}
+
+fn instance_endpoint(port: u16, instance_id: &str) -> String {
+    format!("http://127.0.0.1:{port}/instances/{instance_id}/mcp")
 }
 
 /// Poisoned Mutex を recover しつつ guard を返す。pty.rs と同じ方針。
@@ -222,16 +322,17 @@ pub fn resolve_pending_response(request_id: &str, response: Value) -> Result<(),
     Ok(())
 }
 
-/// MCP server を spawn する。bind fail で panic せず Err を返す。
-/// 呼び出し元（lib.rs setup）が Err を dev-log に落として継続する。
-pub fn spawn_server(app_handle: AppHandle) -> Result<u16, String> {
-    let port = resolve_port();
-
-    // bind pre-check — rmcp 側の async bind 前に占有確認。ここで fail したら
-    // early return して Yorishiro 本体は継続させる。
-    let probe = std::net::TcpListener::bind(("127.0.0.1", port))
-        .map_err(|e| format!("port {} bind failed: {}", port, e))?;
-    drop(probe); // すぐ解放、rmcp 側で再 bind。
+/// MCP server を spawn する。listener はこの関数内で同期的に確保し、そのまま
+/// async runtime へ move するため、probe → drop → re-bind の race を作らない。
+pub fn spawn_server(app_handle: AppHandle) -> Result<McpServerRuntime, String> {
+    let listener = bind_listener_for_port(read_configured_port(), DEFAULT_PORT)?;
+    let port = listener
+        .local_addr()
+        .map_err(|error| format!("MCP listener address lookup failed: {error}"))?
+        .port();
+    let instance_id = uuid::Uuid::new_v4().to_string();
+    let endpoint = instance_endpoint(port, &instance_id);
+    let instance_path = format!("/instances/{instance_id}/mcp");
 
     // rmcp StreamableHttpService を axum Router に mount して tokio::spawn で
     // background に流す。factory closure は session ごとに Yorishiro 新規 instance
@@ -249,17 +350,21 @@ pub fn spawn_server(app_handle: AppHandle) -> Result<u16, String> {
         .into(),
         Default::default(),
     );
-    let router = axum::Router::new().nest_service("/mcp", service);
+    // /mcp は既存の手動 client 互換。embedded agent は instance path だけを使うため、
+    // 別 process の endpoint を誤って渡されても route が一致せず接続できない。
+    let router = axum::Router::new()
+        .nest_service("/mcp", service.clone())
+        .nest_service(&instance_path, service);
 
     // Tauri 2 の setup closure は tokio runtime context 内で動かないため、
     // `tokio::spawn` を直接呼ぶと "no reactor running" panic になる。
     // tauri の async_runtime::spawn は Tauri 本体の tokio runtime 上に task を
     // 流すため、setup の外側からでも安全に呼べる。
     tauri::async_runtime::spawn(async move {
-        let listener = match tokio::net::TcpListener::bind(("127.0.0.1", port)).await {
+        let listener = match tokio::net::TcpListener::from_std(listener) {
             Ok(l) => l,
             Err(e) => {
-                eprintln!("[yorishiro-mcp] bind failed after probe: {}", e);
+                eprintln!("[yorishiro-mcp] listener handoff failed: {}", e);
                 return;
             }
         };
@@ -268,7 +373,11 @@ pub fn spawn_server(app_handle: AppHandle) -> Result<u16, String> {
         }
     });
 
-    Ok(port)
+    Ok(McpServerRuntime {
+        port,
+        endpoint,
+        instance_id,
+    })
 }
 
 #[cfg(test)]
@@ -276,7 +385,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_port_falls_back_to_default_when_no_config() {
+    fn configured_port_is_none_when_no_config_exists() {
         let _guard = crate::TEST_HOME_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -292,10 +401,62 @@ mod tests {
                     .unwrap_or(0)
             )),
         );
-        assert_eq!(resolve_port(), DEFAULT_PORT);
-        if let Some(h) = orig {
-            std::env::set_var("HOME", h);
+        assert_eq!(read_configured_port(), None);
+        match orig {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
         }
+    }
+
+    #[test]
+    fn unconfigured_listener_falls_back_when_preferred_port_is_occupied() {
+        let occupied = TcpListener::bind(("127.0.0.1", 0)).expect("bind occupied port");
+        let occupied_port = occupied.local_addr().expect("occupied address").port();
+
+        let listener =
+            bind_listener_for_port(None, occupied_port).expect("bind automatic fallback port");
+        let selected_port = listener.local_addr().expect("selected address").port();
+
+        assert_ne!(selected_port, occupied_port);
+    }
+
+    #[test]
+    fn configured_listener_fails_closed_when_port_is_occupied() {
+        let occupied = TcpListener::bind(("127.0.0.1", 0)).expect("bind occupied port");
+        let occupied_port = occupied.local_addr().expect("occupied address").port();
+
+        let error = bind_listener_for_port(Some(occupied_port), DEFAULT_PORT)
+            .expect_err("configured collision must fail");
+
+        assert!(error.contains("configured MCP port"));
+        assert!(error.contains(&occupied_port.to_string()));
+    }
+
+    #[test]
+    fn instance_endpoint_contains_runtime_identity() {
+        assert_eq!(
+            instance_endpoint(18744, "instance-a"),
+            "http://127.0.0.1:18744/instances/instance-a/mcp"
+        );
+        assert_ne!(
+            instance_endpoint(18744, "instance-a"),
+            instance_endpoint(18744, "instance-b")
+        );
+    }
+
+    #[test]
+    fn status_returns_only_the_started_runtime_endpoint() {
+        let status = McpServerStatus::default();
+        assert!(status.endpoint().is_err());
+
+        let runtime = McpServerRuntime {
+            port: 18744,
+            endpoint: instance_endpoint(18744, "instance-a"),
+            instance_id: "instance-a".to_string(),
+        };
+        status.set_started(&runtime).expect("store runtime status");
+
+        assert_eq!(status.endpoint(), Ok(runtime.endpoint));
     }
 
     #[test]

--- a/src-tauri/src/sessions/agent_adapter/claude.rs
+++ b/src-tauri/src/sessions/agent_adapter/claude.rs
@@ -32,6 +32,9 @@ impl TerminalAgent for ClaudeAgent {
     fn build_launch_args(&self, ctx: &LaunchContext<'_>) -> Result<LaunchArgs, String> {
         let mut args = Vec::new();
         let mut temp_files = Vec::new();
+        let mcp_endpoint = ctx
+            .mcp_endpoint
+            .ok_or_else(|| "Yorishiro MCP endpoint is unavailable".to_string())?;
 
         if ctx.resume && self.has_existing_session(ctx.cwd) {
             args.push("-c".to_string());
@@ -47,8 +50,9 @@ impl TerminalAgent for ClaudeAgent {
         temp_files.push(hooks_path);
 
         // Claude Code plugin 配下の .mcp.json は auto-discover されないため、
-        // 起動ごとに実 port を反映した config を session-scoped に生成する。
-        let mcp_config_json = claude_yorishiro_mcp_config_json(ctx.mcp_port);
+        // 起動ごとに、この Yorishiro process が所有する endpoint を反映した config を
+        // session-scoped に生成する。未起動時は別 instance へ fallback せず fail closed。
+        let mcp_config_json = claude_yorishiro_mcp_config_json(mcp_endpoint);
         let mcp_config_path = super::temp_config_path("mcp", "json");
         let mcp_config_path_arg = super::utf8_path_for_cli(&mcp_config_path, "Claude MCP config")?;
         std::fs::write(&mcp_config_path, &mcp_config_json)
@@ -86,12 +90,12 @@ impl TerminalAgent for ClaudeAgent {
     }
 }
 
-fn claude_yorishiro_mcp_config_json(port: u16) -> String {
+fn claude_yorishiro_mcp_config_json(endpoint: &str) -> String {
     serde_json::json!({
         "mcpServers": {
             "yorishiro": {
                 "type": "http",
-                "url": format!("http://127.0.0.1:{}/mcp", port),
+                "url": endpoint,
             }
         }
     })
@@ -214,12 +218,35 @@ mod tests {
 
     #[test]
     fn claude_yorishiro_mcp_config_json_points_to_streamable_http_server() {
-        let parsed: serde_json::Value =
-            serde_json::from_str(&claude_yorishiro_mcp_config_json(18744)).expect("valid json");
+        let parsed: serde_json::Value = serde_json::from_str(&claude_yorishiro_mcp_config_json(
+            "http://127.0.0.1:18744/instances/instance-a/mcp",
+        ))
+        .expect("valid json");
         assert_eq!(
             parsed["mcpServers"]["yorishiro"]["url"],
-            "http://127.0.0.1:18744/mcp"
+            "http://127.0.0.1:18744/instances/instance-a/mcp"
         );
         assert_eq!(parsed["mcpServers"]["yorishiro"]["type"], "http");
+    }
+
+    #[test]
+    fn claude_fails_closed_without_runtime_mcp_endpoint() {
+        let ctx = LaunchContext {
+            cwd: None,
+            system_prompt: None,
+            prompt_reminder: None,
+            plugin_dir: None,
+            mcp_endpoint: None,
+            hook_port: 19001,
+            resume: false,
+            resume_session_id: None,
+            realtime_endpoint: None,
+        };
+
+        let error = CLAUDE
+            .build_launch_args(&ctx)
+            .err()
+            .expect("missing endpoint must fail");
+        assert!(error.contains("MCP endpoint is unavailable"));
     }
 }

--- a/src-tauri/src/sessions/agent_adapter/codex.rs
+++ b/src-tauri/src/sessions/agent_adapter/codex.rs
@@ -53,8 +53,11 @@ impl TerminalAgent for CodexAgent {
             args.push("--last".to_string());
         }
 
+        let mcp_endpoint = ctx
+            .mcp_endpoint
+            .ok_or_else(|| "Yorishiro MCP endpoint is unavailable".to_string())?;
         args.push("-c".to_string());
-        args.push(codex_yorishiro_mcp_config_arg(ctx.mcp_port));
+        args.push(codex_yorishiro_mcp_config_arg(mcp_endpoint));
 
         if let Some(prompt) =
             super::merge_system_prompt_and_reminder(ctx.system_prompt, ctx.prompt_reminder)
@@ -167,9 +170,8 @@ fn toml_basic_string(value: &str) -> String {
     out
 }
 
-fn codex_yorishiro_mcp_config_arg(port: u16) -> String {
-    let url = format!("http://127.0.0.1:{}/mcp", port);
-    format!("mcp_servers.yorishiro.url={}", toml_basic_string(&url))
+fn codex_yorishiro_mcp_config_arg(endpoint: &str) -> String {
+    format!("mcp_servers.yorishiro.url={}", toml_basic_string(endpoint))
 }
 
 #[cfg(test)]
@@ -186,7 +188,7 @@ mod tests {
             system_prompt,
             prompt_reminder,
             plugin_dir: None,
-            mcp_port: 18743,
+            mcp_endpoint: Some("http://127.0.0.1:18743/instances/test-instance/mcp"),
             hook_port: 19001,
             resume: true,
             resume_session_id: None,
@@ -205,7 +207,7 @@ mod tests {
             system_prompt,
             prompt_reminder,
             plugin_dir: None,
-            mcp_port: 18743,
+            mcp_endpoint: Some("http://127.0.0.1:18743/instances/test-instance/mcp"),
             hook_port: 19001,
             resume,
             resume_session_id: None,
@@ -290,9 +292,21 @@ mod tests {
     #[test]
     fn codex_yorishiro_mcp_config_arg_points_to_streamable_http_server() {
         assert_eq!(
-            codex_yorishiro_mcp_config_arg(18743),
-            "mcp_servers.yorishiro.url=\"http://127.0.0.1:18743/mcp\""
+            codex_yorishiro_mcp_config_arg("http://127.0.0.1:18743/instances/test-instance/mcp"),
+            "mcp_servers.yorishiro.url=\"http://127.0.0.1:18743/instances/test-instance/mcp\""
         );
+    }
+
+    #[test]
+    fn codex_fails_closed_without_runtime_mcp_endpoint() {
+        let mut ctx = make_ctx_with_resume(None, None, None, false);
+        ctx.mcp_endpoint = None;
+
+        let error = CODEX
+            .build_launch_args(&ctx)
+            .err()
+            .expect("missing endpoint must fail");
+        assert!(error.contains("MCP endpoint is unavailable"));
     }
 
     #[test]
@@ -312,10 +326,10 @@ mod tests {
 
         assert!(!result.args.iter().any(|arg| arg == "resume"));
         assert!(!result.args.iter().any(|arg| arg == "--last"));
-        assert!(result
-            .args
-            .iter()
-            .any(|arg| arg == &codex_yorishiro_mcp_config_arg(18743)));
+        assert!(result.args.iter().any(|arg| arg
+            == &codex_yorishiro_mcp_config_arg(
+                "http://127.0.0.1:18743/instances/test-instance/mcp"
+            )));
     }
 
     #[test]

--- a/src-tauri/src/sessions/agent_adapter/mod.rs
+++ b/src-tauri/src/sessions/agent_adapter/mod.rs
@@ -66,7 +66,8 @@ pub struct LaunchContext<'a> {
     pub system_prompt: Option<&'a str>,
     pub prompt_reminder: Option<&'a str>,
     pub plugin_dir: Option<&'a Path>,
-    pub mcp_port: u16,
+    /// この process が実際に所有する instance-scoped MCP endpoint。
+    pub mcp_endpoint: Option<&'a str>,
     pub hook_port: u16,
     pub resume: bool,
     /// provider 固有の会話 ID を指定した exact resume。未指定時は従来の resume policy。

--- a/src-tauri/src/sessions/agent_adapter/opencode.rs
+++ b/src-tauri/src/sessions/agent_adapter/opencode.rs
@@ -36,6 +36,9 @@ impl TerminalAgent for OpencodeAgent {
         let mut env = Vec::new();
         let mut temp_files = Vec::new();
         let commands = opencode_yorishiro_commands(ctx.plugin_dir)?;
+        let mcp_endpoint = ctx
+            .mcp_endpoint
+            .ok_or_else(|| "Yorishiro MCP endpoint is unavailable".to_string())?;
 
         // OpenCode の runtime config は session-scoped 注入経路として env var に渡す。
         // project-local opencode.json との deep-merge は v2 scope。
@@ -44,7 +47,7 @@ impl TerminalAgent for OpencodeAgent {
             "mcp": {
                 "yorishiro": {
                     "type": "remote",
-                    "url": format!("http://127.0.0.1:{}/mcp", ctx.mcp_port),
+                    "url": mcp_endpoint,
                     "enabled": true,
                 }
             }
@@ -252,7 +255,7 @@ mod tests {
             system_prompt,
             prompt_reminder: None,
             plugin_dir,
-            mcp_port: 18743,
+            mcp_endpoint: Some("http://127.0.0.1:18743/instances/test-instance/mcp"),
             hook_port: 19001,
             resume: true,
             resume_session_id: None,
@@ -269,7 +272,7 @@ mod tests {
             system_prompt,
             prompt_reminder,
             plugin_dir: None,
-            mcp_port: 18743,
+            mcp_endpoint: Some("http://127.0.0.1:18743/instances/test-instance/mcp"),
             hook_port: 19001,
             resume: true,
             resume_session_id: None,
@@ -352,9 +355,24 @@ mod tests {
         let parsed: Value = serde_json::from_str(json_str).expect("valid json");
         let yorishiro_mcp = &parsed["mcp"]["yorishiro"];
         assert_eq!(yorishiro_mcp["type"], "remote");
-        assert_eq!(yorishiro_mcp["url"], "http://127.0.0.1:18743/mcp");
+        assert_eq!(
+            yorishiro_mcp["url"],
+            "http://127.0.0.1:18743/instances/test-instance/mcp"
+        );
         assert_eq!(yorishiro_mcp["enabled"], true);
         cleanup_temp_files(&result);
+    }
+
+    #[test]
+    fn opencode_fails_closed_without_runtime_mcp_endpoint() {
+        let mut ctx = make_ctx(None, None, None);
+        ctx.mcp_endpoint = None;
+
+        let error = OPENCODE
+            .build_launch_args(&ctx)
+            .err()
+            .expect("missing endpoint must fail");
+        assert!(error.contains("MCP endpoint is unavailable"));
     }
 
     #[test]

--- a/src-tauri/src/sessions/pty_session.rs
+++ b/src-tauri/src/sessions/pty_session.rs
@@ -14,7 +14,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 use tauri::ipc::{Channel, InvokeResponseBody};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 
 use crate::pty::PtyExit;
 
@@ -556,6 +556,11 @@ impl PtySession {
             } => {
                 let adapter = crate::sessions::agent_adapter::lookup(agent_id.as_str())
                     .ok_or_else(|| format!("Unknown agent id: {}", agent_id))?;
+                let mcp_endpoint = if adapter.capabilities().mcp_injection {
+                    Some(app.state::<crate::mcp::McpServerStatus>().endpoint()?)
+                } else {
+                    None
+                };
                 let binary = resolve_agent_binary(adapter, command.as_deref());
                 let mut cmd = CommandBuilder::new(&binary);
                 apply_base_env(&mut cmd);
@@ -583,7 +588,7 @@ impl PtySession {
                     system_prompt: system_prompt.as_deref(),
                     prompt_reminder: prompt_reminder.as_deref(),
                     plugin_dir: plugin_dir.as_deref(),
-                    mcp_port: crate::mcp::server::resolve_port(),
+                    mcp_endpoint: mcp_endpoint.as_deref(),
                     hook_port: crate::pty::HOOK_SERVER_PORT,
                     resume: *resume,
                     resume_session_id: resume_session_id.as_deref(),

--- a/src/bindings/tauri-commands.ts
+++ b/src/bindings/tauri-commands.ts
@@ -292,6 +292,8 @@ export const listSupportedAgents = (): Promise<readonly AgentDescriptor[]> =>
 
 export interface McpServerStatus {
   readonly port: number | null;
+  readonly endpoint: string | null;
+  readonly instanceId: string | null;
   readonly error: string | null;
 }
 

--- a/src/runtime/health-check.ts
+++ b/src/runtime/health-check.ts
@@ -58,7 +58,12 @@ export async function collectHealthReport(deps: CollectHealthReportDeps): Promis
       readYorishiroConfigText(),
       readLastStartupReport().catch(() => ""),
       listSupportedAgents().catch(() => []),
-      mcpServerStatus().catch(() => ({ port: null, error: "Could not read MCP status." })),
+      mcpServerStatus().catch(() => ({
+        port: null,
+        endpoint: null,
+        instanceId: null,
+        error: "Could not read MCP status.",
+      })),
       deps.listPacks().catch(() => ({ packs: [] })),
     ]);
 
@@ -165,15 +170,17 @@ export async function collectHealthReport(deps: CollectHealthReportDeps): Promis
 
   items.push(
     healthItem(
-      "mcp-port",
-      "MCP port",
+      "mcp-endpoint",
+      "MCP endpoint",
       mcpStatus.error === null ? "ok" : "warning",
       mcpStatus.error === null
-        ? ` Yorishiro MCP is listening on localhost:${mcpStatus.port ?? expectedMcpPort}.`
+        ? ` Yorishiro MCP is listening at ${mcpStatus.endpoint ?? `http://127.0.0.1:${mcpStatus.port ?? expectedMcpPort}/mcp`} (instance ${mcpStatus.instanceId ?? "unknown"}).`
         : ` Yorishiro MCP did not start on localhost:${expectedMcpPort}: ${mcpStatus.error}`,
       mcpStatus.error === null
         ? undefined
-        : "Check whether another process is using the configured MCP port, then restart  Yorishiro.",
+        : config.mcpPort === null
+          ? "Restart Yorishiro and inspect the startup log."
+          : "Check whether another process is using the configured MCP port, then restart Yorishiro.",
     ),
   );
 


### PR DESCRIPTION
Implements #128.

## Changes

- isolate runtime MCP endpoints per Yorishiro instance
- inject the owned endpoint into Claude Code, Codex, and OpenCode
- update MCP status, Health, tests, and documentation

## Validation

- `npm run check`
- `npm run test:run` — 191 files, 2460 tests
- `npm run test:rust` — 316 tests
- `npm run build`
- live production + dev multi-instance check

Closes #128
