### PR TITLE
Fix Codex realtime model rejection

### DIFF
--- a/src/runtime/codex-realtime/codex-realtime-client.test.ts
+++ b/src/runtime/codex-realtime/codex-realtime-client.test.ts
@@ -41,6 +41,8 @@ const bridge = vi.hoisted(() => ({
   threadReadFailures: {} as Record<string, number>,
   /** voice → error message。entry がある voice の thread/realtime/start を error 応答にする。 */
   realtimeStartErrors: {} as Record<string, string>,
+  /** version → error message。specific protocol rejection の compatibility test 用。 */
+  realtimeStartVersionErrors: {} as Record<string, string>,
   initializeUserAgent: "codex_cli_rs/0.146.0",
   capabilities: { appServerVersion: "0.146.0", personaInitialItems: true },
   suppressRealtimeSdp: false,
@@ -127,7 +129,10 @@ vi.mock("../../bindings/tauri-commands", () => ({
         });
       } else if (request.method === "thread/realtime/start") {
         const voice = request.params?.voice;
-        const rejection = typeof voice === "string" ? bridge.realtimeStartErrors[voice] : undefined;
+        const version = request.params?.version;
+        const rejection =
+          (typeof version === "string" ? bridge.realtimeStartVersionErrors[version] : undefined) ??
+          (typeof voice === "string" ? bridge.realtimeStartErrors[voice] : undefined);
         if (rejection !== undefined) {
           queueMicrotask(() => {
             bridge.channel?.onmessage(
@@ -260,6 +265,7 @@ describe("CodexRealtimeClient", () => {
     vi.mocked(ensureAudioContextRunning).mockResolvedValue({} as AudioContext);
     bridge.threadReadFailures = {};
     bridge.realtimeStartErrors = {};
+    bridge.realtimeStartVersionErrors = {};
     bridge.suppressRealtimeSdp = false;
     Object.defineProperty(navigator, "mediaDevices", {
       configurable: true,
@@ -500,6 +506,75 @@ describe("CodexRealtimeClient", () => {
       bridge.sent.find((message) => message.method === "thread/realtime/start")?.params,
     ).toMatchObject({ voice: "juniper" });
     client.stop();
+  });
+
+  it.each([
+    {
+      name: "plain detail",
+      rejection: "Field `session.model` is not allowed for this Codex realtime session",
+    },
+    {
+      name: "reported JSON detail",
+      rejection:
+        '{ "detail": "Field `session.model` is not allowed for this Codex realtime session" }',
+    },
+  ])("retries with realtime v2 for the exact v3 session.model rejection as $name", async ({
+    rejection,
+  }) => {
+    bridge.realtimeStartVersionErrors = {
+      v3: rejection,
+    };
+    const diagnostics: CodexRealtimePersonaApplication[] = [];
+    const voiceFallbacks: CodexRealtimeVoiceFallback[] = [];
+    const client = new CodexRealtimeClient("main-session", undefined, {
+      getPersonaSnapshot: () => ({ personaId: "yori", instructions: "persona guidance" }),
+      includeStartupContext: false,
+      getVoiceCandidates: () => ["maple", "sol"],
+      onVoiceFallback: (fallback) => voiceFallbacks.push(fallback),
+      onPersonaApplication: (application) => diagnostics.push(application),
+    });
+
+    await client.start();
+
+    const starts = bridge.sent.filter((message) => message.method === "thread/realtime/start");
+    expect(starts).toHaveLength(2);
+    expect(starts[0]?.params).toMatchObject({
+      threadId: "thread-1",
+      outputModality: "audio",
+      version: "v3",
+      voice: "maple",
+      includeStartupContext: false,
+      initialItems: [{ role: "developer", text: "persona guidance" }],
+      transport: { type: "webrtc", sdp: "local-offer" },
+    });
+    expect(starts[1]?.params).toEqual({
+      threadId: "thread-1",
+      outputModality: "audio",
+      version: "v2",
+      voice: "maple",
+      includeStartupContext: true,
+      transport: { type: "webrtc", sdp: "local-offer" },
+    });
+    expect(voiceFallbacks).toEqual([]);
+    expect(diagnostics).toEqual([
+      { personaId: "yori", status: "unsupported", appServerVersion: "0.146.0" },
+    ]);
+    expect(client.getStatus()).toBe("active");
+    client.stop();
+  });
+
+  it("does not downgrade realtime for other v3 start failures", async () => {
+    bridge.realtimeStartVersionErrors = {
+      v3: "realtime is not enabled for this account",
+    };
+    const client = new CodexRealtimeClient("main-session");
+
+    await expect(client.start()).rejects.toThrow("realtime is not enabled for this account");
+
+    const starts = bridge.sent.filter((message) => message.method === "thread/realtime/start");
+    expect(starts).toHaveLength(1);
+    expect(starts[0]?.params?.version).toBe("v3");
+    expect(client.getStatus()).toBe("error");
   });
 
   it("falls back to the next candidate only when the app-server rejects the voice", async () => {

--- a/src/runtime/codex-realtime/codex-realtime-client.ts
+++ b/src/runtime/codex-realtime/codex-realtime-client.ts
@@ -134,6 +134,8 @@ export const DEFAULT_CODEX_REALTIME_VOICE = "sol";
 const REMOTE_SPEECH_SAMPLE_INTERVAL_MS = 33;
 const START_RETRY_BASE_DELAYS_MS = [500, 1_500] as const;
 const APP_VERSION = "0.6.2";
+const REALTIME_V3_SESSION_MODEL_REJECTION =
+  "Field `session.model` is not allowed for this Codex realtime session";
 
 class StartAttemptCancelledError extends Error {
   constructor() {
@@ -354,7 +356,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     const threadId = await this.waitForLoadedThread(attempt);
     this.assertAttemptOwner(attempt);
     this.threadId = threadId;
-    await this.startWebRtc(
+    const realtimeVersion = await this.startWebRtc(
       threadId,
       attempt,
       personaApplication.initialItems,
@@ -362,7 +364,15 @@ export class CodexRealtimeClient implements LipSyncSource {
       personaApplication.startupContextIncluded,
     );
     this.assertAttemptOwner(attempt);
-    return { billing, personaApplication: personaApplication.diagnostic };
+    const personaDiagnostic =
+      realtimeVersion === "v2" && personaApplication.diagnostic.delivery === "initial-items"
+        ? {
+            personaId: personaApplication.diagnostic.personaId,
+            status: "unsupported" as const,
+            appServerVersion: personaApplication.diagnostic.appServerVersion,
+          }
+        : personaApplication.diagnostic;
+    return { billing, personaApplication: personaDiagnostic };
   }
 
   stop(): void {
@@ -591,7 +601,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     initialItems?: ReadonlyArray<{ readonly role: "developer"; readonly text: string }>,
     prompt?: string,
     startupContextIncluded = true,
-  ): Promise<void> {
+  ): Promise<"v2" | "v3"> {
     this.assertAttemptOwner(attempt);
     this.currentStage = "microphone";
     const peer = new RTCPeerConnection();
@@ -657,6 +667,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     // （persona override → global → built-in default）で再試行する。認証・接続などの
     // 一般エラーはそのまま投げ、voice fallback で隠さない。
     let remoteSdp: Promise<string> | null = null;
+    let realtimeVersion: "v2" | "v3" = "v3";
     this.currentStage = "realtime-start";
     for (let index = 0; index < candidates.length && remoteSdp === null; index++) {
       const voice = candidates[index];
@@ -668,24 +679,52 @@ export class CodexRealtimeClient implements LipSyncSource {
       // start が失敗した attempt の promise は誰も await しない。後始末の
       // rejectAllPending が reject しても unhandled rejection にしない。
       void attemptRemoteSdp.catch(() => {});
+      let startError: unknown = null;
       try {
         await this.request("thread/realtime/start", {
           threadId,
           outputModality: "audio",
-          version: "v3",
+          version: realtimeVersion,
           voice,
-          includeStartupContext: startupContextIncluded,
-          ...(initialItems ? { initialItems } : {}),
+          includeStartupContext:
+            realtimeVersion === "v2" && initialItems ? true : startupContextIncluded,
+          ...(realtimeVersion === "v3" && initialItems ? { initialItems } : {}),
           ...(prompt ? { prompt } : {}),
           transport: { type: "webrtc", sdp },
         });
-        remoteSdp = attemptRemoteSdp;
       } catch (error) {
         if (error instanceof StartAttemptCancelledError) throw error;
         this.assertAttemptOwner(attempt, peer);
+        if (realtimeVersion === "v3" && isRealtimeV3SessionModelRejection(error)) {
+          // Codex 0.149.0 can inject a v3 default session.model that the selected
+          // Frameless backend rejects. Retry the non-Frameless v2 compatibility path.
+          // initialItems is v3-only, so retain Codex startup context when omitting it.
+          realtimeVersion = "v2";
+          try {
+            await this.request("thread/realtime/start", {
+              threadId,
+              outputModality: "audio",
+              version: realtimeVersion,
+              voice,
+              includeStartupContext: initialItems ? true : startupContextIncluded,
+              ...(prompt ? { prompt } : {}),
+              transport: { type: "webrtc", sdp },
+            });
+          } catch (fallbackError) {
+            startError = fallbackError;
+          }
+        } else {
+          startError = error;
+        }
+      }
+      if (startError === null) {
+        remoteSdp = attemptRemoteSdp;
+      } else {
+        if (startError instanceof StartAttemptCancelledError) throw startError;
+        this.assertAttemptOwner(attempt, peer);
         const nextVoice = candidates[index + 1];
-        const reason = error instanceof Error ? error.message : String(error);
-        if (nextVoice === undefined || !isCodexVoiceRejectionMessage(reason)) throw error;
+        const reason = startError instanceof Error ? startError.message : String(startError);
+        if (nextVoice === undefined || !isCodexVoiceRejectionMessage(reason)) throw startError;
         this.onVoiceFallback?.({ fromVoice: voice, toVoice: nextVoice, reason });
       }
     }
@@ -702,6 +741,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     this.currentStage = "sdp-application";
     await peer.setRemoteDescription({ type: "answer", sdp: answerSdp });
     this.assertAttemptOwner(attempt, peer);
+    return realtimeVersion;
   }
 
   private connectRemoteAudio(stream: MediaStream, attempt: number): void {
@@ -1129,6 +1169,17 @@ function jsonRpcErrorMessage(error: unknown): string {
   }
   const message = (error as { readonly message?: unknown }).message;
   return typeof message === "string" ? message : "Codex app-server request failed";
+}
+
+function isRealtimeV3SessionModelRejection(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.message === REALTIME_V3_SESSION_MODEL_REJECTION) return true;
+  try {
+    const body: unknown = JSON.parse(error.message);
+    return isRecord(body) && body.detail === REALTIME_V3_SESSION_MODEL_REJECTION;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeThreadIdSet(values: ReadonlyArray<unknown>): string[] | null {


### PR DESCRIPTION
## Summary
- retry the exact Codex 0.149 v3 session.model rejection through the v2 compatibility path
- preserve startup context when v3-only persona initial items must be omitted
- keep unrelated realtime and voice errors unchanged

## Verification
- focused Codex realtime tests (55 passed)
- TypeScript typecheck
- Biome lint and Rust Clippy
- production build