### PR TITLE
Guard against CSP black-screen regression

### DIFF
--- a/src/index-html-csp.test.ts
+++ b/src/index-html-csp.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { JSDOM } from "jsdom";
+import { describe, expect, it } from "vitest";
+
+describe("index.html CSP compatibility", () => {
+  it("keeps boot styles in an external stylesheet", () => {
+    const html = readFileSync(new URL("../index.html", import.meta.url), "utf8");
+    const document = new JSDOM(html).window.document;
+
+    expect(document.querySelectorAll("style")).toHaveLength(0);
+    expect(document.querySelector('link[rel="stylesheet"][href="/boot.css"]')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #130

## Summary

- Add a DOM-based regression test that rejects inline `<style>` elements in `index.html`.
- Verify the boot styles remain loaded from `/boot.css`.

## Context

The reported black window came from launching a stale debug bundle created before the existing CSP fix. Current source is already CSP-compatible; this test prevents the unsafe markup from being reintroduced.

## Validation

- `npx vitest run src/index-html-csp.test.ts`
- `npm run test:run` (192 files, 2461 tests)
- `npm run check`
- `npm run build`
