### PR TITLE
Keep GPT Live attached to the workspace thread

### DIFF
--- a/src-tauri/src/sessions/codex_tui_proxy.rs
+++ b/src-tauri/src/sessions/codex_tui_proxy.rs
@@ -288,10 +288,18 @@ fn track_thread_selection_request(raw: &str, pending: &mut HashMap<String, bool>
         return;
     };
     let method = message.get("method").and_then(Value::as_str);
+    let ephemeral = message
+        .get("params")
+        .and_then(|params| params.get("ephemeral"))
+        .and_then(Value::as_bool)
+        == Some(true);
     let confirmed = match method {
-        Some("thread/start") => Some(false),
+        // Codex creates ephemeral low-effort threads for internal work such as task-title
+        // generation. Those requests share the TUI transport but never represent a user
+        // workspace selection, so they must not replace the backing thread used by GPT Live.
+        Some("thread/start") if !ephemeral => Some(false),
         Some("thread/resume") => Some(true),
-        Some("thread/fork") => (message
+        Some("thread/fork") if !ephemeral => (message
             .get("params")
             .and_then(|params| params.get("excludeTurns"))
             .and_then(Value::as_bool)
@@ -925,6 +933,60 @@ mod tests {
                 id: "blank".to_string(),
                 confirmed: false,
                 revision: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn ignores_ephemeral_internal_threads_as_tui_selections() {
+        let selected = Arc::new(Mutex::new(Some(SelectedThread {
+            id: "workspace-thread".to_string(),
+            confirmed: true,
+            revision: 7,
+        })));
+        let mut selection_pending = HashMap::new();
+        track_thread_selection_request(
+            r#"{"method":"thread/start","id":"title","params":{"ephemeral":true}}"#,
+            &mut selection_pending,
+        );
+        track_thread_selection_request(
+            r#"{"method":"thread/fork","id":"internal-fork","params":{"ephemeral":true}}"#,
+            &mut selection_pending,
+        );
+
+        assert!(selection_pending.is_empty());
+        assert_eq!(
+            take_selected_thread_response(
+                r#"{"id":"title","result":{"thread":{"id":"title-thread"}}}"#,
+                &mut selection_pending,
+            ),
+            None
+        );
+
+        // The title generator immediately starts a turn on its ephemeral thread. Even
+        // after that succeeds, it must not confirm or replace the durable workspace
+        // selection that GPT Live uses.
+        let mut turn_pending = HashMap::new();
+        track_turn_start_request(
+            r#"{"method":"turn/start","id":"title-turn","params":{"threadId":"title-thread","input":[]}}"#,
+            &mut turn_pending,
+        );
+        let thread_id = take_successful_turn_start_response(
+            r#"{"id":"title-turn","result":{"turn":{"id":"generated-title"}}}"#,
+            &mut turn_pending,
+        )
+        .expect("accepted internal title turn");
+        mark_selected_thread_confirmed(&thread_id, &selected);
+
+        assert_eq!(
+            selected
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone(),
+            Some(SelectedThread {
+                id: "workspace-thread".to_string(),
+                confirmed: true,
+                revision: 7,
             })
         );
     }

--- a/src-tauri/src/sessions/pty_session.rs
+++ b/src-tauri/src/sessions/pty_session.rs
@@ -331,6 +331,7 @@ struct CodexAppServerProcess {
 pub struct CodexRealtimeCapabilities {
     pub app_server_version: Option<String>,
     pub persona_initial_items: bool,
+    pub delegation_ack_filler: bool,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -409,12 +410,22 @@ fn detect_codex_realtime_capabilities(
         .ok()
         .and_then(|child| read_child_stdout_with_timeout(child, CODEX_VERSION_PROBE_TIMEOUT))
         .and_then(|output| parse_codex_cli_version(&output));
+    codex_realtime_capabilities_for_version(app_server_version)
+}
+
+fn codex_realtime_capabilities_for_version(
+    app_server_version: Option<String>,
+) -> CodexRealtimeCapabilities {
     let persona_initial_items = app_server_version
         .as_deref()
-        .is_some_and(|version| codex_version_at_least(version, [0, 146, 0]));
+        .is_some_and(|version| codex_version_at_least(version, [0, 145, 0]));
+    let delegation_ack_filler = app_server_version
+        .as_deref()
+        .is_some_and(|version| codex_version_at_least(version, [0, 147, 0]));
     CodexRealtimeCapabilities {
         app_server_version,
         persona_initial_items,
+        delegation_ack_filler,
     }
 }
 
@@ -1231,7 +1242,10 @@ impl PtySession {
 
 #[cfg(test)]
 mod codex_realtime_capability_tests {
-    use super::{codex_version_at_least, parse_codex_cli_version, read_child_stdout_with_timeout};
+    use super::{
+        codex_realtime_capabilities_for_version, parse_codex_cli_version,
+        read_child_stdout_with_timeout, CodexRealtimeCapabilities,
+    };
     use std::process::{Command, Stdio};
     use std::time::{Duration, Instant};
 
@@ -1245,11 +1259,51 @@ mod codex_realtime_capability_tests {
     }
 
     #[test]
-    fn gates_realtime_persona_initial_items_by_version() {
-        assert!(!codex_version_at_least("0.145.9", [0, 146, 0]));
-        assert!(codex_version_at_least("0.146.0", [0, 146, 0]));
-        assert!(codex_version_at_least("0.147.0", [0, 146, 0]));
-        assert!(!codex_version_at_least("invalid", [0, 146, 0]));
+    fn gates_realtime_capabilities_by_app_server_version() {
+        let capabilities = |version: Option<&str>| {
+            codex_realtime_capabilities_for_version(version.map(str::to_owned))
+        };
+
+        assert_eq!(
+            capabilities(Some("0.144.6")),
+            CodexRealtimeCapabilities {
+                app_server_version: Some("0.144.6".to_owned()),
+                persona_initial_items: false,
+                delegation_ack_filler: false,
+            }
+        );
+        assert_eq!(
+            capabilities(Some("0.145.0")),
+            CodexRealtimeCapabilities {
+                app_server_version: Some("0.145.0".to_owned()),
+                persona_initial_items: true,
+                delegation_ack_filler: false,
+            }
+        );
+        assert_eq!(
+            capabilities(Some("0.146.0")),
+            CodexRealtimeCapabilities {
+                app_server_version: Some("0.146.0".to_owned()),
+                persona_initial_items: true,
+                delegation_ack_filler: false,
+            }
+        );
+        assert_eq!(
+            capabilities(Some("0.147.0")),
+            CodexRealtimeCapabilities {
+                app_server_version: Some("0.147.0".to_owned()),
+                persona_initial_items: true,
+                delegation_ack_filler: true,
+            }
+        );
+        assert_eq!(
+            capabilities(None),
+            CodexRealtimeCapabilities {
+                app_server_version: None,
+                persona_initial_items: false,
+                delegation_ack_filler: false,
+            }
+        );
     }
 
     #[cfg(unix)]

--- a/src/bindings/tauri-commands.ts
+++ b/src/bindings/tauri-commands.ts
@@ -195,6 +195,8 @@ export interface SessionRealtimeCapabilities {
   readonly appServerVersion: string | null;
   /** Codex V3 supports supplemental developer `initialItems` without replacing its base prompt. */
   readonly personaInitialItems: boolean;
+  /** Realtime V3 can disable its synthetic acknowledgement after creating a delegation. */
+  readonly delegationAckFiller: boolean;
 }
 
 /** Host-verified capabilities of the Codex binary that owns this session's app-server. */

--- a/src/runtime/codex-realtime/codex-realtime-client.test.ts
+++ b/src/runtime/codex-realtime/codex-realtime-client.test.ts
@@ -23,6 +23,11 @@ interface SentMessage {
   readonly result?: unknown;
 }
 
+const localWorkHandoffItem = () => ({
+  role: "developer",
+  text: expect.stringContaining("not a standalone chat screen"),
+});
+
 const bridge = vi.hoisted(() => ({
   channel: null as FakeChannel<string> | null,
   sent: [] as SentMessage[],
@@ -38,6 +43,7 @@ const bridge = vi.hoisted(() => ({
   accountPrelude: null as "server-request" | "id-only" | "error-response" | null,
   loadedThreadResponses: [] as string[][],
   loadedThreadParents: {} as Record<string, string | null | undefined>,
+  ephemeralThreads: new Set<string>(),
   threadReadFailures: {} as Record<string, number>,
   /** voice → error message。entry がある voice の thread/realtime/start を error 応答にする。 */
   realtimeStartErrors: {} as Record<string, string>,
@@ -46,7 +52,11 @@ const bridge = vi.hoisted(() => ({
   /** version → async error notification。backend negotiation failure の実順序を再現する。 */
   realtimeStartVersionRemoteErrors: {} as Record<string, string>,
   initializeUserAgent: "codex_cli_rs/0.146.0",
-  capabilities: { appServerVersion: "0.146.0", personaInitialItems: true },
+  capabilities: {
+    appServerVersion: "0.146.0",
+    personaInitialItems: true,
+    delegationAckFiller: false,
+  },
   suppressRealtimeSdp: false,
 }));
 
@@ -127,6 +137,7 @@ vi.mock("../../bindings/tauri-commands", () => ({
           thread: {
             id: threadId,
             ...(parentThreadId !== undefined ? { parentThreadId } : {}),
+            ephemeral: typeof threadId === "string" && bridge.ephemeralThreads.has(threadId),
           },
         });
       } else if (request.method === "thread/realtime/start") {
@@ -274,8 +285,13 @@ describe("CodexRealtimeClient", () => {
     bridge.accountPrelude = null;
     bridge.loadedThreadResponses = [];
     bridge.loadedThreadParents = {};
+    bridge.ephemeralThreads = new Set();
     bridge.initializeUserAgent = "codex_cli_rs/0.146.0";
-    bridge.capabilities = { appServerVersion: "0.146.0", personaInitialItems: true };
+    bridge.capabilities = {
+      appServerVersion: "0.146.0",
+      personaInitialItems: true,
+      delegationAckFiller: false,
+    };
     vi.mocked(ensureAudioContextRunning).mockReset();
     vi.mocked(ensureAudioContextRunning).mockResolvedValue({} as AudioContext);
     bridge.threadReadFailures = {};
@@ -352,6 +368,7 @@ describe("CodexRealtimeClient", () => {
     const start = bridge.sent.find((message) => message.method === "thread/realtime/start");
     expect(start?.params?.initialItems).toEqual([
       { role: "developer", text: "persona speaking guidance" },
+      localWorkHandoffItem(),
     ]);
     // `prompt` replaces Codex's configured realtime backend instructions and must stay absent.
     expect(start?.params).not.toHaveProperty("prompt");
@@ -365,6 +382,36 @@ describe("CodexRealtimeClient", () => {
       },
     ]);
     expect(JSON.stringify(diagnostics)).not.toContain("persona speaking guidance");
+    client.stop();
+  });
+
+  it("grounds local-work delegation without replacing the backing Codex prompt", async () => {
+    bridge.capabilities = {
+      appServerVersion: "0.150.1",
+      personaInitialItems: true,
+      delegationAckFiller: true,
+    };
+    const client = new CodexRealtimeClient("main-session", undefined, {
+      getPersonaSnapshot: () => ({ personaId: "yori-ja", instructions: "persona guidance" }),
+    });
+
+    await client.start();
+
+    const start = bridge.sent.find((message) => message.method === "thread/realtime/start");
+    expect(start?.params?.initialItems).toEqual([
+      { role: "developer", text: "persona guidance" },
+      localWorkHandoffItem(),
+    ]);
+    expect(start?.params?.delegationAckFiller).toBe(false);
+    const handoff = (start?.params?.initialItems as Array<{ text?: string }> | undefined)?.[1];
+    expect(handoff?.text).toContain("must create a delegation to the backing Codex agent");
+    expect(handoff?.text).toContain("Do not say that you are checking");
+    expect(handoff?.text).toContain("report completion only after delegated Codex output");
+    expect(start?.params).not.toHaveProperty("prompt");
+    expect(start?.params).not.toHaveProperty("realtimeStartInstructions");
+    expect(start?.params).not.toHaveProperty("realtimeEndInstructions");
+    expect(start?.params).not.toHaveProperty("clientManagedHandoffs");
+    expect(start?.params).not.toHaveProperty("codexResponseHandoffMode");
     client.stop();
   });
 
@@ -408,7 +455,7 @@ describe("CodexRealtimeClient", () => {
     const start = bridge.sent.find((message) => message.method === "thread/realtime/start");
     expect(start?.params).toMatchObject({
       includeStartupContext: false,
-      initialItems: [{ role: "developer", text: "I am Yori" }],
+      initialItems: [{ role: "developer", text: "I am Yori" }, localWorkHandoffItem()],
     });
     expect(start?.params).not.toHaveProperty("prompt");
     expect(diagnostics[diagnostics.length - 1]).toMatchObject({
@@ -433,8 +480,8 @@ describe("CodexRealtimeClient", () => {
 
     const starts = bridge.sent.filter((message) => message.method === "thread/realtime/start");
     expect(starts.map((message) => message.params?.initialItems)).toEqual([
-      [{ role: "developer", text: "persona A" }],
-      [{ role: "developer", text: "persona B" }],
+      [{ role: "developer", text: "persona A" }, localWorkHandoffItem()],
+      [{ role: "developer", text: "persona B" }, localWorkHandoffItem()],
     ]);
     client.stop();
   });
@@ -450,7 +497,7 @@ describe("CodexRealtimeClient", () => {
       snapshot: { personaId: "quiet", instructions: "  " },
       status: "skipped-empty",
     },
-  ] as const)("starts honestly without persona initial items for $name", async ({
+  ] as const)("starts with grounded workflow and no persona text for $name", async ({
     snapshot,
     status,
   }) => {
@@ -464,14 +511,22 @@ describe("CodexRealtimeClient", () => {
     await client.start();
 
     const start = bridge.sent.find((message) => message.method === "thread/realtime/start");
-    expect(start?.params).not.toHaveProperty("initialItems");
+    expect(start?.params?.initialItems).toEqual([localWorkHandoffItem()]);
     expect(start?.params?.includeStartupContext).toBe(true);
+    expect(start?.params).not.toHaveProperty("prompt");
+    expect(start?.params).not.toHaveProperty("realtimeStartInstructions");
+    expect(start?.params).not.toHaveProperty("realtimeEndInstructions");
+    expect(start?.params).not.toHaveProperty("clientManagedHandoffs");
     expect(diagnostics[0]?.status).toBe(status);
     client.stop();
   });
 
   it("falls back without inventing fields when app-server capability is absent", async () => {
-    bridge.capabilities = { appServerVersion: "0.145.0", personaInitialItems: false };
+    bridge.capabilities = {
+      appServerVersion: "0.145.0",
+      personaInitialItems: false,
+      delegationAckFiller: false,
+    };
     const diagnostics: CodexRealtimePersonaApplication[] = [];
     const client = new CodexRealtimeClient("main-session", undefined, {
       getPersonaSnapshot: () => ({ personaId: "yori", instructions: "persona prompt" }),
@@ -484,6 +539,7 @@ describe("CodexRealtimeClient", () => {
     const start = bridge.sent.find((message) => message.method === "thread/realtime/start");
     expect(start?.params).not.toHaveProperty("initialItems");
     expect(start?.params).not.toHaveProperty("prompt");
+    expect(start?.params).not.toHaveProperty("delegationAckFiller");
     expect(start?.params?.includeStartupContext).toBe(true);
     expect(JSON.stringify(start?.params)).not.toContain("persona prompt");
     expect(diagnostics).toEqual([
@@ -506,6 +562,7 @@ describe("CodexRealtimeClient", () => {
 
     expect(client.getStatus()).toBe("active");
     const start = bridge.sent.find((message) => message.method === "thread/realtime/start");
+    expect(start?.params?.initialItems).toEqual([localWorkHandoffItem()]);
     expect(start?.params?.includeStartupContext).toBe(true);
     expect(diagnostics).toEqual([
       { personaId: null, status: "load-failed", appServerVersion: "0.146.0" },
@@ -546,7 +603,7 @@ describe("CodexRealtimeClient", () => {
       model: "gpt-live-1-codex",
       voice: "maple",
       includeStartupContext: false,
-      initialItems: [{ role: "developer", text: "persona guidance" }],
+      initialItems: [{ role: "developer", text: "persona guidance" }, localWorkHandoffItem()],
       transport: { type: "webrtc", sdp: "local-offer" },
     });
     expect(client.getStatus()).toBe("error");
@@ -568,6 +625,11 @@ describe("CodexRealtimeClient", () => {
   });
 
   it("falls back to the next candidate only when the app-server rejects the voice", async () => {
+    bridge.capabilities = {
+      appServerVersion: "0.149.0",
+      personaInitialItems: true,
+      delegationAckFiller: true,
+    };
     bridge.realtimeStartErrors = { maple: "Invalid voice: maple" };
     const fallbacks: CodexRealtimeVoiceFallback[] = [];
     const client = new CodexRealtimeClient("main-session", undefined, {
@@ -579,6 +641,11 @@ describe("CodexRealtimeClient", () => {
 
     const starts = bridge.sent.filter((message) => message.method === "thread/realtime/start");
     expect(starts.map((message) => message.params?.voice)).toEqual(["maple", "juniper"]);
+    expect(starts.map((message) => message.params?.delegationAckFiller)).toEqual([false, false]);
+    expect(starts.map((message) => message.params?.initialItems)).toEqual([
+      [localWorkHandoffItem()],
+      [localWorkHandoffItem()],
+    ]);
     expect(fallbacks).toEqual([
       { fromVoice: "maple", toVoice: "juniper", reason: "Invalid voice: maple" },
     ]);
@@ -1024,6 +1091,20 @@ describe("CodexRealtimeClient", () => {
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores an ephemeral title-generation thread during realtime discovery", async () => {
+    bridge.loadedThreadResponses = [["workspace-thread", "title-thread"]];
+    bridge.loadedThreadParents = { "workspace-thread": null, "title-thread": null };
+    bridge.ephemeralThreads.add("title-thread");
+    const client = new CodexRealtimeClient("main-session");
+
+    await client.start();
+
+    expect(
+      bridge.sent.find((message) => message.method === "thread/realtime/start")?.params,
+    ).toMatchObject({ threadId: "workspace-thread" });
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
   it("fails closed when thread/read omits the subagent relationship", async () => {
     bridge.loadedThreadResponses = [["thread-1", "thread-2"]];
     bridge.loadedThreadParents = { "thread-1": null, "thread-2": undefined };
@@ -1121,6 +1202,7 @@ describe("CodexRealtimeClient", () => {
     expect(starts).toHaveLength(1);
     expect(starts[0]?.params?.initialItems).toEqual([
       { role: "developer", text: "stable persona snapshot" },
+      localWorkHandoffItem(),
     ]);
     expect(diagnostics).toEqual([
       {
@@ -1137,12 +1219,29 @@ describe("CodexRealtimeClient", () => {
   it("sends realtime stop before retrying after an accepted start times out", async () => {
     vi.useFakeTimers();
     vi.spyOn(Math, "random").mockReturnValue(0.5);
+    bridge.capabilities = {
+      appServerVersion: "0.150.1",
+      personaInitialItems: true,
+      delegationAckFiller: true,
+    };
     bridge.suppressRealtimeSdp = true;
     const client = new CodexRealtimeClient("main-session");
     const result = client.start().catch((error: unknown) => error);
 
     await vi.advanceTimersByTimeAsync(47_000);
     expect(await result).toEqual(new Error("Codex realtime SDP answer timed out"));
+    const starts = bridge.sent.filter((message) => message.method === "thread/realtime/start");
+    expect(starts).toHaveLength(3);
+    expect(starts.map((message) => message.params?.delegationAckFiller)).toEqual([
+      false,
+      false,
+      false,
+    ]);
+    expect(starts.map((message) => message.params?.initialItems)).toEqual([
+      [localWorkHandoffItem()],
+      [localWorkHandoffItem()],
+      [localWorkHandoffItem()],
+    ]);
     expect(bridge.disconnect).toHaveBeenCalledTimes(3);
     for (const call of bridge.disconnect.mock.calls) {
       expect(call[0]).toEqual(

--- a/src/runtime/codex-realtime/codex-realtime-client.ts
+++ b/src/runtime/codex-realtime/codex-realtime-client.ts
@@ -132,6 +132,12 @@ const RPC_TIMEOUT_MS = 15_000;
 const THREAD_DISCOVERY_TIMEOUT_MS = 8_000;
 export const DEFAULT_CODEX_REALTIME_VOICE = "sol";
 const CODEX_REALTIME_V3_MODEL = "gpt-live-1-codex";
+const CODEX_REALTIME_LOCAL_WORK_HANDOFF = [
+  "You are the realtime conversational surface of the same local Codex work session, not a standalone chat screen.",
+  "When the user asks for an action, local work, or current-state inspection, you must create a delegation to the backing Codex agent; conversation alone is not execution.",
+  "Do not say that you are checking, started, working, or completed before delegation, and report completion only after delegated Codex output confirms it.",
+  "If you cannot delegate, say that execution did not start. Never simulate progress. Keep this internal handoff topology private unless the user asks.",
+].join(" ");
 const REMOTE_SPEECH_SAMPLE_INTERVAL_MS = 33;
 const START_RETRY_BASE_DELAYS_MS = [500, 1_500] as const;
 const APP_VERSION = "0.6.2";
@@ -336,6 +342,15 @@ export class CodexRealtimeClient implements LipSyncSource {
       realtimeCapabilities,
       await personaSnapshot,
     );
+    // Keep Codex's backing-executor prompt intact. This supplemental Live-side item only
+    // corrects routing decisions made before a request is handed to that executor.
+    const initialItems =
+      realtimeCapabilities.personaInitialItems && this.personaPromptMode !== "replace"
+        ? [
+            ...(personaApplication.initialItems ?? []),
+            { role: "developer" as const, text: CODEX_REALTIME_LOCAL_WORK_HANDOFF },
+          ]
+        : personaApplication.initialItems;
     this.assertAttemptOwner(attempt);
     this.currentStage = "account";
     const account = (await this.request("account/read", { refreshToken: false })) as {
@@ -358,9 +373,10 @@ export class CodexRealtimeClient implements LipSyncSource {
     await this.startWebRtc(
       threadId,
       attempt,
-      personaApplication.initialItems,
+      initialItems,
       personaApplication.prompt,
       personaApplication.startupContextIncluded,
+      realtimeCapabilities.delegationAckFiller,
     );
     this.assertAttemptOwner(attempt);
     return { billing, personaApplication: personaApplication.diagnostic };
@@ -437,14 +453,18 @@ export class CodexRealtimeClient implements LipSyncSource {
       if (typeof thread !== "object" || thread === null) {
         throw new Error("Codex returned an invalid loaded thread.");
       }
-      const loaded = thread as { readonly id?: unknown; readonly parentThreadId?: unknown };
+      const loaded = thread as {
+        readonly id?: unknown;
+        readonly parentThreadId?: unknown;
+        readonly ephemeral?: unknown;
+      };
       if (loaded.id !== threadId || !("parentThreadId" in loaded)) {
         throw new Error("Codex returned an invalid loaded thread.");
       }
       // parentThreadId は subagent にだけ設定される。agent team の子 thread を除外し、
       // TUI が所有する唯一の top-level thread へ接続する。
       if (loaded.parentThreadId === null) {
-        primaryThreadIds.push(threadId);
+        if (loaded.ephemeral !== true) primaryThreadIds.push(threadId);
       } else if (typeof loaded.parentThreadId !== "string" || loaded.parentThreadId.length === 0) {
         throw new Error("Codex returned an invalid loaded thread.");
       }
@@ -505,6 +525,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     capabilities: {
       readonly appServerVersion: string | null;
       readonly personaInitialItems: boolean;
+      readonly delegationAckFiller: boolean;
     },
     personaSnapshot: PersonaSnapshotLoadResult,
   ): {
@@ -592,6 +613,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     initialItems?: ReadonlyArray<{ readonly role: "developer"; readonly text: string }>,
     prompt?: string,
     startupContextIncluded = true,
+    disableDelegationAckFiller = false,
   ): Promise<void> {
     this.assertAttemptOwner(attempt);
     this.currentStage = "microphone";
@@ -673,6 +695,7 @@ export class CodexRealtimeClient implements LipSyncSource {
           initialItems,
           prompt,
           startupContextIncluded,
+          disableDelegationAckFiller,
         });
       } catch (error) {
         if (error instanceof StartAttemptCancelledError) throw error;
@@ -709,6 +732,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     initialItems,
     prompt,
     startupContextIncluded,
+    disableDelegationAckFiller,
   }: {
     readonly threadId: string;
     readonly attempt: number;
@@ -718,6 +742,7 @@ export class CodexRealtimeClient implements LipSyncSource {
     readonly initialItems?: ReadonlyArray<{ readonly role: "developer"; readonly text: string }>;
     readonly prompt?: string;
     readonly startupContextIncluded: boolean;
+    readonly disableDelegationAckFiller: boolean;
   }): Promise<string> {
     let acceptRemoteSdp!: (sdp: string) => void;
     let rejectRemoteSdp!: (error: Error) => void;
@@ -743,6 +768,7 @@ export class CodexRealtimeClient implements LipSyncSource {
         includeStartupContext: startupContextIncluded,
         ...(initialItems ? { initialItems } : {}),
         ...(prompt ? { prompt } : {}),
+        ...(disableDelegationAckFiller ? { delegationAckFiller: false } : {}),
         transport: { type: "webrtc", sdp },
       });
       this.assertAttemptOwner(attempt, peer);

--- a/src/runtime/codex-realtime/codex-thread-tracker.test.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.test.ts
@@ -18,6 +18,7 @@ const bridge = vi.hoisted(() => ({
   sent: [] as SentMessage[],
   loadedThreads: ["thread-1"] as string[],
   parents: {} as Record<string, string | null>,
+  ephemeralThreads: new Set<string>(),
   pendingReads: false,
   selectedThread: null as string | null,
   connectFailuresRemaining: 0,
@@ -61,6 +62,7 @@ vi.mock("../../bindings/tauri-commands", () => ({
             id: threadId,
             parentThreadId:
               typeof threadId === "string" ? (bridge.parents[threadId] ?? null) : null,
+            ephemeral: typeof threadId === "string" && bridge.ephemeralThreads.has(threadId),
           },
         });
       if (bridge.pendingReads) bridge.readResponders.push(sendRead);
@@ -75,6 +77,7 @@ describe("CodexThreadTracker", () => {
     bridge.sent = [];
     bridge.loadedThreads = ["thread-1"];
     bridge.parents = {};
+    bridge.ephemeralThreads = new Set();
     bridge.pendingReads = false;
     bridge.selectedThread = null;
     bridge.connectFailuresRemaining = 0;
@@ -92,7 +95,7 @@ describe("CodexThreadTracker", () => {
     tracker.stop();
   });
 
-  it("tracks the top-level thread started by /clear while ignoring subagents", async () => {
+  it("ignores generic thread starts and follows /clear only after the TUI proxy selects it", async () => {
     const tracker = new CodexThreadTracker("main-session");
     await tracker.start();
 
@@ -107,10 +110,13 @@ describe("CodexThreadTracker", () => {
     bridge.channel?.onmessage(
       JSON.stringify({
         method: "thread/started",
-        params: { thread: { id: "thread-after-clear", parentThreadId: null } },
+        params: { thread: { id: "internal-title-thread", parentThreadId: null } },
       }),
     );
-    expect(tracker.getCurrentThreadId()).toBe("thread-after-clear");
+    expect(tracker.getCurrentThreadId()).toBe("thread-1");
+
+    bridge.selectedThread = "thread-after-clear";
+    await vi.waitFor(() => expect(tracker.getCurrentThreadId()).toBe("thread-after-clear"));
     tracker.stop();
   });
 
@@ -213,12 +219,8 @@ describe("CodexThreadTracker", () => {
   it("does not switch back when the previous top-level thread later becomes idle", async () => {
     const tracker = new CodexThreadTracker("main-session");
     await tracker.start();
-    bridge.channel?.onmessage(
-      JSON.stringify({
-        method: "thread/started",
-        params: { thread: { id: "thread-2", parentThreadId: null } },
-      }),
-    );
+    bridge.selectedThread = "thread-2";
+    await vi.waitFor(() => expect(tracker.getCurrentThreadId()).toBe("thread-2"));
 
     bridge.channel?.onmessage(
       JSON.stringify({
@@ -259,7 +261,22 @@ describe("CodexThreadTracker", () => {
     tracker.stop();
   });
 
-  it("does not overwrite a broadcast thread with an older discovery snapshot", async () => {
+  it("never selects Codex's ephemeral title-generation thread", async () => {
+    bridge.loadedThreads = ["workspace-thread", "title-thread"];
+    bridge.ephemeralThreads.add("title-thread");
+    const tracker = new CodexThreadTracker("main-session");
+
+    await tracker.start();
+    expect(tracker.getCurrentThreadId()).toBe("workspace-thread");
+
+    // Even if an older proxy reports the internal thread, validation must keep the workspace.
+    bridge.selectedThread = "title-thread";
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(tracker.getCurrentThreadId()).toBe("workspace-thread");
+    tracker.stop();
+  });
+
+  it("does not select a generic started thread while startup discovery is in flight", async () => {
     bridge.pendingReads = true;
     const tracker = new CodexThreadTracker("main-session");
     const started = tracker.start();
@@ -274,7 +291,7 @@ describe("CodexThreadTracker", () => {
     bridge.readResponders.shift()?.();
     await started;
 
-    expect(tracker.getCurrentThreadId()).toBe("thread-after-clear");
+    expect(tracker.getCurrentThreadId()).toBeNull();
     tracker.stop();
   });
 

--- a/src/runtime/codex-realtime/codex-thread-tracker.ts
+++ b/src/runtime/codex-realtime/codex-thread-tracker.ts
@@ -27,10 +27,11 @@ const TUI_SELECTION_POLL_MS = 100;
 class TrackerRequestTimeoutError extends Error {}
 
 /**
- * TUI の thread/started broadcast を voice が停止中も監視する。
+ * TUI proxy が確認した選択 thread を voice が停止中も追跡する。
  *
- * thread/loaded/list は unsubscribe 済み thread も grace period 中は返すため、
- * /clear や /resume 後の current TUI thread を一覧だけから特定することはできない。
+ * app-server の `thread/started` は全 client の内部 thread も broadcast するため、
+ * TUI ownership の根拠にはできない。`thread/loaded/list` も unsubscribe 済み thread を
+ * grace period 中は返すので、接続後の /clear や /resume は proxy 選択だけを正本にする。
  */
 export class CodexThreadTracker {
   private readonly sessionId: string;
@@ -173,7 +174,7 @@ export class CodexThreadTracker {
       if (epoch !== this.epoch || generation !== this.topLevelStartedGeneration) return;
       const thread = (read as { readonly thread?: unknown }).thread;
       if (!isRecord(thread) || thread.id !== id || !("parentThreadId" in thread)) return;
-      if (thread.parentThreadId === null) topLevelIds.push(id);
+      if (thread.parentThreadId === null && thread.ephemeral !== true) topLevelIds.push(id);
     }
 
     // Startup 時に一意なら初期値にできる。複数時は過去の broadcast がないため推測しない。
@@ -225,7 +226,8 @@ export class CodexThreadTracker {
           isRecord(thread) &&
           thread.id === threadId &&
           "parentThreadId" in thread &&
-          thread.parentThreadId === null
+          thread.parentThreadId === null &&
+          thread.ephemeral !== true
         ) {
           this.setCurrentThreadId(threadId);
         }
@@ -312,10 +314,11 @@ export class CodexThreadTracker {
         thread.parentThreadId === null &&
         (!("forkedFromId" in thread) || thread.forkedFromId === null)
       ) {
+        // This broadcast is app-server-global. Realtime handoffs, title generation, and other
+        // clients can all create indistinguishable top-level threads. It may invalidate an
+        // in-flight startup snapshot, but only the TUI proxy may retarget an established voice.
         this.topLevelStartedGeneration += 1;
-        this.threadSelectionGeneration += 1;
         this.knownLoadedThreadIds.add(thread.id);
-        this.setCurrentThreadId(thread.id);
       }
       return;
     }


### PR DESCRIPTION
## Summary

- keep GPT Live requests routed to the backing local Codex work session
- ignore global broadcasts and ephemeral internal title-generation threads when tracking the selected workspace thread
- gate Realtime startup fields by the detected Codex app-server version and add regression coverage

## Root cause

Codex automatic title generation creates an ephemeral internal thread on the same app-server transport used by the TUI. The proxy treated every thread start request as a user-selected workspace thread, so the title-generation thread replaced the durable backing thread after the first voice turn. Later delegations then ran against the title thread and produced misleading results.

## Verification

- npm run check
- npm run test:run (2522 tests passed)
- npm run test:rust (388 tests passed)
- npm run build
- manual verification: repeated GPT Live local file operations continue working after automatic title generation and voice reconnection