### PR TITLE
Fix VRM head pose residue after animations

### DIFF
--- a/src/core/body/animation-player.test.ts
+++ b/src/core/body/animation-player.test.ts
@@ -1,0 +1,43 @@
+import type { VRM } from "@pixiv/three-vrm";
+import * as THREE from "three";
+import { describe, expect, it, vi } from "vitest";
+import { AnimationPlayer } from "./animation-player";
+
+describe("AnimationPlayer base pose capture", () => {
+  it("clears procedural head pitch before AnimationMixer saves its restore pose", async () => {
+    const scene = new THREE.Object3D();
+    const head = new THREE.Object3D();
+    head.name = "Head";
+    scene.add(head);
+    const vrm = { scene } as VRM;
+    const beforeActionPlay = vi.fn(() => {
+      head.rotation.x = 0;
+    });
+    const player = new AnimationPlayer(vrm, undefined, beforeActionPlay);
+    const clip = new THREE.AnimationClip("head-motion", 1, [
+      new THREE.QuaternionKeyframeTrack(
+        "Head.quaternion",
+        [0, 1],
+        [0, 0, 0, 1, Math.sin(0.1), 0, 0, Math.cos(0.1)],
+      ),
+    ]);
+    (player as unknown as { clipCache: Map<string, THREE.AnimationClip> }).clipCache.set(
+      "anim:test-head-motion",
+      clip,
+    );
+
+    // A cursor-attention episode left a temporary upward pitch on the bone.
+    head.rotation.x = 0.14;
+    const playback = await player.play("anim:test-head-motion", {
+      fadeInMs: 0,
+      fadeOutMs: 0,
+      weight: 1,
+    });
+    player.update(0.5);
+    playback.cancel();
+
+    expect(beforeActionPlay).toHaveBeenCalledOnce();
+    // stop() restores the clean pose captured after beforeActionPlay, not 0.14.
+    expect(head.rotation.x).toBeCloseTo(0, 6);
+  });
+});

