### PR TITLE
Clarify ambient sound label

### DIFF
--- a/src/i18n/strings.test.ts
+++ b/src/i18n/strings.test.ts
@@ -118,7 +118,7 @@ describe("changeStrings", () => {
   });
 
   it("labels the independent voice volume control in both languages", () => {
-    expect(getStrings("en").ambientVolume).toBe("Ambience");
+    expect(getStrings("en").ambientVolume).toBe("Ambient Sound");
     expect(getStrings("en").voiceVolume).toBe("Voice");
     expect(getStrings("en").muteVoice).toBe("Mute voice");
     expect(getStrings("en").unmuteVoice).toBe("Unmute voice");

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -155,7 +155,7 @@ const EN: UiStrings = {
   muteAmbient: "Mute ambient sound",
   unmuteVoice: "Unmute voice",
   muteVoice: "Mute voice",
-  ambientVolume: "Ambience",
+  ambientVolume: "Ambient Sound",
   voiceVolume: "Voice",
   motionIntensity: "Motion Intensity",
   motionLevelCalm: "Calm",


### PR DESCRIPTION
## What changed

- Rename the English `Ambience` setting label to `Ambient Sound`.
- Keep the existing Japanese `環境音` label unchanged.

## Validation

- `npm run check`
- Focused i18n and Settings tests (51 tests)