### PR TITLE
VRM の宣言バージョンと exporter/model version を正しく表示

### DIFF
--- a/bundled-packs/ui/yorishiro-settings/README.md
+++ b/bundled-packs/ui/yorishiro-settings/README.md
@@ -13,7 +13,7 @@ Yorishiro の設定画面。`activeUi` を `"yorishiro-settings"` に一時 swap
 
 ## 設定項目
 
-- **キャラクター**: VRM body / Persona / Scene。VRM は独立した chooser で検索・サムネイル・作者・正確な仕様 version・利用条件を確認し、固定 footer の明示的な「切り替える」でだけ変更する。license/reference の HTTPS URL は詳細から host 検証済みの外部 browser で開く。catalog は bounded JSON metadata だけを列挙し、一覧は20件ずつ段階表示、画像は可視候補だけ遅延取得する。import は候補追加までで即時適用しない。選択中でない imported VRM は確認後に一覧から外して AppData の管理用コピーを削除できるが、読み込み元の VRM file には触れない。存在しない active path は通知後に自動整理する
+- **キャラクター**: VRM body / Persona / Scene。VRM は独立した chooser で検索・サムネイル・作者・仕様 version（記載がない場合は未記載と表示）・モデル version・exporter version・利用条件を確認し、固定 footer の明示的な「切り替える」でだけ変更する。license/reference の HTTPS URL は詳細から host 検証済みの外部 browser で開く。catalog は bounded JSON metadata だけを列挙し、一覧は20件ずつ段階表示、画像は可視候補だけ遅延取得する。import は候補追加までで即時適用しない。選択中でない imported VRM は確認後に一覧から外して AppData の管理用コピーを削除できるが、読み込み元の VRM file には触れない。存在しない active path は通知後に自動整理する
 - **ターミナル**: Coding agent（Claude Code / Codex）。OpenCode adapter は内部に残すが、dropdown には表示しない
 - **ショートカット**: terminal に選択中 agent 用の固定 shortcut prompt（Claude Code は `/yori:shortcut ...`、Codex は `$yori-shortcut ...`、OpenCode は `/yori-shortcut ...`）を pre-fill する button
 - フッタ: `⌘R / Ctrl+R` の hint

