### PR TITLE
ci: verify packaged macOS release signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,13 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
 
+      # Verify the packaged payloads, not only the intermediate app bundle. This extracts the
+      # updater archive and mounts the DMG read-only, then requires a valid Developer ID chain,
+      # hardened runtime, entitlements, secure timestamp, Gatekeeper acceptance, and stapled ticket.
+      # Any failure must stop the job before either artifact can be uploaded or published.
+      - name: Verify signed and notarized release artifacts
+        run: node scripts/verify-macos-release-artifacts.mjs "src-tauri/target/${{ matrix.target }}/release/bundle"
+
       # updater artifact（.app.tar.gz + .sig）は両アーキで同名（Yorishiro.app.tar.gz）に
       # なるため、arch を含む名前にリネームしてから artifact 化する。この名前が
       # そのまま Release asset 名になり、latest.json の url が指す。

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -70,8 +70,8 @@ npm run check:macos-signature
 The verification script runs the equivalent of:
 
 ```bash
-codesign --verify --deep --strict src-tauri/target/release/bundle/macos/Yorishiro.app
-codesign -d --entitlements :- src-tauri/target/release/bundle/macos/Yorishiro.app
+codesign --verify --deep --strict --verbose=4 src-tauri/target/release/bundle/macos/Yorishiro.app
+codesign -d --verbose=4 --entitlements - --xml src-tauri/target/release/bundle/macos/Yorishiro.app
 ```
 
 and requires the audio-input, network-client, JIT, and unsigned executable
@@ -80,6 +80,21 @@ notarized and do not establish a developer identity. In release CI,
 `APPLE_SIGNING_IDENTITY` overrides the ad-hoc configuration with the imported
 Developer ID identity, after which Tauri performs the existing signing and
 notarization flow.
+
+Release CI additionally runs `npm run check:macos-release-artifacts --
+<bundle-root>` before uploading anything. It extracts the updater archive,
+mounts the DMG read-only, and verifies both app payloads with `codesign`,
+Gatekeeper, and `stapler`. The release check requires the Developer ID chain,
+hardened runtime, secure timestamp, required entitlements, and stapled
+notarization ticket.
+
+Run Developer ID trust checks from a normal macOS shell or CI runner with
+access to Security.framework trust services. A restricted process that cannot
+reach `trustd` or the system keychains can falsely report
+`Authority=(unavailable)`, `invalid signature`, or `invalid entitlements blob`
+for every Developer ID app. If that happens, repeat the check outside the
+sandbox and compare it with a known notarized app before diagnosing an artifact
+as damaged.
 
 ## 2. Fresh macOS install
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "check": "tsc --noEmit && biome check . && cargo fmt --manifest-path src-tauri/Cargo.toml -- --check && cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings",
     "check:pack": "node scripts/check-pack.mjs",
     "check:macos-signature": "node scripts/verify-macos-signature.mjs",
+    "check:macos-release-artifacts": "node scripts/verify-macos-release-artifacts.mjs",
     "doc": "typedoc",
     "doc:rust": "cargo doc --manifest-path src-tauri/Cargo.toml --no-deps --document-private-items",
     "doc:open": "open docs/api/typescript/index.html",