--- a/src/core/body/animation-player.ts
+++ b/src/core/body/animation-player.ts
@@ -63,10 +63,12 @@ export class AnimationPlayer {
   private readonly clipCache = new Map<string, THREE.AnimationClip>();
   private readonly active = new Map<number, ActiveAnimation>();
   private readonly devLog?: SubsystemLog;
+  private readonly beforeActionPlay?: () => void;
 
-  constructor(vrm: VRM, devLog?: SubsystemLog) {
+  constructor(vrm: VRM, devLog?: SubsystemLog, beforeActionPlay?: () => void) {
     this.vrm = vrm;
     this.devLog = devLog;
+    this.beforeActionPlay = beforeActionPlay;
     this.mixer = new THREE.AnimationMixer(vrm.scene);
     this.loader = new GLTFLoader();
     this.loader.register((parser) => new VRMAnimationLoaderPlugin(parser));
@@ -159,6 +161,11 @@ export class AnimationPlayer {
     if (opts.speed !== undefined) action.setEffectiveTimeScale(opts.speed);
 
     const fadeInSec = (opts.fadeInMs ?? 200) / 1000;
+
+    // AnimationMixer saves the current bone transforms as the state it restores
+    // when the last action stops. Remove procedural overlays immediately before
+    // activation so a transient gaze/head offset cannot become that base.
+    this.beforeActionPlay?.();
 
     if (prevActive && fadeInSec > 0) {
       // Synchronized crossfade: prev の weight を duration で 0 へ、self の weight

--- a/src/core/body/body.test.ts
+++ b/src/core/body/body.test.ts
@@ -339,6 +339,23 @@ describe("Body motion activation ownership", () => {
     expect(updateProcedural.mock.calls[0][2]).toBeCloseTo(0.68);
     speech.cancel();
   });
+
+  it("animation claim 中は procedural head pose を外し、release 後に neutral idleへ戻す", () => {
+    const { vrm, getBone } = mockBodyVrm();
+    const claimState = mockClaimState();
+    const body = new Body(vrm, undefined, claimState);
+
+    body.update(1 / 60, 0);
+    expect(getBone("head").rotation.x).toBeLessThan(0);
+
+    const claim = claimState.claim("animation");
+    body.update(1 / 60, 1 / 60);
+    expect(getBone("head").rotation.x).toBeCloseTo(0, 6);
+
+    claim.dispose();
+    body.update(1 / 60, 2 / 60);
+    expect(getBone("head").rotation.x).toBeLessThan(0);
+  });
 });
 
 // ─── Body speech microexpression wiring ─────────────────

--- a/src/core/body/index.ts
+++ b/src/core/body/index.ts
@@ -409,9 +409,11 @@ export class Body {
       },
       /* ambientGate */ () => getAttentionRuntime().get().target !== null,
     );
-    this.animationPlayer = new AnimationPlayer(vrm, devLog);
     this.proceduralBones = new ProceduralBones();
     this.proceduralBones.bindVrm(vrm);
+    this.animationPlayer = new AnimationPlayer(vrm, devLog, () =>
+      this.proceduralBones.restoreHeadBaseRotation(),
+    );
     this.beatTarget = this.createBeatTarget();
     this.beatScheduler = new IdleBeatScheduler(defaultProfiles);
 
@@ -678,6 +680,10 @@ export class Body {
     this.logCursorAttentionSample(delta, cursorAttention);
 
     // 1. Animation mixer
+    // Previous-frame procedural head pose must not be seen as AnimationMixer's base
+    // pose. This also clears the last offset while an external animation claim
+    // owns the body.
+    this.proceduralBones.restoreHeadBaseRotation();
     if (!animationClaimed) {
       this.animationPlayer.update(delta);
     }

--- a/src/core/body/procedural-bones.test.ts
+++ b/src/core/body/procedural-bones.test.ts
@@ -202,6 +202,85 @@ describe("ProceduralBones breathing offsets", () => {
     expect(getBone("head").rotation.x).toBeCloseTo(baseline, 5);
   });
 
+  it("restoreHeadBaseRotation は一時的な上向き pitch を AnimationMixer の原点から外す", () => {
+    const { vrm, getBone } = mockVrm();
+    const bones = new ProceduralBones(() => 0.5);
+    bones.bindVrm(vrm);
+    bones.setHeadLookAtOffset(0, 0.14);
+
+    for (let t = 0; t < 2; t += DT) bones.update(DT, t, 1.0);
+    expect(getBone("head").rotation.x).toBeGreaterThan(0.08);
+
+    bones.restoreHeadBaseRotation();
+
+    expect(getBone("head").rotation.x).toBeCloseTo(0, 6);
+  });
+
+  it("restoreHeadBaseRotation は外部 animation が置換した回転へ stale base を戻さない", () => {
+    const { vrm, getBone } = mockVrm();
+    const bones = new ProceduralBones(() => 0.5);
+    bones.bindVrm(vrm);
+    bones.setHeadLookAtOffset(0, 0.14);
+
+    for (let t = 0; t < 2; t += DT) bones.update(DT, t, 1.0);
+    // AnimationAction.stop() は activation 時に保存した quaternion を直接復元する。
+    getBone("head").rotation.x = 0;
+
+    bones.restoreHeadBaseRotation();
+
+    expect(getBone("head").rotation.x).toBe(0);
+  });
+
+  it("AnimationMixer の再生・停止を反復しても thinking pitch が idle の原点に残らない", () => {
+    const { vrm, getBone } = mockVrm();
+    const head = getBone("head");
+    const bones = new ProceduralBones(() => 0.5);
+    bones.bindVrm(vrm);
+    const mixer = new THREE.AnimationMixer(head);
+    const clip = new THREE.AnimationClip("head-motion", 1, [
+      new THREE.QuaternionKeyframeTrack(
+        ".quaternion",
+        [0, 1],
+        [0, 0, 0, 1, Math.sin(0.1), 0, 0, Math.cos(0.1)],
+      ),
+    ]);
+    const action = mixer.clipAction(clip);
+    let elapsed = 0;
+    const updateProcedural = (durationS: number, weight = 1): void => {
+      const end = elapsed + durationS;
+      while (elapsed < end) {
+        bones.update(DT, elapsed, weight);
+        elapsed += DT;
+      }
+    };
+
+    for (let cycle = 0; cycle < 5; cycle++) {
+      bones.setActivityState("thinking");
+      updateProcedural(2);
+      expect(head.rotation.x).toBeGreaterThan(0.015);
+
+      // Body / AnimationPlayer do this immediately before action.play().
+      bones.restoreHeadBaseRotation();
+      expect(head.rotation.x).toBeCloseTo(0, 6);
+      action.reset().setLoop(THREE.LoopRepeat, Infinity).setEffectiveWeight(0.5).play();
+      bones.setActivityState("idle");
+      const animationEnd = elapsed + 1;
+      while (elapsed < animationEnd) {
+        bones.restoreHeadBaseRotation();
+        mixer.update(DT);
+        bones.update(DT, elapsed, 0.5);
+        elapsed += DT;
+      }
+
+      // stop() writes the original quaternion directly, invalidating the last
+      // procedural write. restoreHeadBaseRotation must recognize that takeover.
+      action.stop();
+      bones.restoreHeadBaseRotation();
+      updateProcedural(2);
+      expect(head.rotation.x).toBeCloseTo(-0.035, 3);
+    }
+  });
+
   it("weight 0 では breathing offset も適用されない", () => {
     const { vrm, getBone } = mockVrm();
     const bones = new ProceduralBones(() => 0.5);

--- a/src/core/body/procedural-bones.ts
+++ b/src/core/body/procedural-bones.ts
@@ -40,6 +40,7 @@ const FLINCH_PITCH_RAD = -0.045; // 負 = chin down
 // drift（z/y）と違い pitch には揺らぎが無く中心が素のポーズ任せだったため、ここで中心だけ寄せる。
 // procedural weight に乗せるので、conscious animation 中はフェードして効かない。
 const HEAD_REST_PITCH_RAD = -0.035;
+const APPLIED_ROTATION_EPSILON = 1e-6;
 
 // ─── Utility ─────────────────────────────────────────────
 
@@ -69,8 +70,13 @@ export class ProceduralBones {
   private headLookAtTargetY = 0;
   private headLookAtCurrentX = 0;
   private headLookAtCurrentY = 0;
-  private headLookAtAppliedX = 0;
-  private headLookAtAppliedY = 0;
+  private headBaseRotationX = 0;
+  private headBaseRotationY = 0;
+  private headBaseRotationZ = 0;
+  private headRotationAfterApplyX = 0;
+  private headRotationAfterApplyY = 0;
+  private headRotationAfterApplyZ = 0;
+  private headRotationApplied = false;
   private restPose: VrmRestPose | null = null;
 
   // BreathingSystem からの胸郭・肩オフセット（毎フレーム Body が供給）。
@@ -180,6 +186,34 @@ export class ProceduralBones {
     this.headLookAtTargetX = pitchRad;
   }
 
+  /**
+   * Remove the head overlay written by the previous procedural frame.
+   *
+   * AnimationMixer captures the current quaternion when an action starts and
+   * restores it when the action stops. Leaving a gaze/state pitch on the head
+   * at activation would therefore promote a transient offset into the restored
+   * base pose. If another system has already replaced the quaternion, only
+   * forget our bookkeeping; restoring a stale base would create a new residue.
+   */
+  restoreHeadBaseRotation(): void {
+    const head = this.headBone;
+    if (
+      head &&
+      this.headRotationApplied &&
+      Math.abs(head.rotation.x - this.headRotationAfterApplyX) <= APPLIED_ROTATION_EPSILON &&
+      Math.abs(head.rotation.y - this.headRotationAfterApplyY) <= APPLIED_ROTATION_EPSILON &&
+      Math.abs(head.rotation.z - this.headRotationAfterApplyZ) <= APPLIED_ROTATION_EPSILON
+    ) {
+      head.rotation.set(
+        this.headBaseRotationX,
+        this.headBaseRotationY,
+        this.headBaseRotationZ,
+        head.rotation.order,
+      );
+    }
+    this.headRotationApplied = false;
+  }
+
   /** BreathingSystem の胸郭・肩オフセットを受け取る。update で weight 込みで適用。 */
   setBreathingOffsets(chestPitchRad: number, shoulderLiftRad: number): void {
     this.breathChestPitch = chestPitchRad;
@@ -262,6 +296,10 @@ export class ProceduralBones {
 
     // ── Head drift ──────────────────────────────────────
     if (this.headBone) {
+      this.restoreHeadBaseRotation();
+      this.headBaseRotationX = this.headBone.rotation.x;
+      this.headBaseRotationY = this.headBone.rotation.y;
+      this.headBaseRotationZ = this.headBone.rotation.z;
       this.headDriftTimer -= delta;
       if (this.headDriftTimer <= 0) {
         const ampZ = HEAD_DRIFT_AMP_Z * headGain * this.statePose.driftAmpScale;
@@ -299,16 +337,16 @@ export class ProceduralBones {
       const headArc = Math.abs(this.headSpringZ.pos) * 0.3 * w;
       const appliedPitchX =
         this.headLookAtCurrentX + restPitchX + flinchX - headArc + this.statePose.headPitch * w;
-      this.headBone.rotation.x -= this.headLookAtAppliedX;
-      this.headBone.rotation.y -= this.headLookAtAppliedY;
       if (w >= 0.001) {
         this.headBone.rotation.z = this.headSpringZ.pos * w;
         this.headBone.rotation.y = this.headSpringY.pos * w;
       }
       this.headBone.rotation.x += appliedPitchX;
       this.headBone.rotation.y += this.headLookAtCurrentY;
-      this.headLookAtAppliedX = appliedPitchX;
-      this.headLookAtAppliedY = this.headLookAtCurrentY;
+      this.headRotationAfterApplyX = this.headBone.rotation.x;
+      this.headRotationAfterApplyY = this.headBone.rotation.y;
+      this.headRotationAfterApplyZ = this.headBone.rotation.z;
+      this.headRotationApplied = true;
     }
 
     // ── Arm drag（spine → 遅延追従）──────────────────────


### PR DESCRIPTION
## Summary

- restore the clean head base rotation before AnimationMixer captures an action restore pose
- detect external quaternion replacement so stale procedural offsets are not applied twice
- clear procedural head ownership while animation claims are active
- add real Three.js mixer regression coverage for repeated thinking-to-idle animation cycles

## Root cause

AnimationMixer saved a transient procedural head rotation as its original state when an action started. When the action stopped, that transient rotation was restored as the new base pose, allowing an upward gaze or thinking pitch to remain on the model.

## Validation

- Frontend: 198 files, 2528 tests passed
- Rust: 374 library tests and 14 binary tests passed
- Production build passed
- TypeScript, Biome, rustfmt, and Clippy passed

Closes #101