--- a/bundled-packs/ui/yorishiro-settings/ui.test.ts
+++ b/bundled-packs/ui/yorishiro-settings/ui.test.ts
@@ -12,6 +12,7 @@ import {
   filterPersonaOptionsForLanguage,
   filterVrmCandidates,
   formatVrmMetaValue,
+  formatVrmSpecVersion,
   type NewSessionChangeKind,
   packWorkbenchKey,
   resolveCloseTarget,
@@ -40,6 +41,8 @@ const validVrmEntry = {
   invalidReason: null,
   meta: {
     specVersion: "1.0",
+    specVersionDeclared: true,
+    exporterVersion: null,
     name: "Avatar",
     version: null,
     authors: ["Creator"],
@@ -152,6 +155,15 @@ describe("VRM chooser discovery", () => {
 });
 
 describe("VRM permission presentation", () => {
+  it("keeps declared spec versions exact and labels VRM0 fallbacks honestly", () => {
+    const en = getStrings("en");
+    expect(formatVrmSpecVersion({ specVersion: "0.7", specVersionDeclared: true }, en)).toBe("0.7");
+    expect(formatVrmSpecVersion({ specVersion: "1.1", specVersionDeclared: true }, en)).toBe("1.1");
+    expect(formatVrmSpecVersion({ specVersion: "0.x", specVersionDeclared: false }, en)).toBe(
+      "0.x (exact spec version not declared)",
+    );
+  });
+
   it("only turns credential-free HTTPS metadata into external links", () => {
     expect(safeVrmExternalUrl("https://example.test/license")).toBe("https://example.test/license");
     expect(safeVrmExternalUrl("http://example.test/license")).toBeNull();

--- a/bundled-packs/ui/yorishiro-settings/ui.tsx
+++ b/bundled-packs/ui/yorishiro-settings/ui.tsx
@@ -87,6 +87,8 @@ export interface VrmLicenseInfo {
 
 export interface VrmAvatarMeta {
   readonly specVersion: string;
+  readonly specVersionDeclared: boolean;
+  readonly exporterVersion: string | null;
   readonly name: string | null;
   readonly version: string | null;
   readonly authors: readonly string[];
@@ -2391,6 +2393,14 @@ export function formatVrmMetaValue(value: VrmMetaValue, strings: UiStrings): str
   return localized;
 }
 
+export function formatVrmSpecVersion(
+  meta: Pick<VrmAvatarMeta, "specVersion" | "specVersionDeclared">,
+  strings: UiStrings,
+): string {
+  if (meta.specVersionDeclared) return meta.specVersion;
+  return strings.vrmSpecVersionNotDeclared.replace("{version}", meta.specVersion);
+}
+
 function VrmDetailRow({
   label,
   value,
@@ -2998,12 +3008,15 @@ function VrmCandidateDetail({
             marginTop: SPACING.sm,
           }}
         >
-          <VrmDetailRow label={strings.vrmSpec} value={meta.specVersion} />
+          <VrmDetailRow label={strings.vrmSpec} value={formatVrmSpecVersion(meta, strings)} />
           <VrmDetailRow label={strings.vrmName} value={meta.name ?? strings.vrmNotSpecified} />
           <VrmDetailRow
             label={strings.vrmVersion}
             value={meta.version ?? strings.vrmNotSpecified}
           />
+          {meta.exporterVersion ? (
+            <VrmDetailRow label={strings.vrmExporterVersion} value={meta.exporterVersion} />
+          ) : null}
           <VrmDetailRow
             label={strings.vrmAuthors}
             value={meta.authors.join(", ") || strings.vrmNotSpecified}
@@ -3662,7 +3675,9 @@ function VrmChooserDialog({
                     }}
                   >
                     <span style={{ color: COLORS.fgDimmer, fontSize: FONT.sizeXs }}>VRM</span>
-                    <span style={{ color: COLORS.fg }}>{selected.meta.specVersion}</span>
+                    <span style={{ color: COLORS.fg }}>
+                      {formatVrmSpecVersion(selected.meta, strings)}
+                    </span>
                   </div>
                 ) : null}
                 {selected?.kind === "yori" ? (

--- a/bundled-packs/ui/yorishiro-settings/vrm-import-flow.test.tsx
+++ b/bundled-packs/ui/yorishiro-settings/vrm-import-flow.test.tsx
@@ -28,6 +28,8 @@ const activeEntry: VrmAvatarEntry = {
   invalidReason: null,
   meta: {
     specVersion: "1.0",
+    specVersionDeclared: true,
+    exporterVersion: null,
     name: "Active",
     version: "1",
     authors: ["Active Author"],
@@ -63,6 +65,24 @@ const importedEntry: VrmAvatarEntry = {
             ...activeEntry.meta.license,
             urls: ["https://example.test/permission"],
           },
+        },
+};
+
+const legacyEntry: VrmAvatarEntry = {
+  ...activeEntry,
+  id: "legacy.vrm",
+  fileName: "legacy.vrm",
+  path: "/app/avatars/legacy.vrm",
+  meta:
+    activeEntry.meta === null
+      ? null
+      : {
+          ...activeEntry.meta,
+          specVersion: "0.x",
+          specVersionDeclared: false,
+          exporterVersion: "UniVRM-0.89.0",
+          name: "Legacy",
+          version: "0.9",
         },
 };
 
@@ -122,6 +142,24 @@ beforeEach(() => {
 });
 
 describe("VRM import settings handler", () => {
+  it("shows a truthful VRM0 fallback and preserves exporter/model versions", async () => {
+    localStorage.setItem("yorishiro:vrm", activeEntry.path);
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "list_vrm_avatars") return [activeEntry, legacyEntry];
+      throw new Error(`unexpected command: ${command}`);
+    });
+
+    render(<Panel ctx={settingsContext(vi.fn())} />);
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("list_vrm_avatars"));
+    fireEvent.click(screen.getByRole("button", { name: "Change…" }));
+    fireEvent.click(await screen.findByRole("option", { name: /legacy\.vrm/ }));
+
+    expect(screen.getAllByText("0.x (exact spec version not declared)").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByText("More details"));
+    expect(screen.getByText("UniVRM-0.89.0")).toBeTruthy();
+    expect(screen.getByText("0.9")).toBeTruthy();
+  });
+
   it("inspects import without applying, then applies explicitly and cancels back to active", async () => {
     localStorage.setItem("yorishiro:vrm", activeEntry.path);
     const setVrm = vi.fn();

--- a/docs/decisions/avatar-import-validation.md
+++ b/docs/decisions/avatar-import-validation.md
@@ -17,7 +17,7 @@
 - **TOCTOU-safe copy**：検証で開いた file handle を rewind して `std::io::copy` でコピーする。`std::fs::copy(path, ...)` のように path を再オープンしない
 - **非上書き・atomic finalize**：同一 directory の `.tmp-<pid>-<nonce>.vrm` へ copy / `sync_all` した後、no-clobber rename で publish する。同名との競合時は検証済み temporary copy と既存 file を size + 固定長 buffer で完全比較し、同一なら既存 path を返す。内容が異なる場合だけ `name (2).vrm`、`name (3).vrm` と再試行し、失敗時は temporary を cleanup する
 
-`list_vrm_avatars` は `$APPDATA/avatars/` 直下の `.vrm` だけを決定的な basename 順で返す。VRM本体や画像を展開せず、bounded JSON chunk の metadata と thumbnail 参照だけを読む。extension に `specVersion` があればその実値を返し、欠落時だけ系列名へ fallback する。symlink、非 regular file、破損 file は追跡・除外せず理由付き invalid row とし、temporary file と他拡張子は列挙しない。metadata の欠落は `NotSpecified`、未知 enum は `Unknown` として、許可扱いしない。raw enum も残し、アプリは法的判断を代行しない。UI は検索対象 metadata を保持しつつ最初の20件だけ描画し、scroll末尾付近で20件ずつ追加する。
+`list_vrm_avatars` は `$APPDATA/avatars/` 直下の `.vrm` だけを決定的な basename 順で返す。VRM本体や画像を展開せず、bounded JSON chunk の metadata と thumbnail 参照だけを読む。VRM1 の `VRMC_vrm.specVersion`、またはファイルに存在する `specVersion` の実値は保持し、欠落時は系列名へ fallback したうえで「正確な仕様バージョンの記載なし」と表示する（標準 VRM0 に仕様 version フィールドはない）。VRM0 の標準 `exporterVersion` と model `meta.version` は、glTF `asset.version` とは別の値として保持・表示する。symlink、非 regular file、破損 file は追跡・除外せず理由付き invalid row とし、temporary file と他拡張子は列挙しない。metadata の欠落は `NotSpecified`、未知 enum は `Unknown` として、許可扱いしない。raw enum も残し、アプリは法的判断を代行しない。UI は検索対象 metadata を保持しつつ最初の20件だけ描画し、scroll末尾付近で20件ずつ追加する。
 
 `read_vrm_thumbnail` は catalog の basename ID だけを受ける。`$APPDATA/avatars` 直下の regular file に再制限し、外部/data URI と symlink を拒否する。埋め込み BIN の PNG/JPEG だけを最大 8 MiB・最大辺 2048px・宣言範囲内で読み、magic と画像 header を確認して raw bytes を返す。catalog response には画像 bytes を含めず、chooser が可視候補と選択中候補だけを最大3件ずつ遅延取得し、ready cache は48件か64 MiBの小さい方に制限する。
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2299,6 +2299,8 @@ enum VrmMetaNormalized {
 #[serde(rename_all = "camelCase")]
 struct VrmAvatarMeta {
     spec_version: String,
+    spec_version_declared: bool,
+    exporter_version: Option<String>,
     name: Option<String>,
     version: Option<String>,
     authors: Vec<String>,
@@ -2421,8 +2423,11 @@ fn missing_meta_value() -> VrmMetaValue {
     }
 }
 
-fn declared_vrm_spec_version(extension: &serde_json::Value, fallback: &str) -> String {
-    limited_meta_text(extension.get("specVersion")).unwrap_or_else(|| fallback.to_string())
+fn declared_vrm_spec_version(extension: &serde_json::Value, fallback: &str) -> (String, bool) {
+    match limited_meta_text(extension.get("specVersion")) {
+        Some(version) => (version, true),
+        None => (fallback.to_string(), false),
+    }
 }
 
 fn parse_vrm0_meta(extension: &serde_json::Value, meta: &serde_json::Value) -> VrmAvatarMeta {
@@ -2453,8 +2458,11 @@ fn parse_vrm0_meta(extension: &serde_json::Value, meta: &serde_json::Value) -> V
         }
     }
 
+    let (spec_version, spec_version_declared) = declared_vrm_spec_version(extension, "0.x");
     VrmAvatarMeta {
-        spec_version: declared_vrm_spec_version(extension, "0.x"),
+        spec_version,
+        spec_version_declared,
+        exporter_version: limited_meta_text(extension.get("exporterVersion")),
         name: limited_meta_text(meta.get("title")),
         version: limited_meta_text(meta.get("version")),
         authors: limited_meta_text(meta.get("author")).into_iter().collect(),
@@ -2489,8 +2497,11 @@ fn parse_vrm1_meta(extension: &serde_json::Value, meta: &serde_json::Value) -> V
         }
     }
 
+    let (spec_version, spec_version_declared) = declared_vrm_spec_version(extension, "1.x");
     VrmAvatarMeta {
-        spec_version: declared_vrm_spec_version(extension, "1.x"),
+        spec_version,
+        spec_version_declared,
+        exporter_version: None,
         name: limited_meta_text(meta.get("name")),
         version: limited_meta_text(meta.get("version")),
         authors: limited_meta_list(meta.get("authors")),
@@ -3216,6 +3227,7 @@ mod import_vrm_tests {
     fn vrm1_glb(name: &str) -> Vec<u8> {
         glb_bytes(
             &serde_json::json!({
+                "asset": { "version": "2.0", "generator": "Example VRM exporter" },
                 "extensions": { "VRMC_vrm": { "specVersion": "1.1", "meta": {
                     "name": name,
                     "version": "1.2",
@@ -3384,7 +3396,7 @@ mod import_vrm_tests {
     #[test]
     fn parses_vrm0_metadata_and_preserves_raw_permissions() {
         let bytes = glb_bytes(
-            &serde_json::json!({"extensions":{"VRM":{"specVersion":"0.7","meta":{
+            &serde_json::json!({"asset":{"version":"2.0","generator":"UniVRM-0.89.0"},"extensions":{"VRM":{"specVersion":"0.7","exporterVersion":"UniVRM-0.89.0","meta":{
                 "title":"Old Avatar","version":"0.9","author":"Creator",
                 "contactInformation":"contact","reference":"https://example.test",
                 "allowedUserName":"ExplicitlyLicensedPerson","violentUssageName":"Disallow",
@@ -3399,7 +3411,15 @@ mod import_vrm_tests {
         let mut file = fs::File::open(&path).expect("open");
         let meta = read_vrm_meta(&mut file, bytes.len() as u64).expect("parse");
         assert_eq!(meta.spec_version, "0.7");
+        assert!(meta.spec_version_declared);
+        assert_eq!(meta.exporter_version.as_deref(), Some("UniVRM-0.89.0"));
         assert_eq!(meta.name.as_deref(), Some("Old Avatar"));
+        assert_eq!(meta.version.as_deref(), Some("0.9"));
+        let serialized = serde_json::to_value(&meta).expect("serialize metadata");
+        assert_eq!(serialized["specVersion"], "0.7");
+        assert_eq!(serialized["specVersionDeclared"], true);
+        assert_eq!(serialized["exporterVersion"], "UniVRM-0.89.0");
+        assert!(serialized.get("assetVersion").is_none());
         assert_eq!(meta.authors, ["Creator"]);
         assert_eq!(meta.commercial_usage.raw.as_deref(), Some("Disallow"));
         assert_eq!(meta.license.name.as_deref(), Some("CC_BY_NC"));
@@ -3420,6 +3440,9 @@ mod import_vrm_tests {
         let mut file = fs::File::open(&path).expect("open");
         let meta = read_vrm_meta(&mut file, bytes.len() as u64).expect("parse");
         assert_eq!(meta.spec_version, "1.1");
+        assert!(meta.spec_version_declared);
+        assert_eq!(meta.exporter_version, None);
+        assert_eq!(meta.version.as_deref(), Some("1.2"));
         assert_eq!(meta.authors, ["Alice", "Bob"]);
         assert_eq!(meta.commercial_usage.raw.as_deref(), Some("personalProfit"));
         assert_eq!(
@@ -3484,6 +3507,8 @@ mod import_vrm_tests {
         let mut file = fs::File::open(&path).expect("open");
         let document = read_vrm_document(&mut file, bytes.len() as u64).expect("parse");
         assert_eq!(document.meta.spec_version, "0.x");
+        assert!(!document.meta.spec_version_declared);
+        assert_eq!(document.meta.exporter_version, None);
         assert_eq!(document.thumbnail.expect("thumbnail").public.image_index, 0);
         let _ = fs::remove_dir_all(dir);
     }

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -59,8 +59,10 @@ export interface UiStrings {
   readonly vrmRetry: string;
   readonly vrmDetails: string;
   readonly vrmSpec: string;
+  readonly vrmSpecVersionNotDeclared: string;
   readonly vrmName: string;
   readonly vrmVersion: string;
+  readonly vrmExporterVersion: string;
   readonly vrmAuthors: string;
   readonly vrmContact: string;
   readonly vrmReferences: string;
@@ -285,8 +287,10 @@ const EN: UiStrings = {
   vrmRetry: "Retry",
   vrmDetails: "Avatar details",
   vrmSpec: "VRM spec",
+  vrmSpecVersionNotDeclared: "{version} (exact spec version not declared)",
   vrmName: "Name",
-  vrmVersion: "Version",
+  vrmVersion: "Model version",
+  vrmExporterVersion: "Exporter version",
   vrmAuthors: "Authors",
   vrmContact: "Contact",
   vrmReferences: "References",
@@ -506,8 +510,10 @@ const JA: UiStrings = {
   vrmRetry: "再試行",
   vrmDetails: "アバターの詳細",
   vrmSpec: "VRM 仕様",
+  vrmSpecVersionNotDeclared: "{version}（正確な仕様バージョンの記載なし）",
   vrmName: "名前",
-  vrmVersion: "バージョン",
+  vrmVersion: "モデルバージョン",
+  vrmExporterVersion: "エクスポーターバージョン",
   vrmAuthors: "制作者",
   vrmContact: "連絡先",
   vrmReferences: "参照情報",


### PR DESCRIPTION
Closes #141\n\nVRM version metadata is now explicit about provenance. VRM1 and any declared specVersion remain exact (for example 1.1 and 0.7); standard VRM0 fallback is shown as 0.x with an exact-version-not-declared label because the standard has no specVersion field. VRM0 exporterVersion and model meta.version are parsed and displayed separately, while glTF asset.version remains ignored as a glTF value.\n\nTests: focused Vitest (51), focused Rust import_vrm_tests (27), npm run check, npm run test:run -- --maxWorkers=4 (2503), git diff --check.