--- a/scripts/lib/macos-signature-verifier.mjs
+++ b/scripts/lib/macos-signature-verifier.mjs
@@ -1,0 +1,54 @@
+export const REQUIRED_MACOS_ENTITLEMENTS = [
+  "com.apple.security.cs.allow-jit",
+  "com.apple.security.cs.allow-unsigned-executable-memory",
+  "com.apple.security.network.client",
+  "com.apple.security.device.audio-input",
+];
+
+function hasEnabledEntitlement(output, entitlement) {
+  const escaped = entitlement.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`<key>\\s*${escaped}\\s*</key>\\s*<true\\s*/>`).test(output);
+}
+
+export function macosSignatureErrors(output, { requireDeveloperId = false } = {}) {
+  const errors = [];
+  const missingEntitlements = REQUIRED_MACOS_ENTITLEMENTS.filter(
+    (entitlement) => !hasEnabledEntitlement(output, entitlement),
+  );
+
+  if (missingEntitlements.length > 0) {
+    errors.push(`Missing signed entitlements: ${missingEntitlements.join(", ")}`);
+  }
+  if (/invalid entitlements blob/i.test(output)) {
+    errors.push("The signed executable contains an invalid entitlements blob.");
+  }
+  if (!/^CodeDirectory .*flags=.*\bruntime\b/m.test(output)) {
+    errors.push("The hardened runtime flag is missing from the code signature.");
+  }
+
+  if (requireDeveloperId) {
+    if (!/^Authority=Developer ID Application:/m.test(output)) {
+      errors.push("The Developer ID Application authority is missing.");
+    }
+    if (!/^Authority=Developer ID Certification Authority$/m.test(output)) {
+      errors.push("The Developer ID intermediate authority is missing.");
+    }
+    if (!/^Authority=Apple Root CA$/m.test(output)) {
+      errors.push("The Apple Root CA authority is missing.");
+    }
+    if (!/^TeamIdentifier=(?!not set$)\S+$/m.test(output)) {
+      errors.push("The Developer ID team identifier is missing.");
+    }
+    if (!/^Timestamp=.+$/m.test(output)) {
+      errors.push("The secure signing timestamp is missing.");
+    }
+    if (!/^Notarization Ticket=stapled$/m.test(output)) {
+      errors.push("The notarization ticket is not stapled to the app.");
+    }
+    if (/^Signature=adhoc$/m.test(output)) {
+      errors.push("The release app is ad-hoc signed instead of Developer ID signed.");
+    }
+  }
+
+  return errors;
+}

--- a/scripts/lib/macos-signature-verifier.test.mjs
+++ b/scripts/lib/macos-signature-verifier.test.mjs
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { macosSignatureErrors, REQUIRED_MACOS_ENTITLEMENTS } from "./macos-signature-verifier.mjs";
+
+const entitlements = REQUIRED_MACOS_ENTITLEMENTS.map(
+  (entitlement) => `<key>${entitlement}</key><true/>`,
+).join("");
+const validReleaseSignature = `
+CodeDirectory v=20500 flags=0x10000(runtime)
+Authority=Developer ID Application: Example (TEAM123)
+Authority=Developer ID Certification Authority
+Authority=Apple Root CA
+Timestamp=Aug 26, 2026 at 0:32:11
+Notarization Ticket=stapled
+TeamIdentifier=TEAM123
+<plist><dict>${entitlements}</dict></plist>
+`;
+
+describe("macosSignatureErrors", () => {
+  it("accepts a hardened, notarized Developer ID signature", () => {
+    expect(macosSignatureErrors(validReleaseSignature, { requireDeveloperId: true })).toEqual([]);
+  });
+
+  it("rejects an ad-hoc signature in release mode", () => {
+    const output = `
+CodeDirectory v=20500 flags=0x10002(adhoc,runtime)
+Signature=adhoc
+TeamIdentifier=not set
+<plist><dict>${entitlements}</dict></plist>
+`;
+
+    expect(macosSignatureErrors(output, { requireDeveloperId: true })).toEqual(
+      expect.arrayContaining([
+        "The Developer ID Application authority is missing.",
+        "The Developer ID team identifier is missing.",
+        "The release app is ad-hoc signed instead of Developer ID signed.",
+      ]),
+    );
+  });
+
+  it("rejects malformed or incomplete entitlements", () => {
+    const output = validReleaseSignature
+      .replace("<key>com.apple.security.device.audio-input</key><true/>", "")
+      .concat("\nwarning: binary contains an invalid entitlements blob");
+
+    expect(macosSignatureErrors(output, { requireDeveloperId: true })).toEqual(
+      expect.arrayContaining([
+        "Missing signed entitlements: com.apple.security.device.audio-input",
+        "The signed executable contains an invalid entitlements blob.",
+      ]),
+    );
+  });
+
+  it("keeps local ad-hoc verification compatible", () => {
+    const output = `
+CodeDirectory v=20500 flags=0x10002(adhoc,runtime)
+Signature=adhoc
+TeamIdentifier=not set
+<plist><dict>${entitlements}</dict></plist>
+`;
+
+    expect(macosSignatureErrors(output)).toEqual([]);
+  });
+});

--- a/scripts/verify-macos-release-artifacts.mjs
+++ b/scripts/verify-macos-release-artifacts.mjs
@@ -1,0 +1,111 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const bundleRoot = resolve(process.argv[2] ?? "src-tauri/target/release/bundle");
+const verificationScript = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "verify-macos-signature.mjs",
+);
+
+if (process.platform !== "darwin") {
+  console.error("macOS release artifacts can only be verified on macOS.");
+  process.exit(1);
+}
+
+if (!existsSync(bundleRoot)) {
+  console.error(`Bundle root not found: ${bundleRoot}`);
+  process.exit(1);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { encoding: "utf8", stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} failed with exit code ${result.status ?? 1}`);
+  }
+}
+
+function walk(root, predicate, results = []) {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (predicate(path, entry)) results.push(path);
+      walk(path, predicate, results);
+    } else if (entry.isFile() && predicate(path, entry)) {
+      results.push(path);
+    }
+  }
+  return results;
+}
+
+function findAppBundles(root, results = []) {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const path = join(root, entry.name);
+    if (path.endsWith(".app")) {
+      results.push(path);
+    } else {
+      findAppBundles(path, results);
+    }
+  }
+  return results;
+}
+
+function exactlyOne(label, paths) {
+  if (paths.length !== 1) {
+    throw new Error(`Expected exactly one ${label}, found ${paths.length}: ${paths.join(", ")}`);
+  }
+  return paths[0];
+}
+
+function verifyApp(appPath) {
+  run(process.execPath, [verificationScript, appPath, "--require-developer-id"]);
+}
+
+const updaterArchive = exactlyOne(
+  "macOS updater archive",
+  walk(bundleRoot, (path, entry) => entry.isFile() && path.endsWith(".app.tar.gz")),
+);
+const dmg = exactlyOne(
+  "macOS DMG",
+  walk(bundleRoot, (path, entry) => entry.isFile() && path.endsWith(".dmg")),
+);
+const scratch = mkdtempSync(join(tmpdir(), "yorishiro-release-verification-"));
+if (
+  dirname(scratch) !== resolve(tmpdir()) ||
+  !basename(scratch).startsWith("yorishiro-release-verification-")
+) {
+  throw new Error(`Unexpected verification directory: ${scratch}`);
+}
+const updaterDirectory = join(scratch, "updater");
+const dmgMount = join(scratch, "dmg");
+let dmgMounted = false;
+
+try {
+  mkdirSync(updaterDirectory);
+  run("tar", ["-xzf", updaterArchive, "-C", updaterDirectory]);
+  const updaterApp = exactlyOne("app in the updater archive", findAppBundles(updaterDirectory));
+  verifyApp(updaterApp);
+
+  run("hdiutil", ["verify", dmg]);
+  mkdirSync(dmgMount);
+  run("hdiutil", ["attach", "-nobrowse", "-readonly", "-mountpoint", dmgMount, dmg]);
+  dmgMounted = true;
+  const dmgApp = exactlyOne("app in the DMG", findAppBundles(dmgMount));
+  verifyApp(dmgApp);
+
+  console.log(`Verified updater archive: ${updaterArchive}`);
+  console.log(`Verified DMG: ${dmg}`);
+} finally {
+  try {
+    if (dmgMounted) {
+      run("hdiutil", ["detach", dmgMount]);
+    }
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}

--- a/scripts/verify-macos-signature.mjs
+++ b/scripts/verify-macos-signature.mjs
@@ -1,8 +1,23 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import process from "node:process";
+import {
+  macosSignatureErrors,
+  REQUIRED_MACOS_ENTITLEMENTS,
+} from "./lib/macos-signature-verifier.mjs";
 
-const appPath = process.argv[2] ?? "src-tauri/target/release/bundle/macos/Yorishiro.app";
+const args = process.argv.slice(2);
+const requireDeveloperId = args.includes("--require-developer-id");
+const positionalArgs = args.filter((arg) => !arg.startsWith("--"));
+const unknownFlags = args.filter((arg) => arg.startsWith("--") && arg !== "--require-developer-id");
+const appPath = positionalArgs[0] ?? "src-tauri/target/release/bundle/macos/Yorishiro.app";
+
+if (positionalArgs.length > 1 || unknownFlags.length > 0) {
+  console.error(
+    "Usage: node scripts/verify-macos-signature.mjs [app-path] [--require-developer-id]",
+  );
+  process.exit(2);
+}
 
 if (process.platform !== "darwin") {
   console.error("macOS code signatures can only be verified on macOS.");
@@ -15,8 +30,8 @@ if (!existsSync(appPath)) {
   process.exit(1);
 }
 
-function runCodesign(args) {
-  const result = spawnSync("codesign", args, { encoding: "utf8" });
+function run(command, commandArgs) {
+  const result = spawnSync(command, commandArgs, { encoding: "utf8" });
   const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
   if (result.error) {
     throw result.error;
@@ -28,31 +43,32 @@ function runCodesign(args) {
   return output;
 }
 
-// Keep these equivalent to the commands documented in the release checklist.
-runCodesign(["--verify", "--deep", "--strict", appPath]);
-const entitlements = runCodesign(["-d", "--entitlements", ":-", appPath]);
+run("codesign", ["--verify", "--deep", "--strict", "--verbose=4", appPath]);
+const signatureDetails = run("codesign", [
+  "--display",
+  "--verbose=4",
+  "--entitlements",
+  "-",
+  "--xml",
+  appPath,
+]);
+const errors = macosSignatureErrors(signatureDetails, { requireDeveloperId });
 
-const requiredEntitlements = [
-  "com.apple.security.cs.allow-jit",
-  "com.apple.security.cs.allow-unsigned-executable-memory",
-  "com.apple.security.network.client",
-  "com.apple.security.device.audio-input",
-];
-
-function hasEnabledEntitlement(plist, entitlement) {
-  const escaped = entitlement.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`<key>\\s*${escaped}\\s*</key>\\s*<true\\s*/>`).test(plist);
-}
-
-const missing = requiredEntitlements.filter(
-  (entitlement) => !hasEnabledEntitlement(entitlements, entitlement),
-);
-
-if (missing.length > 0) {
-  console.error(`Missing signed entitlements: ${missing.join(", ")}`);
-  console.error(entitlements.trim());
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  console.error(signatureDetails.trim());
   process.exit(1);
 }
 
+if (requireDeveloperId) {
+  run("spctl", ["--assess", "--type", "execute", "--verbose=4", appPath]);
+  run("xcrun", ["stapler", "validate", appPath]);
+}
+
 console.log(`Valid macOS signature: ${appPath}`);
-console.log(`Signed entitlements: ${requiredEntitlements.join(", ")}`);
+console.log(`Signed entitlements: ${REQUIRED_MACOS_ENTITLEMENTS.join(", ")}`);
+console.log(
+  requireDeveloperId
+    ? "Release trust: Developer ID, secure timestamp, Gatekeeper, and notarization verified"
+    : "Signing mode: local (Developer ID was not required)",
+);


### PR DESCRIPTION
## Summary

- add a mandatory post-packaging macOS release gate before GitHub Actions uploads either architecture's artifacts
- inspect the apps inside both the updater archive and the DMG, rather than relying on an intermediate build output
- require a valid Developer ID chain, team identifier, hardened runtime, secure timestamp, required entitlements, Gatekeeper acceptance, and a stapled notarization ticket
- retain ad-hoc signature support for the existing local development check while adding an explicit release verification mode
- document how restricted trust-service access can produce misleading macOS signature errors

## Root cause and release impact

The reported `invalid signature (code or signature have been modified)` and `invalid entitlements blob` results were managed-sandbox false negatives. The restricted process could not access Security.framework trust services, `trustd`, or the system keychains and returned `Authority=(unavailable)` for unrelated known-good Developer ID applications as well.

The exact public v0.7.4 updater app and the app inside the Homebrew DMG pass strict code-signature verification, Developer ID chain inspection, Gatekeeper assessment, and stapled-ticket validation when run from a normal macOS process. The DMG also passes `hdiutil verify`, and its SHA-256 matches the Homebrew cask.

Therefore this PR does not rotate certificates, change entitlements or signing order, modify v0.7.4 assets, or perform a replacement release. It adds a regression-prevention gate so future release jobs verify the exact packaged payloads before upload.

## Validation

- `npm run check`
- `npm run build`
- `npm run test:run` (197 files, 2,519 tests)
- `npm run test:rust` (373 library tests and 14 binary tests)
- macOS signature verifier unit tests (4 tests)
- end-to-end packaged-artifact verification against the public v0.7.4 updater archive and Homebrew DMG
- pre-push TypeScript, Biome, rustfmt, Clippy, and TypeDoc checks

No tag or release was created.

Closes #151
