### PR TITLE
feat(ui): add extensible presentation view modes

### DIFF
--- a/bundled-packs/ui/companion/manifest.json
+++ b/bundled-packs/ui/companion/manifest.json
@@ -1,12 +1,19 @@
 {
   "$schema": "https://yorishiro.dev/schemas/pack-manifest.schema.json",
   "id": "companion",
-  "name": "Companion",
+  "name": "Portrait",
   "type": "ui",
   "version": "0.1.0",
   "yorishiroVersion": "^0.1.0",
   "executionClass": "trusted-main-thread-js",
   "author": "Yorishiro team",
   "description": "A narrow, always-on-top resident view with the terminal hidden.",
-  "entry": "ui.tsx"
+  "entry": "ui.tsx",
+  "viewMode": {
+    "enabled": true,
+    "label": "Portrait",
+    "icon": "scene",
+    "order": 10,
+    "category": "companion"
+  }
 }

--- a/bundled-packs/ui/companion/ui.tsx
+++ b/bundled-packs/ui/companion/ui.tsx
@@ -10,10 +10,10 @@ const companion: UiPackDefinition = {
   type: "ui",
   layout: {
     window: {
-      width: 320,
-      height: 720,
-      minWidth: 320,
-      minHeight: 420,
+      width: 280,
+      height: 560,
+      minWidth: 240,
+      minHeight: 400,
       alwaysOnTop: true,
     },
     sidebar: { width: "fullscreen" },

--- a/bundled-packs/ui/immersive/manifest.json
+++ b/bundled-packs/ui/immersive/manifest.json
@@ -7,5 +7,12 @@
   "yorishiroVersion": "^0.1.0",
   "author": "Yorishiro team",
   "description": "Transparent terminal background so the character and scene show through clearly.",
-  "entry": "ui.tsx"
+  "entry": "ui.tsx",
+  "viewMode": {
+    "enabled": true,
+    "label": "Immersive",
+    "icon": "immersive",
+    "order": 50,
+    "category": "presentation"
+  }
 }

--- a/bundled-packs/ui/portrait/manifest.json
+++ b/bundled-packs/ui/portrait/manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "portrait",
+  "name": "Call",
+  "type": "ui",
+  "version": "0.1.0",
+  "yorishiroVersion": "^0.1.0",
+  "description": "A compact face-centered conversation view.",
+  "entry": "ui.tsx",
+  "viewMode": {
+    "enabled": true,
+    "label": "Call",
+    "icon": "portrait",
+    "order": 20,
+    "category": "companion"
+  }
+}

--- a/bundled-packs/ui/portrait/ui.test.ts
+++ b/bundled-packs/ui/portrait/ui.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import companionManifest from "../companion/manifest.json";
+import portraitManifest from "./manifest.json";
+import portrait from "./ui";
+
+describe("Call native window layout", () => {
+  it("enters at the aspect-safe compact minimum and remains resizable", () => {
+    expect(portrait.layout.window).toMatchObject({
+      width: 200,
+      height: 300,
+      minWidth: 200,
+      minHeight: 300,
+      aspectRatio: 2 / 3,
+    });
+  });
+
+  it("uses compatibility-safe ids with distinct display labels", () => {
+    expect(companionManifest.id).toBe("companion");
+    expect(companionManifest.viewMode.label).toBe("Portrait");
+    expect(portraitManifest.id).toBe("portrait");
+    expect(portraitManifest.viewMode.label).toBe("Call");
+  });
+});

--- a/bundled-packs/ui/portrait/ui.tsx
+++ b/bundled-packs/ui/portrait/ui.tsx
@@ -1,0 +1,24 @@
+import type { Disposable, UiPackDefinition } from "@yorishiro/sdk";
+
+const portrait: UiPackDefinition = {
+  id: "portrait",
+  type: "ui",
+  layout: {
+    window: {
+      width: 200,
+      height: 300,
+      minWidth: 200,
+      minHeight: 300,
+      alwaysOnTop: true,
+      aspectRatio: 2 / 3,
+    },
+    sidebar: { width: "fullscreen" },
+    terminal: { position: "hidden" },
+    chrome: { visible: false },
+    tabIndicator: { visible: false },
+  },
+  mount(): Disposable {
+    return { dispose() {} };
+  },
+};
+export default portrait;

--- a/bundled-packs/ui/theater/manifest.json
+++ b/bundled-packs/ui/theater/manifest.json
@@ -7,5 +7,12 @@
   "yorishiroVersion": "^0.1.0",
   "author": "Yorishiro team",
   "description": "Fullscreen character view — hides the terminal and chrome.",
-  "entry": "ui.tsx"
+  "entry": "ui.tsx",
+  "viewMode": {
+    "enabled": true,
+    "label": "Theater",
+    "icon": "theater",
+    "order": 40,
+    "category": "presentation"
+  }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ tauri-build = { version = "2", features = [] }
 # 自動で有効になるため dev 体験は保たれる。一方この feature を付けると release build でも
 # Inspector が開き、console から __TAURI_INTERNALS__.invoke で system_exec を含む全 IPC
 # command を直接叩けてしまう（pack 信頼境界を console から迂回できる）。production には含めない。
-tauri = { version = "2", features = ["protocol-asset"] }
+tauri = { version = "2", features = ["protocol-asset", "macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 # in-app updater: GitHub Releases の latest.json を参照して署名検証つきで自己更新する。

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,8 @@
     "core:window:allow-set-min-size",
     "core:window:allow-set-size",
     "core:window:allow-set-always-on-top",
+    "core:window:allow-set-fullscreen",
+    "core:window:allow-set-background-color",
     "opener:default",
     "dialog:default",
     "updater:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1264,6 +1264,8 @@ struct UserPackManifestSummary {
     /// 能力ラダーの sandbox 宣言。Rust 側は素通しし、検証は TS（pack-execution-policy）が行う。
     #[serde(skip_serializing_if = "Option::is_none")]
     sandbox: Option<serde_json::Value>,
+    #[serde(rename = "viewMode", skip_serializing_if = "Option::is_none")]
+    view_mode: Option<serde_json::Value>,
 }
 
 /// Absolute path to ~/.yorishiro/. Does not create it.
@@ -1576,6 +1578,7 @@ fn discover_user_pack_entries(packs_dir: &Path) -> Result<Vec<UserPackEntry>, St
                         min_client_version: m.min_client_version.clone(),
                         platform: m.platform.clone(),
                         sandbox: m.sandbox.clone(),
+                        view_mode: m.view_mode.clone(),
                     }),
                 });
             }
@@ -3775,6 +3778,49 @@ fn external_attach_sync_client_count(server: State<'_, attach::AttachServer>) ->
     server.emit_current_client_count()
 }
 
+#[tauri::command]
+async fn set_window_controls_visible(
+    window: tauri::WebviewWindow,
+    visible: bool,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
+        window
+            .with_webview(move |platform_webview| {
+                use objc2::msg_send;
+                use objc2::runtime::AnyObject;
+
+                let wk_webview: *mut AnyObject = platform_webview.inner().cast();
+                let result = unsafe {
+                    let ns_window: *mut AnyObject = msg_send![wk_webview, window];
+                    if ns_window.is_null() {
+                        Err("WKWebView has no native window".to_string())
+                    } else {
+                        for button_kind in 0_isize..=2 {
+                            let button: *mut AnyObject =
+                                msg_send![ns_window, standardWindowButton: button_kind];
+                            if !button.is_null() {
+                                let _: () = msg_send![button, setHidden: !visible];
+                            }
+                        }
+                        Ok(())
+                    }
+                };
+                let _ = tx.send(result);
+            })
+            .map_err(|error| format!("with_webview failed: {error}"))?;
+        rx.await
+            .map_err(|_| "window control update channel dropped".to_string())?
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (window, visible);
+        Ok(())
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // SessionRegistry を先に Arc 化して PtyState と Tauri managed state の両方
@@ -3867,6 +3913,7 @@ pub fn run() {
             history::snapshot_restore,
             history::snapshot_prune,
             external_attach_sync_client_count,
+            set_window_controls_visible,
             system_exec
         ])
         .setup(move |app| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,6 +19,8 @@
         "minHeight": 600,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "trafficLightPosition": { "x": 12, "y": 10 },
+        "transparent": true,
         "backgroundColor": "#020304",
         "backgroundThrottling": "disabled"
       }
@@ -29,7 +31,8 @@
         "enable": true,
         "scope": ["$APPDATA/**", "$HOME/.yorishiro/**"]
       }
-    }
+    },
+    "macOSPrivateApi": true
   },
   "plugins": {
     "updater": {

--- a/src/App.css
+++ b/src/App.css
@@ -42,6 +42,18 @@ body,
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
+html[data-rounded-view],
+html[data-rounded-view] body,
+html[data-rounded-view] #root {
+  border-radius: 14px;
+  background: transparent;
+  overflow: hidden;
+}
+
+html[data-rounded-view] body {
+  clip-path: inset(0 round 14px);
+}
+
 /* ── Layout ─────────────────────────────────────────── */
 .app {
   display: flex;
@@ -49,6 +61,12 @@ body,
   height: 100vh;
   width: 100vw;
   min-height: 0;
+}
+
+.app.view-mode-window-rounded {
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--yorishiro-bg, #0d1117);
 }
 
 .app-body {
@@ -92,6 +110,27 @@ body,
   border-bottom: 1px solid rgba(44, 44, 48, 0.85);
   color: #d0d0d0;
   user-select: none;
+}
+
+.app.view-mode-chrome-hidden .title-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 900;
+  opacity: 0;
+  pointer-events: none;
+  padding-left: 10px;
+  transform: translateY(-100%);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+}
+.app.view-mode-chrome-hidden.view-mode-hud-visible .title-bar,
+.app.view-mode-chrome-hidden .title-bar:focus-within {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
 }
 
 .title-bar-controls {
@@ -145,6 +184,60 @@ body,
   flex: 0 0 1px;
   margin: 0 3px;
   background: rgba(255, 255, 255, 0.12);
+}
+
+.view-mode-control {
+  position: relative;
+}
+.view-mode-control > .title-bar-button {
+  width: 32px;
+  gap: 1px;
+}
+.view-mode-menu {
+  position: absolute;
+  top: 29px;
+  left: 0;
+  z-index: 1000;
+  min-width: 168px;
+  padding: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(24, 24, 27, 0.98);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+.view-mode-menu button {
+  width: 100%;
+  padding: 7px 9px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: #d4d4d8;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.view-mode-menu kbd {
+  color: #8f8f98;
+  font: inherit;
+  font-size: 11px;
+}
+.view-mode-menu-separator {
+  height: 1px;
+  margin: 4px 5px;
+  border: 0;
+  background: rgba(255, 255, 255, 0.1);
+}
+.view-mode-menu button:hover,
+.view-mode-menu button:focus-visible {
+  outline: none;
+  background: rgba(255, 255, 255, 0.09);
+}
+.view-mode-menu button[aria-checked="true"] {
+  color: white;
+  background: rgba(120, 150, 255, 0.18);
 }
 
 /*

--- a/src/App.css
+++ b/src/App.css
@@ -676,6 +676,11 @@ html[data-rounded-view] body {
   padding: 12px 12px 0;
 }
 
+/* No selector means no sidebar chrome; collapse it so it cannot leave a top strip. */
+.sidebar.sidebar-project-selector-hidden {
+  display: none;
+}
+
 .folder-btn {
   display: flex;
   align-items: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1106,13 +1106,16 @@ function App() {
     [],
   );
   useEffect(() => {
-    const compact = activeUiId === companionPack.id || activeUiId === "portrait";
+    // Settings is a temporary surface over the originating View Mode. Keep that
+    // mode's camera claim alive so opening/closing Settings never re-frames the resident.
+    const cameraViewModeId = pickerActiveViewModeId;
+    const compact = cameraViewModeId === companionPack.id || cameraViewModeId === "portrait";
     const runtime = getThreeRuntime();
     if (!compact) {
       runtime.setCameraBase(0, 1.35, 1.1);
       return;
     }
-    const mode = activeUiId === companionPack.id ? "scene" : activeUiId;
+    const mode = cameraViewModeId === companionPack.id ? "scene" : cameraViewModeId;
     const windowedMode = mode as "scene" | "portrait";
     const characterAnchorY =
       windowedMode === "portrait" ? runtime.getCharacterAnchor()?.y : undefined;
@@ -1132,7 +1135,7 @@ function App() {
       runtime.acquireFixedCamera.bind(runtime),
       characterAnchorY,
     );
-  }, [activeUiId]);
+  }, [pickerActiveViewModeId]);
   useEffect(() => {
     const rounded = roundedWindowForViewMode(activePresentationViewModeIdValue);
     document.documentElement.toggleAttribute("data-rounded-view", rounded);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5800,7 +5800,10 @@ function App() {
           <Sidebar
             folderName={folderName}
             onPickFolder={handlePickFolder}
-            showProjectSelector={shouldShowProjectSelector(isUserLayerReady, activeUiId)}
+            showProjectSelector={shouldShowProjectSelector(
+              isUserLayerReady,
+              pickerActiveViewModeId,
+            )}
           />
           <CharacterSurface
             vrmUrl={vrmUrl}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,8 @@ import {
   PREVIOUS_ACTIVE_UI_KEY,
   pomodoroManifest,
   pomodoroUiManifest,
+  portraitManifest,
+  portraitPack,
   resolveCloseTarget,
   SETTINGS_PACK_ID,
   screenFlashPack,
@@ -352,6 +354,16 @@ import {
   writeYorishiroConfigText,
 } from "./runtime/user-pack-loader/yorishiro-io";
 import {
+  acquireFixedViewModeCamera,
+  acquireResponsiveCallCamera,
+} from "./runtime/view-mode-framing";
+import { enqueueNativeWindowMutation } from "./runtime/view-mode-native-window";
+import {
+  nextViewModeHudVisibility,
+  shouldRevealViewModeHud,
+  shouldStartViewModeWindowDrag,
+} from "./runtime/view-mode-window-interaction";
+import {
   getWorkspaceAttentionStore,
   startCommandRunAttentionProducer,
   startSessionAttentionProducer,
@@ -365,10 +377,26 @@ import * as YorishiroR3f from "./sdk/r3f";
 import type { ScenePackDefinition, ScenePackManifest } from "./sdk/scene-pack";
 import Sidebar from "./sidebar";
 import TitleBar from "./title-bar";
-import { useActiveUiId, useSettingsActive, useSidebarOpen } from "./title-bar-state";
 import {
+  activePresentationViewModeId,
+  buildViewModeShortcuts,
+  matchesViewModeShortcut,
+  nativeWindowControlsVisibleForViewMode,
+  resolvePickerActiveViewModeId,
+  roundedWindowForViewMode,
+  shouldShowProjectSelector,
+  useActiveUiId,
+  useSettingsActive,
+  useSidebarOpen,
+  useViewModes,
+} from "./title-bar-state";
+import {
+  isUiPackHostReady,
   layoutNeedsHostPresenceResume,
+  resolvePersistedUiId,
+  shouldAnimateTheaterTransition,
   shouldResumeHostPresenceForUiActivation,
+  subscribeAndActivateCurrentUi,
 } from "./ui-pack-activation";
 import "./App.css";
 
@@ -1020,6 +1048,101 @@ function App() {
   const sidebarOpen = useSidebarOpen();
   const activeUiId = useActiveUiId();
   const settingsActive = useSettingsActive(SETTINGS_PACK_ID);
+  const viewModes = useViewModes();
+  const savedViewMode = settingsActive
+    ? getUiStateStore().get(SETTINGS_PACK_ID, PREVIOUS_ACTIVE_UI_KEY)
+    : null;
+  const resolvedPickerViewModeId = resolvePickerActiveViewModeId(
+    settingsActive,
+    savedViewMode,
+    activeUiId,
+  );
+  const pickerActiveViewModeId = viewModes.some((entry) => entry.id === resolvedPickerViewModeId)
+    ? resolvedPickerViewModeId
+    : null;
+  const activePresentationViewModeIdValue = activePresentationViewModeId(
+    settingsActive,
+    pickerActiveViewModeId,
+  );
+  const viewModeOwnsChrome = activePresentationViewModeIdValue !== null;
+  const viewModeUsesRoundedWindow = roundedWindowForViewMode(activePresentationViewModeIdValue);
+  const isMac = /Mac/i.test(navigator.platform);
+  const viewModeShortcuts = useMemo(
+    () => buildViewModeShortcuts(viewModes, isMac),
+    [viewModes, isMac],
+  );
+  const viewModeShortcutHints = useMemo(
+    () =>
+      Object.fromEntries(
+        viewModeShortcuts.flatMap((shortcut) =>
+          shortcut.id === null ? [] : [[shortcut.id, shortcut.hint]],
+        ),
+      ),
+    [viewModeShortcuts],
+  );
+  const [viewModeHudVisible, setViewModeHudVisible] = useState(false);
+  useEffect(() => {
+    const subscription = getUiRegistry().subscribeActive(() => setViewModeHudVisible(false));
+    return () => subscription.dispose();
+  }, []);
+  useEffect(() => {
+    void enqueueNativeWindowMutation(() =>
+      invoke<void>("set_window_controls_visible", {
+        visible: nativeWindowControlsVisibleForViewMode(activePresentationViewModeIdValue),
+      }),
+    ).catch((error) => {
+      console.error(
+        "[UiPack:native-window-controls] failed to update native window controls",
+        error,
+      );
+    });
+  }, [activePresentationViewModeIdValue]);
+  useEffect(
+    () => () => {
+      void enqueueNativeWindowMutation(() =>
+        invoke<void>("set_window_controls_visible", { visible: true }),
+      ).catch(() => undefined);
+    },
+    [],
+  );
+  useEffect(() => {
+    const compact = activeUiId === companionPack.id || activeUiId === "portrait";
+    const runtime = getThreeRuntime();
+    if (!compact) {
+      runtime.setCameraBase(0, 1.35, 1.1);
+      return;
+    }
+    const mode = activeUiId === companionPack.id ? "scene" : activeUiId;
+    const windowedMode = mode as "scene" | "portrait";
+    const characterAnchorY =
+      windowedMode === "portrait" ? runtime.getCharacterAnchor()?.y : undefined;
+    if (windowedMode === "portrait") {
+      return acquireResponsiveCallCamera(
+        characterAnchorY,
+        runtime.acquireFixedCamera.bind(runtime),
+        {
+          getWidth: () => window.innerWidth,
+          addEventListener: (_type, listener) => window.addEventListener("resize", listener),
+          removeEventListener: (_type, listener) => window.removeEventListener("resize", listener),
+        },
+      );
+    }
+    return acquireFixedViewModeCamera(
+      windowedMode,
+      runtime.acquireFixedCamera.bind(runtime),
+      characterAnchorY,
+    );
+  }, [activeUiId]);
+  useEffect(() => {
+    const rounded = roundedWindowForViewMode(activePresentationViewModeIdValue);
+    document.documentElement.toggleAttribute("data-rounded-view", rounded);
+    void enqueueNativeWindowMutation(() =>
+      getCurrentWindow().setBackgroundColor(rounded ? [0, 0, 0, 0] : [2, 3, 4, 255]),
+    ).catch(() => undefined);
+    return () => {
+      document.documentElement.removeAttribute("data-rounded-view");
+    };
+  }, [activePresentationViewModeIdValue]);
   // Historical debug switch. Practical tab metadata badges are allowlisted and always shown.
   const [, setTabMetadataBadgesEnabled] = useState(false);
   const [restoreDialog, setRestoreDialog] = useState<RestoreDialogRequest | null>(null);
@@ -1432,6 +1555,15 @@ function App() {
       phase: "register",
       note: `registered bundled UI pack '${companionPack.id}'`,
     });
+    for (const { pack, manifest } of [{ pack: portraitPack, manifest: portraitManifest }]) {
+      uiPackRegistry.register({
+        id: pack.id,
+        origin: "bundled",
+        manifest: manifest as UiPackManifest,
+        pack: { layout: pack.layout, mount: pack.mount },
+      });
+      appLog.write({ phase: "register", note: `registered bundled UI pack '${pack.id}'` });
+    }
 
     // ── PersonaReflexDispatcher を構築 ───────────────────────────────────────
     // active persona の reflex（customTriggers + responses）を EventBus に bridge する。
@@ -1694,7 +1826,7 @@ function App() {
         scenePackRegistry.setActiveScene(
           resolveSceneForProject(config, projectRootValue(projectRoot)),
         );
-        uiPackRegistry.setActiveUi(config.activeUi);
+        uiPackRegistry.setActiveUi(resolvePersistedUiId(config.activeUi));
         syncAmbientUiActiveSet(config.activeAmbientUi);
         // ─ Persona resume gate ─
         // per (agent, place) で最後に spawn した persona を記録し、変わっていたら
@@ -2829,8 +2961,11 @@ function App() {
     applyTerminalPresentationForMountedSessions();
   }, [tabState.activeSessionId, applyTerminalPresentationForMountedSessions]);
 
-  const canMountTerminals =
-    isUserLayerReady && isSessionRestoreReady && resolvedSystemPrompt !== undefined;
+  const canMountTerminals = isUiPackHostReady(
+    isUserLayerReady,
+    isSessionRestoreReady,
+    resolvedSystemPrompt !== undefined,
+  );
   const getTerminalSpec = useCallback(
     (sessionId: SessionId): SpawnSpec => {
       if (sessionId !== DEFAULT_SESSION_ID) {
@@ -3101,61 +3236,69 @@ function App() {
   // Yorishiro 本体の layout と独立にするため。pointer-events: none で default 透過し、
   // pack 側で auto を明示した要素だけがクリックを受ける。
   useEffect(() => {
-    // Terminal が mount されるまでは subscribe しない（空振り事故防止）。
-    // bundled register は factory 内の同期 code なので、ここに到達した時点で registry は既に埋まっている。
-    if (!isUserLayerReady) return;
+    // Terminal と host surface が DOM commit されるまでは subscribe しない。
+    // user layer の準備だけでは session restore / prompt 解決前で terminal がまだ存在せず、
+    // persisted View Mode の初回 activation が空振りしたまま再通知されない。
+    // bundled register は factory 内の同期 code なので、この時点で registry も埋まっている。
+    if (!canMountTerminals) return;
 
     let currentDisposable: Disposable | null = null;
     let currentContainer: HTMLDivElement | null = null;
     let currentAbort: AbortController | null = null;
     let currentLayout: UiLayout | null = null;
-    let nativeWindowUpdate = Promise.resolve();
+    let currentEntryId: string | null = null;
     let savedWindowSize: LogicalSize | null = null;
+    let savedFullscreen: boolean | null = null;
     const applyNativeWindowLayout = (layout: UiLayout | null): void => {
       const width = layout?.window?.width;
       const height = layout?.window?.height;
       const minWidth = layout?.window?.minWidth ?? 900;
       const minHeight = layout?.window?.minHeight ?? 600;
       const alwaysOnTop = layout?.window?.alwaysOnTop ?? false;
+      const fullscreen = layout?.window?.fullscreen ?? false;
 
       // active UI が短時間に連続で変わっても古い async call が後から勝たないよう直列化する。
-      nativeWindowUpdate = nativeWindowUpdate
-        .then(async () => {
-          const appWindow = getCurrentWindow();
-          const requestsSize = width !== undefined || height !== undefined;
-          if (requestsSize && savedWindowSize === null) {
-            const [innerSize, scaleFactor] = await Promise.all([
-              appWindow.innerSize(),
-              appWindow.scaleFactor(),
-            ]);
-            savedWindowSize = innerSize.toLogical(scaleFactor);
-          }
+      void enqueueNativeWindowMutation(async () => {
+        const appWindow = getCurrentWindow();
+        const requestsSize = width !== undefined || height !== undefined;
+        if (requestsSize && savedWindowSize === null) {
+          const [innerSize, scaleFactor] = await Promise.all([
+            appWindow.innerSize(),
+            appWindow.scaleFactor(),
+          ]);
+          savedWindowSize = innerSize.toLogical(scaleFactor);
+        }
 
-          await appWindow.setMinSize(new LogicalSize(minWidth, minHeight));
-          if (requestsSize) {
-            const [innerSize, scaleFactor] = await Promise.all([
-              appWindow.innerSize(),
-              appWindow.scaleFactor(),
-            ]);
-            const currentSize = innerSize.toLogical(scaleFactor);
-            await appWindow.setSize(
-              new LogicalSize(width ?? currentSize.width, height ?? currentSize.height),
-            );
-          } else if (savedWindowSize !== null) {
-            const restoreSize = savedWindowSize;
-            savedWindowSize = null;
-            await appWindow.setSize(restoreSize);
-          }
-          await appWindow.setAlwaysOnTop(alwaysOnTop);
-        })
-        .catch((error) => {
-          devLog.write({
-            subsystem: "UiPack",
-            phase: "window-layout",
-            note: "failed to apply native window layout",
-            data: { error: error instanceof Error ? error.message : String(error) },
-          });
+        await appWindow.setMinSize(new LogicalSize(minWidth, minHeight));
+        if (requestsSize) {
+          const [innerSize, scaleFactor] = await Promise.all([
+            appWindow.innerSize(),
+            appWindow.scaleFactor(),
+          ]);
+          const currentSize = innerSize.toLogical(scaleFactor);
+          await appWindow.setSize(
+            new LogicalSize(width ?? currentSize.width, height ?? currentSize.height),
+          );
+        } else if (savedWindowSize !== null) {
+          const restoreSize = savedWindowSize;
+          savedWindowSize = null;
+          await appWindow.setSize(restoreSize);
+        }
+        await appWindow.setAlwaysOnTop(alwaysOnTop);
+        if (savedFullscreen === null) savedFullscreen = await appWindow.isFullscreen();
+        await appWindow.setFullscreen(fullscreen || savedFullscreen === true);
+        if (!layout && savedFullscreen !== null) {
+          await appWindow.setFullscreen(savedFullscreen);
+          savedFullscreen = null;
+        }
+      }).catch((error) => {
+        devLog.write({
+          subsystem: "UiPack",
+          phase: "window-layout",
+          note: "failed to apply native window layout",
+          data: { error: error instanceof Error ? error.message : String(error) },
         });
+      });
     };
     const setCurrentLayout = (layout: UiLayout | null): void => {
       currentLayout = layout;
@@ -3687,6 +3830,7 @@ function App() {
     const activateEntry = (entry: UiPackEntry | null) => {
       // 前の layout を捕捉してから cleanup（deactivate 時の閉じアニメ判定に使う）。
       const prevLayout = currentLayout;
+      const prevEntryId = currentEntryId;
       // 前の UI pack を cleanup
       if (currentAbort) currentAbort.abort();
       currentAbort = null;
@@ -3697,6 +3841,7 @@ function App() {
         currentContainer = null;
       }
       setCurrentLayout(null);
+      currentEntryId = entry?.id ?? null;
       if (resetLayoutForAllTerminals()) refitPresentedTerminals();
       applyNativeWindowLayout(entry?.pack.layout ?? null);
       claimState.releaseAll();
@@ -3707,7 +3852,10 @@ function App() {
         // 1-shot フラグはここで必ず消費する（pack 種別に関わらずリークさせない）。
         const exitToClosed = exitFullscreenToClosedRef.current;
         exitFullscreenToClosedRef.current = false;
-        if (prevLayout?.transition?.kind === "stage") {
+        if (
+          prevLayout?.transition?.kind === "stage" &&
+          shouldAnimateTheaterTransition(prevEntryId, null)
+        ) {
           // 前 pack が stage 遷移（theater 等）：reset 後の素の状態から「閉じアニメ」を再生する
           // （resetLayout で end-state を一旦 clear → playStage("close") が反対端へ override して tween）。
           playStage("close", exitToClosed);
@@ -3752,7 +3900,12 @@ function App() {
 
       // stage 遷移を宣言した pack（theater 等）は、applyLayout が置いた end-state を
       // 反対端へ override して「開きアニメ」を再生する（snap でなく Tween）。
-      if (entry.pack.layout.transition?.kind === "stage") playStage("open");
+      if (
+        entry.pack.layout.transition?.kind === "stage" &&
+        shouldAnimateTheaterTransition(prevEntryId, entry.id)
+      ) {
+        playStage("open");
+      }
 
       const container = document.createElement("div");
       container.className = "ui-pack-container";
@@ -3784,7 +3937,8 @@ function App() {
       }
     };
 
-    const sub = uiPackRegistry.subscribeActive(activateEntry);
+    // Persisted activeUi may have been restored before this effect can subscribe.
+    const sub = subscribeAndActivateCurrentUi(uiPackRegistry, activateEntry);
 
     // タブ切替・追加時に active UI pack のレイアウトを新ターミナルにも適用する。
     // React の DOM commit を待つため requestAnimationFrame で遅延させる。
@@ -3827,7 +3981,7 @@ function App() {
     devLog,
     claimState,
     uiState,
-    isUserLayerReady,
+    canMountTerminals,
     logBridge,
     applyVrmPath,
     runtime,
@@ -4364,6 +4518,17 @@ function App() {
     uiState.set(SETTINGS_PACK_ID, PREVIOUS_ACTIVE_UI_KEY, current);
     uiPackRegistry.setActiveUi(SETTINGS_PACK_ID);
   }, []);
+
+  const handleSelectViewMode = useCallback(
+    (id: string | null) => {
+      setViewModeHudVisible(false);
+      getUiRegistry().setActiveUi(id);
+      void updateYorishiroConfig((config) => ({ ...config, activeUi: id })).catch((error) => {
+        console.warn("[App] failed to persist View Mode", error);
+      });
+    },
+    [updateYorishiroConfig],
+  );
 
   const handleVoiceEntryCancel = useCallback(() => {
     setVoiceEntryDialog(null);
@@ -5455,12 +5620,23 @@ function App() {
         event.preventDefault();
         setLevaHidden((prev) => !prev);
       }
+      const viewModeShortcut = viewModeShortcuts.find((shortcut) =>
+        matchesViewModeShortcut(shortcut, event, isMac),
+      );
+      if (viewModeShortcut) {
+        event.preventDefault();
+        handleSelectViewMode(viewModeShortcut.id);
+      }
+      if (event.code === "Escape" && viewModeOwnsChrome) {
+        event.preventDefault();
+        handleSelectViewMode(null);
+      }
     };
     window.addEventListener("keydown", onKeyDown, { capture: true });
     return () => {
       window.removeEventListener("keydown", onKeyDown, { capture: true });
     };
-  }, [handleOpenSettings]);
+  }, [handleOpenSettings, handleSelectViewMode, isMac, viewModeOwnsChrome, viewModeShortcuts]);
 
   // command run の keyboard 操作（active session）。
   // Cmd+Shift+F: 直近 failed run を reference 化。
@@ -5492,15 +5668,40 @@ function App() {
   // 経由で動かす（runtime singleton で register 済み）。この useEffect は不要。
 
   return (
-    <div className="app">
+    // A secondary click is the discoverable HUD gesture for chrome-owning View Modes.
+    <div
+      className={`app${viewModeOwnsChrome ? " view-mode-chrome-hidden" : ""}${viewModeUsesRoundedWindow ? " view-mode-window-rounded" : ""}${viewModeHudVisible ? " view-mode-hud-visible" : ""}`}
+      onContextMenuCapture={(event) => {
+        if (!shouldRevealViewModeHud(viewModeOwnsChrome, event.button)) return;
+        event.preventDefault();
+        setViewModeHudVisible((visible) =>
+          nextViewModeHudVisibility(viewModeOwnsChrome, event.button, visible),
+        );
+      }}
+      onPointerDown={(event) => {
+        if (!shouldStartViewModeWindowDrag(viewModeOwnsChrome, event.button, event.target)) return;
+        event.preventDefault();
+        void getCurrentWindow()
+          .startDragging()
+          .catch(() => undefined);
+      }}
+    >
       <TitleBar
         sidebarOpen={sidebarOpen}
         settingsActive={settingsActive}
         sidebarLabel={strings.labelPresence}
-        showSidebarToggle={activeUiId !== companionPack.id}
+        viewModeLabel={strings.viewMode}
+        terminalLabel={strings.terminal}
+        terminalShortcutHint={viewModeShortcuts[0]?.hint}
+        viewModeShortcutHints={viewModeShortcutHints}
+        settingsShortcutHint={/Mac/i.test(navigator.platform) ? "⌘," : "Ctrl+,"}
+        showSidebarToggle={!viewModeOwnsChrome}
         settingsLabel={strings.settings}
         onToggleSidebar={handleToggleSidebar}
         onOpenSettings={handleOpenSettings}
+        viewModes={viewModes}
+        activeViewModeId={pickerActiveViewModeId}
+        onSelectViewMode={handleSelectViewMode}
         voiceAvailable={voiceEntryAvailable}
         voiceDisabled={mainSessionReplacing}
         voiceState={titleBarVoiceState}
@@ -5596,7 +5797,11 @@ function App() {
             if (el) getSurfaceRegistry().register("shell", el);
           }}
         >
-          <Sidebar folderName={folderName} onPickFolder={handlePickFolder} />
+          <Sidebar
+            folderName={folderName}
+            onPickFolder={handlePickFolder}
+            showProjectSelector={shouldShowProjectSelector(isUserLayerReady, activeUiId)}
+          />
           <CharacterSurface
             vrmUrl={vrmUrl}
             onBodyReady={handleBodyReady}

--- a/src/bundled-packs.ts
+++ b/src/bundled-packs.ts
@@ -47,6 +47,8 @@ export { default as companionManifest } from "../bundled-packs/ui/companion/mani
 export { default as companionPack } from "../bundled-packs/ui/companion/ui";
 export { default as immersiveManifest } from "../bundled-packs/ui/immersive/manifest.json";
 export { default as immersivePack } from "../bundled-packs/ui/immersive/ui";
+export { default as portraitManifest } from "../bundled-packs/ui/portrait/manifest.json";
+export { default as portraitPack } from "../bundled-packs/ui/portrait/ui";
 export { default as theaterManifest } from "../bundled-packs/ui/theater/manifest.json";
 export { default as theaterPack } from "../bundled-packs/ui/theater/ui";
 export { default as yorishiroSettingsManifest } from "../bundled-packs/ui/yorishiro-settings/manifest.json";

--- a/src/i18n/strings.test.ts
+++ b/src/i18n/strings.test.ts
@@ -73,6 +73,13 @@ describe("resolveFixedTerminalPrompt", () => {
   });
 });
 
+describe("View Mode labels", () => {
+  it("keeps the null/default selection named Terminal in every locale", () => {
+    expect(getStrings("en").terminal).toBe("Terminal");
+    expect(getStrings("ja").terminal).toBe("Terminal");
+  });
+});
+
 describe("AGENT_COMMAND_SYNTAX", () => {
   // Rust 各 adapter の command_syntax() の mirror。ズレると prefill コマンドが
   // 間違った記法になる。Rust↔TS の drift は health-check で runtime 検知される。

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -5,6 +5,8 @@ import type { ResolvedLanguage } from "../runtime/language/language";
 
 export interface UiStrings {
   readonly settings: string;
+  readonly viewMode: string;
+  readonly terminal: string;
   readonly closeSettings: string;
   readonly language: string;
   readonly languageAuto: string;
@@ -232,6 +234,8 @@ export interface UiStrings {
 
 const EN: UiStrings = {
   settings: "Settings",
+  viewMode: "View Mode",
+  terminal: "Terminal",
   closeSettings: "Close settings",
   language: "Language",
   languageAuto: "Auto",
@@ -455,6 +459,8 @@ const EN: UiStrings = {
 
 const JA: UiStrings = {
   settings: "設定",
+  viewMode: "表示モード",
+  terminal: "Terminal",
   closeSettings: "設定を閉じる",
   language: "言語",
   languageAuto: "自動",

--- a/src/runtime/three-runtime/r3f-runtime-root.test.tsx
+++ b/src/runtime/three-runtime/r3f-runtime-root.test.tsx
@@ -79,6 +79,7 @@ vi.mock("../scene-pack-registry/asset-resolver", () => ({
 vi.mock("../three-runtime", () => ({
   getThreeRuntime: () => ({
     setCameraTracking: vi.fn(),
+    acquireFixedCamera: vi.fn(() => ({ setTarget: vi.fn(), dispose: vi.fn() })),
     getCameraTracking: () => true,
     getCamera: () => ({
       position: { x: 0, y: 1.35, z: 1.1, set: vi.fn() },

--- a/src/runtime/three-runtime/three-runtime.ts
+++ b/src/runtime/three-runtime/three-runtime.ts
@@ -6,6 +6,7 @@ import { Body } from "../../core/body";
 import { registerOrphanMorphs } from "../../core/body/register-orphan-morphs";
 import { applyVrmRestPose } from "../../core/body/vrm-rest-pose";
 import type { SubsystemLog } from "../../core/dev-log";
+import { easeInOutCubic } from "../../core/tween/lerp";
 import { TweenManager } from "../../core/tween/tween-manager";
 import { getOrInit } from "../hot-data";
 import { KEYS } from "../module-registry/keys";
@@ -14,7 +15,7 @@ import { getVrmCache } from "../vrm-cache";
 import { CameraModulationRegistry } from "./camera-modulation";
 import { R3fHost } from "./r3f-host";
 import { R3fRuntimeRoot } from "./r3f-runtime-root";
-import type { ThreeRuntime } from "./types";
+import type { FixedCameraHandle, ThreeRuntime } from "./types";
 
 const DEFAULT_RENDER_FPS = 30;
 const MIN_RENDER_FRAME_INTERVAL_MS = 1000 / DEFAULT_RENDER_FPS;
@@ -61,6 +62,13 @@ class ThreeRuntimeImpl implements ThreeRuntime {
   private loadToken = 0;
   private readonly tweenManager = new TweenManager();
   private readonly cameraBase = { x: 0, y: 1.35, z: 1.1 };
+  private fixedCamera: {
+    readonly token: symbol;
+    readonly previousBase: { x: number; y: number; z: number };
+    readonly previousPosition: THREE.Vector3;
+    readonly previousQuaternion: THREE.Quaternion;
+    readonly previousTracking: boolean;
+  } | null = null;
   private readonly cameraModulation = new CameraModulationRegistry();
   private readonly baseFov: number;
   private currentPlaceholder: HTMLElement | null = null;
@@ -224,16 +232,18 @@ class ThreeRuntimeImpl implements ThreeRuntime {
               else headPos.set(0, 1.6, 0);
 
               const targetY = headPos.y - 0.05;
-              this.cameraBase.x = 0;
-              this.cameraBase.y = targetY;
-              this.cameraBase.z = 1.1;
-              this.camera.position.set(0, targetY, 1.1);
-              this.camera.lookAt(0, targetY, 0);
+              if (!this.fixedCamera) {
+                this.cameraBase.x = 0;
+                this.cameraBase.y = targetY;
+                this.cameraBase.z = 1.1;
+                this.camera.position.set(0, targetY, 1.1);
+                this.camera.lookAt(0, targetY, 0);
+              }
               // 新しい姿は背丈が違う。切替経路（お別れの暗転中 / 設定画面の
               // live 差し替え）を問わず、ロード時は追従を ON に戻して頭位置の
               // 構図から始める。ここは即時スナップなので、暗転中なら
               // カーテンが明けた瞬間から構図が決まっている。
-              this.cameraTrackingEnabled = true;
+              if (!this.fixedCamera) this.cameraTrackingEnabled = true;
 
               this.bodyListenerRef.current?.(this.currentBody);
               this.updatePlaceholderRect();
@@ -315,6 +325,7 @@ class ThreeRuntimeImpl implements ThreeRuntime {
   }
 
   setCameraTracking(enabled: boolean): void {
+    if (this.fixedCamera) return;
     if (enabled && !this.cameraTrackingEnabled) {
       this.cameraBase.x = this.camera.position.x;
       this.cameraBase.y = this.camera.position.y;
@@ -327,13 +338,68 @@ class ThreeRuntimeImpl implements ThreeRuntime {
     return this.cameraTrackingEnabled;
   }
 
+  acquireFixedCamera(x: number, y: number, z: number): FixedCameraHandle {
+    const token = Symbol("fixed-camera");
+    const tweenKey = `view-mode-fixed-camera:${String(token)}`;
+    const previousBase = { ...this.cameraBase };
+    const previousPosition = this.camera.position.clone();
+    const previousQuaternion = this.camera.quaternion.clone();
+    const previousTracking = this.cameraTrackingEnabled;
+    this.fixedCamera = {
+      token,
+      previousBase,
+      previousPosition,
+      previousQuaternion,
+      previousTracking,
+    };
+    this.cameraTrackingEnabled = false;
+    this.cameraBase.x = x;
+    this.cameraBase.y = y;
+    this.cameraBase.z = z;
+    this.camera.position.set(x, y, z);
+    this.camera.lookAt(0, y, 0);
+    const apply = (nextX: number, nextY: number, nextZ: number) => {
+      if (this.fixedCamera?.token !== token) return;
+      this.cameraBase.x = nextX;
+      this.cameraBase.y = nextY;
+      this.cameraBase.z = nextZ;
+      this.camera.position.set(nextX, nextY, nextZ);
+      this.camera.lookAt(0, nextY, 0);
+    };
+    return {
+      setTarget: (nextX, nextY, nextZ, durationMs) => {
+        this.tweenManager.startVec3(
+          tweenKey,
+          [nextX, nextY, nextZ],
+          durationMs,
+          ([valueX, valueY, valueZ]) => apply(valueX, valueY, valueZ),
+          {
+            from: [this.camera.position.x, this.camera.position.y, this.camera.position.z],
+            easing: easeInOutCubic,
+          },
+        );
+      },
+      dispose: () => {
+        if (this.fixedCamera?.token !== token) return;
+        this.tweenManager.cancel(tweenKey);
+        this.fixedCamera = null;
+        this.cameraBase.x = previousBase.x;
+        this.cameraBase.y = previousBase.y;
+        this.cameraBase.z = previousBase.z;
+        this.camera.position.copy(previousPosition);
+        this.camera.quaternion.copy(previousQuaternion);
+        this.cameraTrackingEnabled = previousTracking;
+      },
+    };
+  }
+
   /**
    * camera が claim されているか（camera-move / UI pack 等が一時占有中）。
    * render loop の Step1-3 と同じ claim を見る。leva debug controls が claim 中に
    * camera 位置を上書きして演出（例: 銃撃の camera-move）を打ち消さないための gate。
    */
   isCameraClaimed(): boolean {
-    return this.claimState.isClaimed("camera");
+    return this.fixedCamera !== null || this.claimState.isClaimed("camera");
   }
 
   /**
@@ -425,7 +491,7 @@ class ThreeRuntimeImpl implements ThreeRuntime {
         this.updateBodyPointerReference();
         this.currentBody.update(delta, elapsed);
 
-        const cameraClaimed = this.claimState.isClaimed("camera");
+        const cameraClaimed = this.isCameraClaimed();
 
         // Step 1: Base — VRM head tracking（claim 未取得時のみ）
         if (this.trackHead && this.cameraTrackingEnabled && !cameraClaimed) {

--- a/src/runtime/three-runtime/types.ts
+++ b/src/runtime/three-runtime/types.ts
@@ -3,6 +3,7 @@ import type * as THREE from "three";
 import type { Body } from "../../core/body";
 import type { SubsystemLog } from "../../core/dev-log";
 import type { TweenManager } from "../../core/tween/tween-manager";
+import type { Disposable } from "../../sdk/context";
 import type { CameraModulationRegistry } from "./camera-modulation";
 
 /**
@@ -66,6 +67,8 @@ export interface ThreeRuntime {
   /** カメラ自動追従（head tracking）の有効/無効。app-level の設定で、claim とは独立。 */
   setCameraTracking(enabled: boolean): void;
   getCameraTracking(): boolean;
+  /** Atomically owns camera translation until disposed, restoring the previous camera state. */
+  acquireFixedCamera(x: number, y: number, z: number): FixedCameraHandle;
   /** camera が claim 中か（camera-move / UI pack 等が一時占有）。leva debug controls が claim を尊重するための gate。 */
   isCameraClaimed(): boolean;
 
@@ -85,4 +88,8 @@ export interface ThreeRuntime {
 
   /** camera modulation が suspend 中か（claim 中 or enabled=false）。 */
   isCameraModulationSuspended(): boolean;
+}
+
+export interface FixedCameraHandle extends Disposable {
+  setTarget(x: number, y: number, z: number, durationMs: number): void;
 }

--- a/src/runtime/ui-pack-registry/types.ts
+++ b/src/runtime/ui-pack-registry/types.ts
@@ -29,4 +29,5 @@ export interface UiPackRegistry {
   getActiveUiId(): string | null;
 
   listEntries(): ReadonlyArray<UiPackEntry>;
+  subscribeEntries(listener: (entries: ReadonlyArray<UiPackEntry>) => void): Disposable;
 }

--- a/src/runtime/ui-pack-registry/ui-pack-registry.test.ts
+++ b/src/runtime/ui-pack-registry/ui-pack-registry.test.ts
@@ -80,6 +80,15 @@ describe("UiPackRegistry", () => {
     expect(reg.listEntries()).toHaveLength(2);
   });
 
+  it("subscribeEntries tracks installation and removal", () => {
+    const reg = createUiPackRegistry();
+    const snapshots: string[][] = [];
+    reg.subscribeEntries((entries) => snapshots.push(entries.map((item) => item.id)));
+    const handle = reg.register(entry("portrait"));
+    handle.dispose();
+    expect(snapshots).toEqual([[], ["portrait"], []]);
+  });
+
   it("getActiveUiId returns active entry's id (alias of base getActiveId)", () => {
     const registry = createUiPackRegistry();
     expect(registry.getActiveUiId()).toBeNull();

--- a/src/runtime/ui-pack-registry/ui-pack-registry.ts
+++ b/src/runtime/ui-pack-registry/ui-pack-registry.ts
@@ -20,6 +20,29 @@ export class UiPackRegistryImpl
   extends SingleActiveRegistry<UiPackEntry, UiPackEntry>
   implements UiPackRegistry
 {
+  private readonly entryListeners = new Set<(entries: ReadonlyArray<UiPackEntry>) => void>();
+
+  override register(entry: UiPackEntry) {
+    const registration = super.register(entry);
+    this.emitEntries();
+    return {
+      dispose: () => {
+        registration.dispose();
+        this.emitEntries();
+      },
+    };
+  }
+
+  subscribeEntries(listener: (entries: ReadonlyArray<UiPackEntry>) => void) {
+    this.entryListeners.add(listener);
+    listener(this.listEntries());
+    return { dispose: () => this.entryListeners.delete(listener) };
+  }
+
+  private emitEntries(): void {
+    const snapshot = this.listEntries();
+    for (const listener of [...this.entryListeners]) listener(snapshot);
+  }
   constructor() {
     super({
       extractValue: (entry) => entry,

--- a/src/runtime/user-pack-loader/user-pack-loader.test.ts
+++ b/src/runtime/user-pack-loader/user-pack-loader.test.ts
@@ -161,6 +161,10 @@ function makeFakeUiPackRegistry(): UiPackRegistry & { readonly entries: UiPackEn
     getActiveUiId: () => null,
     setActiveUi: () => {},
     subscribeActive: () => ({ dispose: () => {} }),
+    subscribeEntries: (listener) => {
+      listener(entries);
+      return { dispose: () => {} };
+    },
     listEntries: () => entries,
   };
 }

--- a/src/runtime/user-pack-loader/user-pack-loader.ts
+++ b/src/runtime/user-pack-loader/user-pack-loader.ts
@@ -26,6 +26,7 @@ import {
   validateEffectDefinition,
   validatePersonaDefinition,
   validateUiPackDefinition,
+  validateUiPackManifest,
 } from "../../sdk/validators";
 import type { AmbientUiPackRegistry } from "../ambient-ui-pack-registry";
 import type { AmenityPackRegistry } from "../amenity-pack-registry";
@@ -61,6 +62,7 @@ export interface UserPackEntry {
     readonly author?: string;
     /** 能力ラダーの sandbox 宣言（raw 値。検証は pack-execution-policy 側）。 */
     readonly sandbox?: unknown;
+    readonly viewMode?: unknown;
   };
 }
 
@@ -346,15 +348,17 @@ export async function loadSingleUserPack(
         throw new Error("UiPackRegistry is required to register UI packs");
       }
       const pack = validateUiPackDefinition(def);
+      const manifest = validateUiPackManifest({
+        id: pack.id,
+        type: "ui",
+        version: "0.0.0",
+        yorishiroVersion: "*",
+        entry: userPackEntryFilename(entry.entryPath),
+        viewMode: entry.manifest?.viewMode,
+      });
       const handle = uiPackRegistry.register({
         id: pack.id,
-        manifest: {
-          id: pack.id,
-          type: "ui",
-          version: "0.0.0",
-          yorishiroVersion: "*",
-          entry: userPackEntryFilename(entry.entryPath),
-        },
+        manifest,
         origin: "user",
         pack: {
           layout: pack.layout,

--- a/src/runtime/user-pack-loader/watcher.ts
+++ b/src/runtime/user-pack-loader/watcher.ts
@@ -503,10 +503,13 @@ async function reloadPack(
       }
     } else if (action.kind === "ui") {
       const pack = validateUiPackDefinition(def);
+      const existingManifest = deps.uiPackRegistry
+        .listEntries()
+        .find((entry) => entry.id === pack.id)?.manifest;
       deps.packRegistry.dispose(action.id, action.kind);
       const handle = deps.uiPackRegistry.register({
         id: pack.id,
-        manifest: {
+        manifest: existingManifest ?? {
           id: pack.id,
           type: "ui",
           version: "0.0.0",

--- a/src/runtime/view-mode-framing.test.ts
+++ b/src/runtime/view-mode-framing.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import {
+  acquireFixedViewModeCamera,
+  acquireResponsiveCallCamera,
+  CALL_TIER_TRANSITION_MS,
+  entryCameraForViewMode,
+  resolveCallFramingTier,
+} from "./view-mode-framing";
+
+describe("stable View Mode framing", () => {
+  it("preserves the tuned Portrait entry composition", () => {
+    expect(entryCameraForViewMode("scene")).toEqual({ x: 0, y: 1.39, z: 0.985 });
+  });
+
+  it("samples Call's character anchor once and uses a safe fallback", () => {
+    const sampled = entryCameraForViewMode("portrait", 1.55);
+    expect(sampled.x).toBe(0);
+    expect(sampled.y).toBeCloseTo(1.57);
+    expect(sampled.z).toBe(0.98);
+    expect(entryCameraForViewMode("portrait", null)).toEqual({ x: 0, y: 1.62, z: 0.98 });
+  });
+
+  it("does not update camera framing while the window resizes", () => {
+    const release = vi.fn();
+    const acquire = vi.fn((_x: number, _y: number, _z: number) => ({ dispose: release }));
+    let anchorY = 1.55;
+    const dispose = acquireFixedViewModeCamera("portrait", acquire, anchorY);
+
+    anchorY = 1.9;
+    window.dispatchEvent(new Event("resize"));
+    window.dispatchEvent(new Event("resize"));
+
+    expect(acquire).toHaveBeenCalledTimes(1);
+    const [x, y, z] = acquire.mock.calls[0];
+    expect(x).toBe(0);
+    expect(y).toBeCloseTo(1.57);
+    expect(z).toBe(0.98);
+    dispose();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("switches Call tiers with hysteresis and changes only camera distance", () => {
+    expect(resolveCallFramingTier(220, "normal")).toBe("small-face");
+    expect(resolveCallFramingTier(228, "small-face")).toBe("small-face");
+    expect(resolveCallFramingTier(236, "small-face")).toBe("normal");
+    const normal = entryCameraForViewMode("portrait", 1.55, "normal");
+    const small = entryCameraForViewMode("portrait", 1.55, "small-face");
+    expect(small.y).toBe(normal.y);
+    expect(normal.z).toBe(0.98);
+    expect(small.z).toBe(0.84);
+  });
+
+  it("transitions once per Call tier crossing, ignores in-tier resize, and cleans up", () => {
+    let width = 250;
+    const listeners = new Set<() => void>();
+    const setTarget = vi.fn();
+    const disposeFixed = vi.fn();
+    const acquire = vi.fn((_x: number, _y: number, _z: number) => ({
+      setTarget,
+      dispose: disposeFixed,
+    }));
+    const resizeSource = {
+      getWidth: () => width,
+      addEventListener: (_type: "resize", listener: () => void) => listeners.add(listener),
+      removeEventListener: (_type: "resize", listener: () => void) => listeners.delete(listener),
+    };
+    const release = acquireResponsiveCallCamera(1.55, acquire, resizeSource);
+    const resize = () => {
+      for (const listener of listeners) listener();
+    };
+
+    width = 230;
+    resize();
+    expect(setTarget).not.toHaveBeenCalled();
+    width = 215;
+    resize();
+    expect(setTarget).toHaveBeenCalledOnce();
+    expect(setTarget).toHaveBeenCalledWith(0, expect.closeTo(1.57), 0.84, CALL_TIER_TRANSITION_MS);
+    width = 228;
+    resize();
+    expect(setTarget).toHaveBeenCalledOnce();
+    width = 240;
+    resize();
+    expect(setTarget).toHaveBeenCalledTimes(2);
+
+    release();
+    expect(listeners.size).toBe(0);
+    expect(disposeFixed).toHaveBeenCalledOnce();
+  });
+});

--- a/src/runtime/view-mode-framing.test.ts
+++ b/src/runtime/view-mode-framing.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("stable View Mode framing", () => {
   it("preserves the tuned Portrait entry composition", () => {
-    expect(entryCameraForViewMode("scene")).toEqual({ x: 0, y: 1.39, z: 0.985 });
+    expect(entryCameraForViewMode("scene")).toEqual({ x: 0, y: 1.36, z: 0.985 });
   });
 
   it("samples Call's character anchor once and uses a safe fallback", () => {

--- a/src/runtime/view-mode-framing.test.ts
+++ b/src/runtime/view-mode-framing.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("stable View Mode framing", () => {
   it("preserves the tuned Portrait entry composition", () => {
-    expect(entryCameraForViewMode("scene")).toEqual({ x: 0, y: 1.31, z: 1.135 });
+    expect(entryCameraForViewMode("scene")).toEqual({ x: 0, y: 1.31, z: 1.285 });
   });
 
   it("samples Call's character anchor once and uses a safe fallback", () => {

--- a/src/runtime/view-mode-framing.test.ts
+++ b/src/runtime/view-mode-framing.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("stable View Mode framing", () => {
   it("preserves the tuned Portrait entry composition", () => {
-    expect(entryCameraForViewMode("scene")).toEqual({ x: 0, y: 1.36, z: 0.985 });
+    expect(entryCameraForViewMode("scene")).toEqual({ x: 0, y: 1.31, z: 1.135 });
   });
 
   it("samples Call's character anchor once and uses a safe fallback", () => {

--- a/src/runtime/view-mode-framing.test.ts
+++ b/src/runtime/view-mode-framing.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("stable View Mode framing", () => {
   it("preserves the tuned Portrait entry composition", () => {
-    expect(entryCameraForViewMode("scene")).toEqual({ x: 0, y: 1.31, z: 1.285 });
+    expect(entryCameraForViewMode("scene")).toEqual({ x: 0, y: 1.3, z: 1.3 });
   });
 
   it("samples Call's character anchor once and uses a safe fallback", () => {

--- a/src/runtime/view-mode-framing.ts
+++ b/src/runtime/view-mode-framing.ts
@@ -1,0 +1,84 @@
+export type WindowedViewMode = "scene" | "portrait";
+
+export interface ViewModeCamera {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export type CallFramingTier = "normal" | "small-face";
+export const CALL_SMALL_ENTER_WIDTH = 220;
+export const CALL_SMALL_EXIT_WIDTH = 236;
+export const CALL_TIER_TRANSITION_MS = 180;
+
+export function resolveCallFramingTier(
+  width: number,
+  previous: CallFramingTier = "normal",
+): CallFramingTier {
+  if (previous === "normal" && width <= CALL_SMALL_ENTER_WIDTH) return "small-face";
+  if (previous === "small-face" && width >= CALL_SMALL_EXIT_WIDTH) return "normal";
+  return previous;
+}
+
+/**
+ * Stable entry framing for each windowed presentation mode. These values are
+ * intentionally independent of viewport size: resizing the native window must
+ * not make the camera chase the user's drag gesture.
+ */
+export function entryCameraForViewMode(
+  mode: WindowedViewMode,
+  characterAnchorY?: number | null,
+  callTier: CallFramingTier = "normal",
+): ViewModeCamera {
+  if (mode === "portrait") {
+    const faceCenterY =
+      typeof characterAnchorY === "number" && Number.isFinite(characterAnchorY)
+        ? characterAnchorY + 0.02
+        : 1.62;
+    return { x: 0, y: faceCenterY, z: callTier === "small-face" ? 0.84 : 0.98 };
+  }
+  return { x: 0, y: 1.39, z: 0.985 };
+}
+
+export function acquireFixedViewModeCamera(
+  mode: WindowedViewMode,
+  acquire: (x: number, y: number, z: number) => { dispose(): void },
+  characterAnchorY?: number | null,
+): () => void {
+  const camera = entryCameraForViewMode(mode, characterAnchorY);
+  const fixedCamera = acquire(camera.x, camera.y, camera.z);
+  return () => fixedCamera.dispose();
+}
+
+interface CallResizeSource {
+  getWidth(): number;
+  addEventListener(type: "resize", listener: () => void): void;
+  removeEventListener(type: "resize", listener: () => void): void;
+}
+
+interface FixedCameraTarget {
+  setTarget(x: number, y: number, z: number, durationMs: number): void;
+  dispose(): void;
+}
+
+export function acquireResponsiveCallCamera(
+  characterAnchorY: number | null | undefined,
+  acquire: (x: number, y: number, z: number) => FixedCameraTarget,
+  resizeSource: CallResizeSource,
+): () => void {
+  let tier = resolveCallFramingTier(resizeSource.getWidth());
+  const initial = entryCameraForViewMode("portrait", characterAnchorY, tier);
+  const fixedCamera = acquire(initial.x, initial.y, initial.z);
+  const onResize = () => {
+    const nextTier = resolveCallFramingTier(resizeSource.getWidth(), tier);
+    if (nextTier === tier) return;
+    tier = nextTier;
+    const target = entryCameraForViewMode("portrait", characterAnchorY, tier);
+    fixedCamera.setTarget(target.x, target.y, target.z, CALL_TIER_TRANSITION_MS);
+  };
+  resizeSource.addEventListener("resize", onResize);
+  return () => {
+    resizeSource.removeEventListener("resize", onResize);
+    fixedCamera.dispose();
+  };
+}

--- a/src/runtime/view-mode-framing.ts
+++ b/src/runtime/view-mode-framing.ts
@@ -37,7 +37,7 @@ export function entryCameraForViewMode(
         : 1.62;
     return { x: 0, y: faceCenterY, z: callTier === "small-face" ? 0.84 : 0.98 };
   }
-  return { x: 0, y: 1.36, z: 0.985 };
+  return { x: 0, y: 1.31, z: 1.135 };
 }
 
 export function acquireFixedViewModeCamera(

--- a/src/runtime/view-mode-framing.ts
+++ b/src/runtime/view-mode-framing.ts
@@ -37,7 +37,7 @@ export function entryCameraForViewMode(
         : 1.62;
     return { x: 0, y: faceCenterY, z: callTier === "small-face" ? 0.84 : 0.98 };
   }
-  return { x: 0, y: 1.31, z: 1.135 };
+  return { x: 0, y: 1.31, z: 1.285 };
 }
 
 export function acquireFixedViewModeCamera(

--- a/src/runtime/view-mode-framing.ts
+++ b/src/runtime/view-mode-framing.ts
@@ -37,7 +37,7 @@ export function entryCameraForViewMode(
         : 1.62;
     return { x: 0, y: faceCenterY, z: callTier === "small-face" ? 0.84 : 0.98 };
   }
-  return { x: 0, y: 1.39, z: 0.985 };
+  return { x: 0, y: 1.36, z: 0.985 };
 }
 
 export function acquireFixedViewModeCamera(

--- a/src/runtime/view-mode-framing.ts
+++ b/src/runtime/view-mode-framing.ts
@@ -37,7 +37,7 @@ export function entryCameraForViewMode(
         : 1.62;
     return { x: 0, y: faceCenterY, z: callTier === "small-face" ? 0.84 : 0.98 };
   }
-  return { x: 0, y: 1.31, z: 1.285 };
+  return { x: 0, y: 1.3, z: 1.3 };
 }
 
 export function acquireFixedViewModeCamera(

--- a/src/runtime/view-mode-native-window.test.ts
+++ b/src/runtime/view-mode-native-window.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  enqueueNativeWindowMutation,
+  resolveWindowAspectRatioStrategy,
+} from "./view-mode-native-window";
+
+describe("View Mode native window aspect ratio", () => {
+  it("disables aspect enforcement on macOS for resize stability", () => {
+    expect(resolveWindowAspectRatioStrategy(2 / 3, true)).toEqual({
+      nativeAspectRatio: null,
+      jsAspectRatio: null,
+    });
+    expect(resolveWindowAspectRatioStrategy(undefined, true)).toEqual({
+      nativeAspectRatio: null,
+      jsAspectRatio: null,
+    });
+  });
+
+  it("also avoids resize correction loops on other platforms", () => {
+    expect(resolveWindowAspectRatioStrategy(2 / 3, false)).toEqual({
+      nativeAspectRatio: null,
+      jsAspectRatio: null,
+    });
+  });
+
+  it("serializes window mutations and continues after a failure", async () => {
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const first = enqueueNativeWindowMutation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          events.push("first:start");
+          releaseFirst = () => {
+            events.push("first:end");
+            reject(new Error("expected"));
+          };
+        }),
+    );
+    const second = enqueueNativeWindowMutation(async () => {
+      events.push("second");
+    });
+    await Promise.resolve();
+    expect(events).toEqual(["first:start"]);
+    releaseFirst();
+    await expect(first).rejects.toThrow("expected");
+    await second;
+    expect(events).toEqual(["first:start", "first:end", "second"]);
+  });
+});

--- a/src/runtime/view-mode-native-window.ts
+++ b/src/runtime/view-mode-native-window.ts
@@ -1,0 +1,19 @@
+export interface WindowAspectRatioStrategy {
+  readonly nativeAspectRatio: number | null;
+  readonly jsAspectRatio: number | null;
+}
+
+export function resolveWindowAspectRatioStrategy(
+  _aspectRatio: number | undefined,
+  _macos: boolean,
+): WindowAspectRatioStrategy {
+  return { nativeAspectRatio: null, jsAspectRatio: null };
+}
+
+let nativeWindowMutationQueue = Promise.resolve();
+
+export function enqueueNativeWindowMutation(operation: () => Promise<void>): Promise<void> {
+  const result = nativeWindowMutationQueue.then(operation);
+  nativeWindowMutationQueue = result.catch(() => undefined);
+  return result;
+}

--- a/src/runtime/view-mode-window-interaction.test.ts
+++ b/src/runtime/view-mode-window-interaction.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  nextViewModeHudVisibility,
+  shouldRevealViewModeHud,
+  shouldStartViewModeWindowDrag,
+} from "./view-mode-window-interaction";
+
+describe("chrome-hidden View Mode window interaction", () => {
+  it("starts primary drag only in chrome-hidden modes", () => {
+    const canvas = document.createElement("canvas");
+    expect(shouldStartViewModeWindowDrag(true, 0, canvas)).toBe(true);
+    expect(shouldStartViewModeWindowDrag(false, 0, canvas)).toBe(false);
+    expect(shouldStartViewModeWindowDrag(true, 2, canvas)).toBe(false);
+  });
+
+  it("excludes interactive descendants", () => {
+    const button = document.createElement("button");
+    const icon = document.createElement("span");
+    button.append(icon);
+    expect(shouldStartViewModeWindowDrag(true, 0, icon)).toBe(false);
+  });
+
+  it("uses secondary click to reveal the HUD", () => {
+    expect(shouldRevealViewModeHud(true, 2)).toBe(true);
+    expect(shouldRevealViewModeHud(true, 0)).toBe(false);
+    expect(shouldRevealViewModeHud(false, 2)).toBe(false);
+  });
+
+  it("toggles the HUD off on a second secondary click", () => {
+    const shown = nextViewModeHudVisibility(true, 2, false);
+    expect(shown).toBe(true);
+    expect(nextViewModeHudVisibility(true, 2, shown)).toBe(false);
+  });
+
+  it("lets a root capture handler see secondary click before a child stops bubbling", () => {
+    const root = document.createElement("div");
+    const canvas = document.createElement("canvas");
+    root.append(canvas);
+    let revealed = false;
+    root.addEventListener(
+      "contextmenu",
+      (event) => {
+        revealed = shouldRevealViewModeHud(true, event.button);
+      },
+      { capture: true },
+    );
+    canvas.addEventListener("contextmenu", (event) => event.stopPropagation());
+
+    canvas.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, button: 2 }));
+
+    expect(revealed).toBe(true);
+  });
+});

--- a/src/runtime/view-mode-window-interaction.ts
+++ b/src/runtime/view-mode-window-interaction.ts
@@ -1,0 +1,37 @@
+const INTERACTIVE_SELECTOR = [
+  "button",
+  "a",
+  "input",
+  "textarea",
+  "select",
+  "summary",
+  "[contenteditable='true']",
+  "[role='button']",
+  "[role='link']",
+  "[role='menu']",
+  "[role='menuitem']",
+  "[role='menuitemradio']",
+  "[role='dialog']",
+  "[data-no-window-drag]",
+].join(",");
+
+export function shouldStartViewModeWindowDrag(
+  chromeHidden: boolean,
+  button: number,
+  target: EventTarget | null,
+): boolean {
+  if (!chromeHidden || button !== 0 || !(target instanceof Element)) return false;
+  return target.closest(INTERACTIVE_SELECTOR) === null;
+}
+
+export function shouldRevealViewModeHud(chromeHidden: boolean, button: number): boolean {
+  return chromeHidden && button === 2;
+}
+
+export function nextViewModeHudVisibility(
+  chromeHidden: boolean,
+  button: number,
+  current: boolean,
+): boolean {
+  return shouldRevealViewModeHud(chromeHidden, button) ? !current : current;
+}

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -6,6 +6,22 @@
 [`docs/decisions/local-source-authoring-contract.md`](../../docs/decisions/local-source-authoring-contract.md)
 を読む。Bundled PackのVite importをlocal Packへそのままコピーできるとは限らない。
 
+## View Mode UI packs
+
+UI packをタイトルバーのView Mode pickerへ表示するには、manifestで明示的にopt inする。
+
+```json
+"viewMode": {
+  "enabled": true,
+  "label": "My Presentation",
+  "icon": "scene",
+  "order": 100,
+  "category": "companion"
+}
+```
+
+`label`、`icon`、`order`は必須。native behaviorを利用できるhostだけに限定する場合は`platforms`を指定する。通常のUI packとSettingsはpickerへ表示されず、View Mode packのinstall、remove、hot reloadはregistry subscription経由でpickerへ反映される。
+
 ---
 
 ## UGC の Pack 種別（6 種類）

--- a/src/sdk/ui-pack.d.ts
+++ b/src/sdk/ui-pack.d.ts
@@ -50,6 +50,9 @@ export interface UiLayout {
     readonly minHeight?: number;
     /** true にすると他アプリより手前へ保つ。companion / overlay UI 用。 */
     readonly alwaysOnTop?: boolean;
+    readonly fullscreen?: boolean;
+    /** Preserve this logical width / height while the user resizes the window. */
+    readonly aspectRatio?: number;
   };
   readonly sidebar?: {
     /**
@@ -136,6 +139,15 @@ export interface UiPackManifest {
     readonly sizeBytes: number;
   };
   readonly entry: string;
+  /** Opts this UI pack into the host View Mode picker. */
+  readonly viewMode?: {
+    readonly enabled: true;
+    readonly label: string;
+    readonly icon: "immersive" | "theater" | "scene" | "overlay" | "portrait";
+    readonly order: number;
+    readonly category?: "presentation" | "companion" | "ambient";
+    readonly platforms?: ReadonlyArray<"macos" | "windows" | "linux">;
+  };
 }
 
 /**

--- a/src/sdk/validators.test.ts
+++ b/src/sdk/validators.test.ts
@@ -5,7 +5,31 @@ import {
   validateEffectDefinition,
   validatePersonaDefinition,
   validateUiPackDefinition,
+  validateUiPackManifest,
 } from "./validators";
+
+describe("validateUiPackManifest", () => {
+  const manifest = {
+    id: "portrait",
+    type: "ui",
+    version: "1.0.0",
+    yorishiroVersion: "*",
+    entry: "ui.tsx",
+  };
+  it("accepts valid View Mode metadata", () => {
+    expect(
+      validateUiPackManifest({
+        ...manifest,
+        viewMode: { enabled: true, label: "Portrait", icon: "portrait", order: 40 },
+      }).viewMode?.label,
+    ).toBe("Portrait");
+  });
+  it("rejects incomplete View Mode metadata", () => {
+    expect(() =>
+      validateUiPackManifest({ ...manifest, viewMode: { enabled: true, label: "Portrait" } }),
+    ).toThrow(/icon/);
+  });
+});
 
 describe("validateEffectDefinition", () => {
   const validEffect = {

--- a/src/sdk/validators.ts
+++ b/src/sdk/validators.ts
@@ -78,6 +78,44 @@ export function validateUiPackDefinition(pack: unknown): UiPackDefinition {
   return pack as unknown as UiPackDefinition;
 }
 
+export function validateUiPackManifest(raw: unknown): import("./ui-pack").UiPackManifest {
+  if (!isObject(raw)) throw new PackValidationError("UI pack manifest must be an object");
+  requireField(raw, "id", (v) => typeof v === "string", "a string", "UiPackManifest");
+  requireField(raw, "type", (v) => v === "ui", '"ui"', "UiPackManifest");
+  requireField(raw, "version", (v) => typeof v === "string", "a string", "UiPackManifest");
+  requireField(raw, "yorishiroVersion", (v) => typeof v === "string", "a string", "UiPackManifest");
+  requireField(raw, "entry", (v) => typeof v === "string", "a string", "UiPackManifest");
+  if (raw.viewMode !== undefined) {
+    if (!isObject(raw.viewMode))
+      throw new PackValidationError("UiPackManifest: field 'viewMode' must be an object");
+    const mode = raw.viewMode;
+    requireField(mode, "enabled", (v) => v === true, "true", "UiPackManifest.viewMode");
+    requireField(
+      mode,
+      "label",
+      (v) => typeof v === "string" && v.trim().length > 0,
+      "a non-empty string",
+      "UiPackManifest.viewMode",
+    );
+    const icons = new Set(["immersive", "theater", "scene", "overlay", "portrait"]);
+    requireField(
+      mode,
+      "icon",
+      (v) => typeof v === "string" && icons.has(v),
+      "a supported icon identifier",
+      "UiPackManifest.viewMode",
+    );
+    requireField(
+      mode,
+      "order",
+      (v) => typeof v === "number" && Number.isFinite(v),
+      "a finite number",
+      "UiPackManifest.viewMode",
+    );
+  }
+  return raw as unknown as import("./ui-pack").UiPackManifest;
+}
+
 /**
  * AmbientUiPackDefinition の shape を検証する。成功時は同じ値を返し、失敗時は
  * PackValidationError を throw する。

--- a/src/sdk/vendor/pack-manifest.schema.json
+++ b/src/sdk/vendor/pack-manifest.schema.json
@@ -114,6 +114,30 @@
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$"
     },
+    "viewMode": {
+      "type": "object",
+      "properties": {
+        "enabled": { "const": true },
+        "label": { "type": "string", "minLength": 1, "maxLength": 100 },
+        "icon": {
+          "type": "string",
+          "enum": ["immersive", "theater", "scene", "overlay", "portrait"]
+        },
+        "order": { "type": "number" },
+        "category": {
+          "type": "string",
+          "enum": ["presentation", "companion", "ambient"]
+        },
+        "platforms": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "enum": ["macos", "windows", "linux"] }
+        }
+      },
+      "required": ["enabled", "label", "icon", "order"],
+      "additionalProperties": false
+    },
     "permissions": {
       "maxItems": 50,
       "type": "array",

--- a/src/sidebar.test.tsx
+++ b/src/sidebar.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Sidebar from "./sidebar";
+
+afterEach(cleanup);
+
+describe("Sidebar project selector spacing", () => {
+  it("keeps normal spacing when the selector is visible", () => {
+    const { container } = render(
+      <Sidebar folderName="Project" onPickFolder={vi.fn()} showProjectSelector />,
+    );
+    expect(container.querySelector(".sidebar-project-selector-hidden")).toBeNull();
+    expect(container.querySelector(".sidebar-top-row")).not.toBeNull();
+  });
+
+  it("collapses the empty top strip when compact-origin Settings hides the selector", () => {
+    const { container } = render(
+      <Sidebar folderName="Project" onPickFolder={vi.fn()} showProjectSelector={false} />,
+    );
+    expect(container.querySelector(".sidebar-project-selector-hidden")).not.toBeNull();
+    expect(container.querySelector(".sidebar-top-row")).toBeNull();
+  });
+});

--- a/src/sidebar.tsx
+++ b/src/sidebar.tsx
@@ -26,7 +26,10 @@ export default function Sidebar({
   }, []);
 
   return (
-    <div className="sidebar" ref={ref}>
+    <div
+      className={`sidebar${showProjectSelector ? "" : " sidebar-project-selector-hidden"}`}
+      ref={ref}
+    >
       {showProjectSelector ? (
         <div className="sidebar-top-row">
           <button type="button" className="folder-btn" onClick={onPickFolder} title={folderName}>

--- a/src/sidebar.tsx
+++ b/src/sidebar.tsx
@@ -5,9 +5,14 @@ import { getSurfaceRegistry } from "./runtime/surface-registry";
 interface SidebarProps {
   readonly folderName: string;
   readonly onPickFolder: () => void;
+  readonly showProjectSelector?: boolean;
 }
 
-export default function Sidebar({ folderName, onPickFolder }: SidebarProps) {
+export default function Sidebar({
+  folderName,
+  onPickFolder,
+  showProjectSelector = true,
+}: SidebarProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   // NOTE: React StrictMode の effect 二重実行は cleanup→re-register の順で進み、
@@ -22,12 +27,14 @@ export default function Sidebar({ folderName, onPickFolder }: SidebarProps) {
 
   return (
     <div className="sidebar" ref={ref}>
-      <div className="sidebar-top-row">
-        <button type="button" className="folder-btn" onClick={onPickFolder} title={folderName}>
-          <Folder className="folder-icon" size={14} aria-hidden="true" />
-          <span className="folder-name">{folderName}</span>
-        </button>
-      </div>
+      {showProjectSelector ? (
+        <div className="sidebar-top-row">
+          <button type="button" className="folder-btn" onClick={onPickFolder} title={folderName}>
+            <Folder className="folder-icon" size={14} aria-hidden="true" />
+            <span className="folder-name">{folderName}</span>
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/title-bar-state.test.tsx
+++ b/src/title-bar-state.test.tsx
@@ -203,8 +203,12 @@ describe("title bar state hooks", () => {
   });
 
   it("shows Terminal while Settings was opened from Terminal", () => {
-    expect(resolvePickerActiveViewModeId(true, null, SETTINGS_PACK_ID)).toBeNull();
-    expect(resolvePickerActiveViewModeId(true, "portrait", SETTINGS_PACK_ID)).toBe("portrait");
+    const terminalOrigin = resolvePickerActiveViewModeId(true, null, SETTINGS_PACK_ID);
+    const portraitOrigin = resolvePickerActiveViewModeId(true, "portrait", SETTINGS_PACK_ID);
+    expect(terminalOrigin).toBeNull();
+    expect(portraitOrigin).toBe("portrait");
+    expect(shouldShowProjectSelector(true, terminalOrigin)).toBe(true);
+    expect(shouldShowProjectSelector(true, portraitOrigin)).toBe(false);
   });
 
   it("keeps the previous picker selection but suspends presentation chrome in Settings", () => {

--- a/src/title-bar-state.test.tsx
+++ b/src/title-bar-state.test.tsx
@@ -209,6 +209,9 @@ describe("title bar state hooks", () => {
     expect(portraitOrigin).toBe("portrait");
     expect(shouldShowProjectSelector(true, terminalOrigin)).toBe(true);
     expect(shouldShowProjectSelector(true, portraitOrigin)).toBe(false);
+    // The same origin value drives camera ownership before, during, and after Settings.
+    expect(resolvePickerActiveViewModeId(false, null, "portrait")).toBe(portraitOrigin);
+    expect(resolvePickerActiveViewModeId(false, null, null)).toBe(terminalOrigin);
   });
 
   it("keeps the previous picker selection but suspends presentation chrome in Settings", () => {

--- a/src/title-bar-state.test.tsx
+++ b/src/title-bar-state.test.tsx
@@ -6,7 +6,19 @@ import { _clearForTest as clearHotDataForTest } from "./runtime/hot-data/hot-dat
 import { _resetForTest as resetPresenceForTest } from "./runtime/presence-intensity/presence-intensity";
 import type { UiPackEntry } from "./runtime/ui-pack-registry";
 import { getUiRegistry } from "./runtime/ui-pack-registry";
-import { useActiveUiId, useSettingsActive, useSidebarOpen } from "./title-bar-state";
+import {
+  activePresentationViewModeId,
+  buildViewModeShortcuts,
+  matchesViewModeShortcut,
+  nativeWindowControlsVisibleForViewMode,
+  resolvePickerActiveViewModeId,
+  roundedWindowForViewMode,
+  shouldShowProjectSelector,
+  sortViewModeEntries,
+  useActiveUiId,
+  useSettingsActive,
+  useSidebarOpen,
+} from "./title-bar-state";
 
 const SETTINGS_PACK_ID = "yorishiro-settings";
 
@@ -48,6 +60,81 @@ afterEach(() => {
 });
 
 describe("title bar state hooks", () => {
+  it("assigns real, collision-resistant shortcuts to Terminal and the first nine modes", () => {
+    const shortcuts = buildViewModeShortcuts(
+      Array.from({ length: 10 }, (_, index) => ({ id: `mode-${index + 1}` })),
+      true,
+    );
+
+    expect(shortcuts).toHaveLength(10);
+    expect(shortcuts[0]).toEqual({ id: null, code: "Digit0", hint: "⌥⌘0" });
+    expect(shortcuts[1]).toEqual({ id: "mode-1", code: "Digit1", hint: "⌥⌘1" });
+    expect(shortcuts[shortcuts.length - 1]?.id).toBe("mode-9");
+    expect(
+      matchesViewModeShortcut(
+        shortcuts[1],
+        { code: "Digit1", ctrlKey: false, altKey: true, shiftKey: false, metaKey: true },
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      matchesViewModeShortcut(
+        shortcuts[1],
+        { code: "Digit1", ctrlKey: true, altKey: true, shiftKey: false, metaKey: false },
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      matchesViewModeShortcut(
+        buildViewModeShortcuts([{ id: "mode-1" }], false)[1],
+        { code: "Digit1", ctrlKey: true, altKey: true, shiftKey: false, metaKey: false },
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps the finalized built-in order ahead of deterministic user modes", () => {
+    const ordered = sortViewModeEntries([
+      uiEntry("user-z"),
+      uiEntry("immersive"),
+      uiEntry("portrait"),
+      uiEntry("theater"),
+      uiEntry("companion"),
+      uiEntry("user-a"),
+    ]);
+    expect(ordered.map((entry) => entry.id)).toEqual([
+      "companion",
+      "portrait",
+      "theater",
+      "immersive",
+      "user-a",
+      "user-z",
+    ]);
+    expect(buildViewModeShortcuts(ordered, true).map(({ id, hint }) => [id, hint])).toEqual([
+      [null, "⌥⌘0"],
+      ["companion", "⌥⌘1"],
+      ["portrait", "⌥⌘2"],
+      ["theater", "⌥⌘3"],
+      ["immersive", "⌥⌘4"],
+      ["user-a", "⌥⌘5"],
+      ["user-z", "⌥⌘6"],
+    ]);
+  });
+
+  it("shows native window controls only for Terminal", () => {
+    expect(nativeWindowControlsVisibleForViewMode(null)).toBe(true);
+    expect(nativeWindowControlsVisibleForViewMode("theater")).toBe(false);
+    expect(nativeWindowControlsVisibleForViewMode("user-view-mode")).toBe(false);
+  });
+
+  it("rounds only windowed compact presentation modes", () => {
+    expect(roundedWindowForViewMode("companion")).toBe(true);
+    expect(roundedWindowForViewMode("portrait")).toBe(true);
+    expect(roundedWindowForViewMode("theater")).toBe(false);
+    expect(roundedWindowForViewMode("immersive")).toBe(false);
+    expect(roundedWindowForViewMode(null)).toBe(false);
+  });
+
   it("syncs sidebarOpen from presence level change events", () => {
     render(<SidebarOpenProbe />);
 
@@ -113,5 +200,27 @@ describe("title bar state hooks", () => {
     } finally {
       companionRegistration.dispose();
     }
+  });
+
+  it("shows Terminal while Settings was opened from Terminal", () => {
+    expect(resolvePickerActiveViewModeId(true, null, SETTINGS_PACK_ID)).toBeNull();
+    expect(resolvePickerActiveViewModeId(true, "portrait", SETTINGS_PACK_ID)).toBe("portrait");
+  });
+
+  it("keeps the previous picker selection but suspends presentation chrome in Settings", () => {
+    const pickerId = resolvePickerActiveViewModeId(true, "portrait", SETTINGS_PACK_ID);
+    const settingsPresentationId = activePresentationViewModeId(true, pickerId);
+    expect(pickerId).toBe("portrait");
+    expect(settingsPresentationId).toBeNull();
+    expect(nativeWindowControlsVisibleForViewMode(settingsPresentationId)).toBe(true);
+    expect(roundedWindowForViewMode(settingsPresentationId)).toBe(false);
+    expect(activePresentationViewModeId(false, pickerId)).toBe("portrait");
+  });
+
+  it("does not flash the project selector before persisted View Mode bootstrap resolves", () => {
+    expect(shouldShowProjectSelector(false, null)).toBe(false);
+    expect(shouldShowProjectSelector(true, "companion")).toBe(false);
+    expect(shouldShowProjectSelector(true, SETTINGS_PACK_ID)).toBe(false);
+    expect(shouldShowProjectSelector(true, null)).toBe(true);
   });
 });

--- a/src/title-bar-state.ts
+++ b/src/title-bar-state.ts
@@ -1,9 +1,82 @@
 import { useEffect, useState } from "react";
 import { getPresenceState, type PresenceLevel } from "./runtime/presence-intensity";
+import type { UiPackEntry } from "./runtime/ui-pack-registry";
 import { getUiRegistry } from "./runtime/ui-pack-registry";
 
 export function sidebarOpenFromPresenceLevel(level: PresenceLevel): boolean {
   return level === "default";
+}
+
+export function resolvePickerActiveViewModeId(
+  settingsActive: boolean,
+  savedViewMode: unknown,
+  activeUiId: string | null,
+): string | null {
+  if (!settingsActive) return activeUiId;
+  return typeof savedViewMode === "string" ? savedViewMode : null;
+}
+
+export interface ViewModeShortcut {
+  readonly id: string | null;
+  readonly code: string;
+  readonly hint: string;
+}
+
+/**
+ * View Mode shortcuts use Option+Command on macOS and Control+Alt elsewhere,
+ * keeping the numbered sequence separate from the terminal tab shortcuts.
+ * The first nine registered modes receive a stable slot; additional user modes
+ * remain fully accessible through the picker until configurable bindings exist.
+ */
+export function buildViewModeShortcuts(
+  entries: ReadonlyArray<Pick<UiPackEntry, "id">>,
+  macos: boolean,
+): ReadonlyArray<ViewModeShortcut> {
+  const prefix = macos ? "⌥⌘" : "Ctrl+Alt+";
+  return [
+    { id: null, code: "Digit0", hint: `${prefix}0` },
+    ...entries.slice(0, 9).map((entry, index) => ({
+      id: entry.id,
+      code: `Digit${index + 1}`,
+      hint: `${prefix}${index + 1}`,
+    })),
+  ];
+}
+
+export function matchesViewModeShortcut(
+  shortcut: ViewModeShortcut,
+  event: Pick<KeyboardEvent, "altKey" | "code" | "ctrlKey" | "metaKey" | "shiftKey">,
+  macos: boolean,
+): boolean {
+  return (
+    event.code === shortcut.code &&
+    !event.shiftKey &&
+    event.altKey &&
+    event.ctrlKey === !macos &&
+    event.metaKey === macos
+  );
+}
+
+export function nativeWindowControlsVisibleForViewMode(activeViewModeId: string | null): boolean {
+  return activeViewModeId === null;
+}
+
+export function roundedWindowForViewMode(activeViewModeId: string | null): boolean {
+  return activeViewModeId === "companion" || activeViewModeId === "portrait";
+}
+
+export function activePresentationViewModeId(
+  settingsActive: boolean,
+  pickerActiveViewModeId: string | null,
+): string | null {
+  return settingsActive ? null : pickerActiveViewModeId;
+}
+
+export function shouldShowProjectSelector(
+  userLayerReady: boolean,
+  activeUiId: string | null,
+): boolean {
+  return userLayerReady && activeUiId === null;
 }
 
 function isPresenceLevel(value: unknown): value is PresenceLevel {
@@ -57,4 +130,52 @@ export function useSettingsActive(settingsPackId: string): boolean {
   }, [settingsPackId]);
 
   return settingsActive;
+}
+
+export function useViewModes(): ReadonlyArray<UiPackEntry> {
+  const [entries, setEntries] = useState<ReadonlyArray<UiPackEntry>>(() =>
+    getUiRegistry().listEntries(),
+  );
+  useEffect(() => {
+    const sub = getUiRegistry().subscribeEntries(setEntries);
+    return () => sub.dispose();
+  }, []);
+  const platform = /Mac/i.test(navigator.platform)
+    ? "macos"
+    : /Win/i.test(navigator.platform)
+      ? "windows"
+      : "linux";
+  return sortViewModeEntries(
+    entries.filter((entry) => {
+      const metadata = entry.manifest.viewMode;
+      return (
+        metadata?.enabled === true && (!metadata.platforms || metadata.platforms.includes(platform))
+      );
+    }),
+  );
+}
+
+const BUILT_IN_VIEW_MODE_ORDER = new Map([
+  ["companion", 0],
+  ["portrait", 1],
+  ["theater", 2],
+  ["immersive", 3],
+]);
+
+export function sortViewModeEntries(
+  entries: ReadonlyArray<UiPackEntry>,
+): ReadonlyArray<UiPackEntry> {
+  return [...entries].sort((a, b) => {
+    const builtInA = BUILT_IN_VIEW_MODE_ORDER.get(a.id);
+    const builtInB = BUILT_IN_VIEW_MODE_ORDER.get(b.id);
+    if (builtInA !== undefined || builtInB !== undefined) {
+      if (builtInA === undefined) return 1;
+      if (builtInB === undefined) return -1;
+      return builtInA - builtInB;
+    }
+    const metadataOrder =
+      (a.manifest.viewMode?.order ?? Number.MAX_SAFE_INTEGER) -
+      (b.manifest.viewMode?.order ?? Number.MAX_SAFE_INTEGER);
+    return metadataOrder || a.id.localeCompare(b.id);
+  });
 }

--- a/src/title-bar.test.tsx
+++ b/src/title-bar.test.tsx
@@ -1,70 +1,143 @@
 // @vitest-environment jsdom
-
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UiPackEntry } from "./runtime/ui-pack-registry";
 import TitleBar from "./title-bar";
-
-function renderTitleBar(overrides: Partial<Parameters<typeof TitleBar>[0]> = {}) {
-  return render(
-    <TitleBar
-      sidebarOpen
-      settingsActive={false}
-      sidebarLabel="Sidebar"
-      settingsLabel="Settings"
-      onToggleSidebar={vi.fn()}
-      onOpenSettings={vi.fn()}
-      {...overrides}
-    />,
-  );
-}
 
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
 });
 
-describe("TitleBar", () => {
+const portrait = {
+  id: "portrait",
+  origin: "bundled",
+  manifest: {
+    id: "portrait",
+    type: "ui",
+    version: "1.0.0",
+    yorishiroVersion: "*",
+    entry: "ui.tsx",
+    viewMode: { enabled: true, label: "Call", icon: "portrait", order: 50 },
+  },
+  pack: { layout: {}, mount: () => ({ dispose() {} }) },
+} satisfies UiPackEntry;
+
+function renderTitleBar(overrides: Partial<Parameters<typeof TitleBar>[0]> = {}) {
+  return render(
+    <TitleBar
+      onToggleSidebar={vi.fn()}
+      onOpenSettings={vi.fn()}
+      sidebarOpen
+      settingsActive={false}
+      settingsLabel="Settings"
+      sidebarLabel="Sidebar"
+      viewModeLabel="View Mode"
+      terminalLabel="Terminal"
+      settingsShortcutHint="⌘,"
+      {...overrides}
+    />,
+  );
+}
+
+describe("TitleBar View Mode picker", () => {
+  it("exposes active state and selects a mode in two clicks", () => {
+    const select = vi.fn();
+    renderTitleBar({
+      viewModes: [portrait],
+      activeViewModeId: "portrait",
+      onSelectViewMode: select,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "View Mode" }));
+    const item = screen.getByRole("menuitemradio", { name: "Call" });
+    expect(item.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(item);
+    expect(select).toHaveBeenCalledWith("portrait");
+  });
+
+  it("opens and focuses from the trigger, then supports arrow navigation and Escape", async () => {
+    renderTitleBar({ viewModes: [portrait], activeViewModeId: "portrait" });
+    const trigger = screen.getByRole("button", { name: "View Mode" });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    const terminal = screen.getByRole("menuitemradio", { name: "Terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(terminal));
+    fireEvent.keyDown(terminal, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(screen.getByRole("menuitemradio", { name: "Call" }));
+    fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("uses caller-provided localized labels", () => {
+    renderTitleBar({ viewModeLabel: "表示モード", terminalLabel: "Terminal" });
+    fireEvent.click(screen.getByRole("button", { name: "表示モード" }));
+    expect(screen.getByRole("menu", { name: "表示モード" })).toBeTruthy();
+    expect(screen.getByRole("menuitemradio", { name: "Terminal" })).toBeTruthy();
+  });
+
+  it("opens with Enter from the trigger and focuses the first item", async () => {
+    renderTitleBar({ viewModes: [portrait] });
+    const trigger = screen.getByRole("button", { name: "View Mode" });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    const terminal = screen.getByRole("menuitemradio", { name: "Terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(terminal));
+  });
+
+  it("shows only wired shortcut hints in the compact HUD menu", () => {
+    renderTitleBar({
+      viewModes: [portrait],
+      terminalShortcutHint: "⌥⌘0",
+      viewModeShortcutHints: { portrait: "⌥⌘1" },
+      settingsShortcutHint: "⌘,",
+    });
+    fireEvent.click(screen.getByRole("button", { name: "View Mode" }));
+    expect(screen.getByRole("menuitemradio", { name: "Terminal (⌥⌘0)" }).textContent).toContain(
+      "⌥⌘0",
+    );
+    expect(screen.getByRole("menuitemradio", { name: "Call (⌥⌘1)" }).textContent).toContain("⌥⌘1");
+    expect(screen.getByRole("menuitem", { name: "Settings (⌘,)" }).textContent).toContain("⌘,");
+  });
+});
+
+describe("TitleBar existing controls", () => {
   it("calls onToggleSidebar when the sidebar button is clicked", () => {
     const onToggleSidebar = vi.fn();
     renderTitleBar({ onToggleSidebar });
-
     fireEvent.click(screen.getByRole("button", { name: "Sidebar" }));
-
     expect(onToggleSidebar).toHaveBeenCalledTimes(1);
   });
 
   it("does not render the sidebar toggle when it is hidden", () => {
     renderTitleBar({ showSidebarToggle: false });
-
     expect(screen.queryByRole("button", { name: "Sidebar" })).toBeNull();
   });
 
   it("calls onOpenSettings when the settings button is clicked", () => {
     const onOpenSettings = vi.fn();
     renderTitleBar({ onOpenSettings });
-
     fireEvent.click(screen.getByRole("button", { name: "Settings" }));
-
     expect(onOpenSettings).toHaveBeenCalledTimes(1);
   });
 
   it("reflects sidebarOpen through aria-pressed", () => {
     const { rerender } = renderTitleBar({ sidebarOpen: true });
-    const sidebarButton = screen.getByRole("button", { name: "Sidebar" });
-
-    expect(sidebarButton.getAttribute("aria-pressed")).toBe("true");
-
+    expect(screen.getByRole("button", { name: "Sidebar" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
     rerender(
       <TitleBar
         sidebarOpen={false}
         settingsActive={false}
         sidebarLabel="Sidebar"
         settingsLabel="Settings"
+        viewModeLabel="View Mode"
+        terminalLabel="Terminal"
+        settingsShortcutHint="⌘,"
         onToggleSidebar={vi.fn()}
         onOpenSettings={vi.fn()}
       />,
     );
-
     expect(screen.getByRole("button", { name: "Sidebar" }).getAttribute("aria-pressed")).toBe(
       "false",
     );
@@ -72,15 +145,13 @@ describe("TitleBar", () => {
 
   it("marks the settings button as active while settings is open", () => {
     renderTitleBar({ settingsActive: true });
-
-    const settingsButton = screen.getByRole("button", { name: "Settings" });
-    expect(settingsButton.classList.contains("is-active")).toBe(true);
-    expect(settingsButton.getAttribute("aria-pressed")).toBe("true");
+    const button = screen.getByRole("button", { name: "Settings" });
+    expect(button.classList.contains("is-active")).toBe(true);
+    expect(button.getAttribute("aria-pressed")).toBe("true");
   });
 
   it("renders tabs inside the title bar", () => {
     renderTitleBar({ tabs: <button type="button">shell-1</button> });
-
     expect(screen.getByRole("button", { name: "shell-1" })).toBeTruthy();
   });
 
@@ -88,13 +159,15 @@ describe("TitleBar", () => {
     const onToggleVoice = vi.fn();
     const { rerender } = renderTitleBar();
     expect(screen.queryByRole("button", { name: "Start voice" })).toBeNull();
-
     rerender(
       <TitleBar
         sidebarOpen
         settingsActive={false}
         sidebarLabel="Sidebar"
         settingsLabel="Settings"
+        viewModeLabel="View Mode"
+        terminalLabel="Terminal"
+        settingsShortcutHint="⌘,"
         voiceAvailable
         voiceState="idle"
         voiceLabel="Start voice"
@@ -116,7 +189,6 @@ describe("TitleBar", () => {
       voiceLabel: "Start voice",
       onToggleVoice,
     });
-
     const button = screen.getByRole("button", { name: "Start voice" });
     expect(button.getAttribute("disabled")).not.toBeNull();
     fireEvent.click(button);
@@ -130,7 +202,6 @@ describe("TitleBar", () => {
       voiceLabel: "Start voice",
       onToggleVoice: vi.fn(),
     });
-
     const button = screen.getByRole("button", { name: "Start voice" });
     expect(button.getAttribute("data-voice-state")).toBe("idle");
     expect(button.getAttribute("aria-pressed")).toBe("false");
@@ -146,7 +217,6 @@ describe("TitleBar", () => {
       voiceLabel: "Connecting voice…",
       onToggleVoice: vi.fn(),
     });
-
     const button = screen.getByRole("button", { name: "Connecting voice…" });
     expect(button.getAttribute("data-voice-state")).toBe("connecting");
     expect(button.getAttribute("aria-busy")).toBe("true");
@@ -155,9 +225,7 @@ describe("TitleBar", () => {
     expect(button.querySelector(".lucide-mic")).toBeNull();
   });
 
-  // active はスラッシュ無しの Mic のまま。MicOff は「ミュート」の慣習アイコンで、
-  // ユーザー操作のミュートが存在しない現状ではどの状態にも出さない。
-  it("keeps the plain mic (never a slashed mic) while the conversation is live", () => {
+  it("keeps the plain mic while the conversation is live", () => {
     renderTitleBar({
       voiceAvailable: true,
       voiceState: "active",
@@ -165,7 +233,6 @@ describe("TitleBar", () => {
       voiceLabel: "Stop voice",
       onToggleVoice: vi.fn(),
     });
-
     const button = screen.getByRole("button", { name: "Stop voice" });
     expect(button.getAttribute("data-voice-state")).toBe("active");
     expect(button.getAttribute("aria-pressed")).toBe("true");
@@ -174,7 +241,7 @@ describe("TitleBar", () => {
     expect(button.querySelector(".title-bar-voice-status-dot")).toBeTruthy();
   });
 
-  it("hides the red dot while the conversation is live but microphone capture is interrupted", () => {
+  it("hides the red dot while microphone capture is interrupted", () => {
     renderTitleBar({
       voiceAvailable: true,
       voiceState: "active",
@@ -182,11 +249,8 @@ describe("TitleBar", () => {
       voiceLabel: "Stop voice",
       onToggleVoice: vi.fn(),
     });
-
     const button = screen.getByRole("button", { name: "Stop voice" });
-    expect(button.getAttribute("data-voice-state")).toBe("active");
     expect(button.getAttribute("data-microphone-active")).toBe("false");
-    expect(button.getAttribute("aria-pressed")).toBe("true");
     expect(button.querySelector(".title-bar-voice-status-dot")).toBeNull();
   });
 
@@ -198,17 +262,12 @@ describe("TitleBar", () => {
       voiceError: "connection failed",
       onToggleVoice: vi.fn(),
     });
-
     const button = screen.getByRole("button", { name: "Retry voice" });
     expect(button.getAttribute("data-voice-state")).toBe("error");
     expect(button.getAttribute("aria-pressed")).toBe("false");
-    expect(button.querySelector(".lucide-mic")).toBeTruthy();
     expect(screen.getByRole("alert").textContent).toBe("connection failed");
   });
 
-  // 回転 animation は CSS class（data-voice-state="connecting"）にだけ紐づける。
-  // inline style で animation を焼き込むと prefers-reduced-motion の media query で
-  // 止められなくなる。
   it("does not inline animation styles so reduced-motion CSS can disable the spinner", () => {
     renderTitleBar({
       voiceAvailable: true,
@@ -216,7 +275,6 @@ describe("TitleBar", () => {
       voiceLabel: "Connecting voice…",
       onToggleVoice: vi.fn(),
     });
-
     const svg = screen
       .getByRole("button", { name: "Connecting voice…" })
       .querySelector(".lucide-loader-circle");
@@ -225,11 +283,10 @@ describe("TitleBar", () => {
 
   it("marks the empty tab area as a Tauri drag region while keeping controls interactive", () => {
     const { container } = renderTitleBar();
-    const root = container.firstElementChild;
-    const tabs = container.querySelector(".title-bar-tabs");
-
-    expect(root?.hasAttribute("data-tauri-drag-region")).toBe(true);
-    expect(tabs?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(container.firstElementChild?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(container.querySelector(".title-bar-tabs")?.hasAttribute("data-tauri-drag-region")).toBe(
+      true,
+    );
     expect(
       screen.getByRole("button", { name: "Sidebar" }).hasAttribute("data-tauri-drag-region"),
     ).toBe(false);

--- a/src/title-bar.tsx
+++ b/src/title-bar.tsx
@@ -1,5 +1,15 @@
-import { LoaderCircle, Mic, PanelLeftClose, PanelLeftOpen, Settings } from "lucide-react";
+import {
+  ChevronDown,
+  LoaderCircle,
+  Mic,
+  Monitor,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Settings,
+} from "lucide-react";
 import type { ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { UiPackEntry } from "./runtime/ui-pack-registry";
 
 /**
  * GPT Live 音声会話ボタンの表示状態。会話状態は realtime client の status を写し、
@@ -17,6 +27,11 @@ export interface TitleBarProps {
   readonly settingsActive: boolean;
   readonly settingsLabel: string;
   readonly sidebarLabel: string;
+  readonly viewModeLabel: string;
+  readonly terminalLabel: string;
+  readonly terminalShortcutHint?: string;
+  readonly settingsShortcutHint: string;
+  readonly viewModeShortcutHints?: Readonly<Record<string, string>>;
   readonly showSidebarToggle?: boolean;
   readonly voiceAvailable?: boolean;
   readonly voiceDisabled?: boolean;
@@ -27,6 +42,9 @@ export interface TitleBarProps {
   readonly voiceError?: string;
   readonly onToggleVoice?: () => void;
   readonly tabs?: ReactNode;
+  readonly viewModes?: ReadonlyArray<UiPackEntry>;
+  readonly activeViewModeId?: string | null;
+  readonly onSelectViewMode?: (id: string | null) => void;
 }
 
 export default function TitleBar({
@@ -36,6 +54,11 @@ export default function TitleBar({
   settingsActive,
   settingsLabel,
   sidebarLabel,
+  viewModeLabel,
+  terminalLabel,
+  terminalShortcutHint,
+  settingsShortcutHint,
+  viewModeShortcutHints = {},
   showSidebarToggle = true,
   voiceAvailable = false,
   voiceDisabled = false,
@@ -45,8 +68,29 @@ export default function TitleBar({
   voiceError,
   onToggleVoice,
   tabs,
+  viewModes = [],
+  activeViewModeId = null,
+  onSelectViewMode,
 }: TitleBarProps) {
   const SidebarIcon = sidebarOpen ? PanelLeftClose : PanelLeftOpen;
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+  const pickerButtonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const focusMenuItem = (edge: "first" | "last") => {
+    requestAnimationFrame(() => {
+      const items = menuRef.current?.querySelectorAll<HTMLButtonElement>("button");
+      items?.[edge === "first" ? 0 : items.length - 1]?.focus();
+    });
+  };
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const close = (event: MouseEvent) => {
+      if (!pickerRef.current?.contains(event.target as Node)) setPickerOpen(false);
+    };
+    window.addEventListener("pointerdown", close);
+    return () => window.removeEventListener("pointerdown", close);
+  }, [pickerOpen]);
 
   return (
     <header className="title-bar" data-tauri-drag-region="">
@@ -63,6 +107,116 @@ export default function TitleBar({
             <SidebarIcon size={15} strokeWidth={1.8} aria-hidden="true" />
           </button>
         ) : null}
+        <div className="view-mode-control" ref={pickerRef}>
+          <button
+            ref={pickerButtonRef}
+            type="button"
+            className={`title-bar-button${pickerOpen ? " is-active" : ""}`}
+            aria-label={viewModeLabel}
+            aria-haspopup="menu"
+            aria-expanded={pickerOpen}
+            title={viewModeLabel}
+            onClick={() => setPickerOpen((open) => !open)}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                event.preventDefault();
+                setPickerOpen(true);
+                focusMenuItem(event.key === "ArrowDown" ? "first" : "last");
+              } else if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                setPickerOpen((open) => {
+                  if (!open) focusMenuItem("first");
+                  return !open;
+                });
+              } else if (event.key === "Escape") {
+                event.preventDefault();
+                setPickerOpen(false);
+              }
+            }}
+          >
+            <Monitor size={15} strokeWidth={1.8} aria-hidden="true" />
+            <ChevronDown size={9} aria-hidden="true" />
+          </button>
+          {pickerOpen ? (
+            <div
+              className="view-mode-menu"
+              ref={menuRef}
+              role="menu"
+              aria-label={viewModeLabel}
+              onKeyDown={(event) => {
+                const items = [
+                  ...event.currentTarget.querySelectorAll<HTMLButtonElement>("button"),
+                ];
+                const index = items.indexOf(document.activeElement as HTMLButtonElement);
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  setPickerOpen(false);
+                  pickerButtonRef.current?.focus();
+                } else if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                  event.preventDefault();
+                  const delta = event.key === "ArrowDown" ? 1 : -1;
+                  items[(index + delta + items.length) % items.length]?.focus();
+                } else if (event.key === "Home" || event.key === "End") {
+                  event.preventDefault();
+                  items[event.key === "Home" ? 0 : items.length - 1]?.focus();
+                }
+              }}
+            >
+              <button
+                type="button"
+                role="menuitemradio"
+                aria-label={
+                  terminalShortcutHint
+                    ? `${terminalLabel} (${terminalShortcutHint})`
+                    : terminalLabel
+                }
+                aria-checked={activeViewModeId === null}
+                onClick={() => {
+                  onSelectViewMode?.(null);
+                  setPickerOpen(false);
+                }}
+              >
+                <span>{terminalLabel}</span>
+                {terminalShortcutHint ? <kbd>{terminalShortcutHint}</kbd> : null}
+              </button>
+              {viewModes.map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  role="menuitemradio"
+                  aria-label={
+                    viewModeShortcutHints[entry.id]
+                      ? `${entry.manifest.viewMode?.label ?? entry.manifest.name ?? entry.id} (${viewModeShortcutHints[entry.id]})`
+                      : undefined
+                  }
+                  aria-checked={activeViewModeId === entry.id}
+                  onClick={() => {
+                    onSelectViewMode?.(entry.id);
+                    setPickerOpen(false);
+                  }}
+                >
+                  <span>{entry.manifest.viewMode?.label ?? entry.manifest.name ?? entry.id}</span>
+                  {viewModeShortcutHints[entry.id] ? (
+                    <kbd>{viewModeShortcutHints[entry.id]}</kbd>
+                  ) : null}
+                </button>
+              ))}
+              <hr className="view-mode-menu-separator" />
+              <button
+                type="button"
+                role="menuitem"
+                aria-label={`${settingsLabel} (${settingsShortcutHint})`}
+                onClick={() => {
+                  onOpenSettings();
+                  setPickerOpen(false);
+                }}
+              >
+                <span>{settingsLabel}</span>
+                <kbd>{settingsShortcutHint}</kbd>
+              </button>
+            </div>
+          ) : null}
+        </div>
         <button
           type="button"
           className={`title-bar-button title-bar-settings-button${

--- a/src/ui-pack-activation.test.ts
+++ b/src/ui-pack-activation.test.ts
@@ -1,9 +1,59 @@
-import { describe, expect, it } from "vitest";
-import { shouldResumeHostPresenceForUiActivation } from "./ui-pack-activation";
+import { describe, expect, it, vi } from "vitest";
+import {
+  isUiPackHostReady,
+  resolvePersistedUiId,
+  shouldAnimateTheaterTransition,
+  shouldResumeHostPresenceForUiActivation,
+  subscribeAndActivateCurrentUi,
+} from "./ui-pack-activation";
 
 const SETTINGS_PACK_ID = "yorishiro-settings";
 
 describe("shouldResumeHostPresenceForUiActivation", () => {
+  it("waits to activate persisted UI until terminal layout targets can mount", () => {
+    expect(isUiPackHostReady(true, false, true)).toBe(false);
+    expect(isUiPackHostReady(true, true, false)).toBe(false);
+    expect(isUiPackHostReady(true, true, true)).toBe(true);
+  });
+
+  it("falls removed Overlay persistence back to Terminal", () => {
+    expect(resolvePersistedUiId("overlay")).toBeNull();
+    expect(resolvePersistedUiId("portrait")).toBe("portrait");
+  });
+
+  it("uses the Theater transition only when moving directly to or from Terminal", () => {
+    expect(shouldAnimateTheaterTransition(null, "theater")).toBe(true);
+    expect(shouldAnimateTheaterTransition("theater", null)).toBe(true);
+    expect(shouldAnimateTheaterTransition("portrait", "theater")).toBe(false);
+    expect(shouldAnimateTheaterTransition("theater", "companion")).toBe(false);
+    expect(shouldAnimateTheaterTransition("immersive", "theater")).toBe(false);
+  });
+
+  it("activates a persisted UI immediately even when it predates subscription", () => {
+    const persisted = { id: "companion" };
+    const subscribed: { current: ((entry: typeof persisted | null) => void) | null } = {
+      current: null,
+    };
+    const activate = vi.fn();
+    const dispose = vi.fn();
+    const subscription = subscribeAndActivateCurrentUi(
+      {
+        getActiveUi: () => persisted,
+        subscribeActive: (listener) => {
+          subscribed.current = listener;
+          return { dispose };
+        },
+      },
+      activate,
+    );
+
+    expect(activate).toHaveBeenCalledWith(persisted);
+    subscribed.current?.(null);
+    expect(activate).toHaveBeenLastCalledWith(null);
+    subscription.dispose();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
   it("does not reopen host presence when opening settings", () => {
     expect(
       shouldResumeHostPresenceForUiActivation({

--- a/src/ui-pack-activation.ts
+++ b/src/ui-pack-activation.ts
@@ -1,5 +1,6 @@
 import type { UiLayout } from "@yorishiro/sdk";
 import type { PresenceLevel } from "./runtime/presence-intensity";
+import type { Disposable } from "./sdk/context";
 
 export interface HostPresenceResumeInput {
   readonly entryId: string;
@@ -22,4 +23,37 @@ export function shouldResumeHostPresenceForUiActivation({
 }: HostPresenceResumeInput): boolean {
   if (entryId === settingsPackId) return false;
   return layoutNeedsHostPresenceResume(layout) || presenceLevel === "closed" || hostDefaultClosed;
+}
+
+export function subscribeAndActivateCurrentUi<Entry>(
+  registry: {
+    getActiveUi(): Entry | null;
+    subscribeActive(listener: (entry: Entry | null) => void): Disposable;
+  },
+  activate: (entry: Entry | null) => void,
+): Disposable {
+  const subscription = registry.subscribeActive(activate);
+  activate(registry.getActiveUi());
+  return subscription;
+}
+
+export function isUiPackHostReady(
+  userLayerReady: boolean,
+  sessionRestoreReady: boolean,
+  systemPromptResolved: boolean,
+): boolean {
+  return userLayerReady && sessionRestoreReady && systemPromptResolved;
+}
+
+export function resolvePersistedUiId(id: string | null): string | null {
+  return id === "overlay" ? null : id;
+}
+
+export function shouldAnimateTheaterTransition(
+  previousId: string | null,
+  nextId: string | null,
+): boolean {
+  return (
+    (previousId === null && nextId === "theater") || (previousId === "theater" && nextId === null)
+  );
 }


### PR DESCRIPTION
## Summary

- add pack-extensible `viewMode` metadata, validation, registry discovery, and user-pack hot loading
- add a fast View Mode picker with Terminal, Portrait, Call, Theater, and Immersive modes plus platform shortcuts
- add mode-specific window chrome, right-click HUD, drag interaction, camera framing, and persisted window restoration
- preserve the originating camera and project-selector layout when opening Settings from each mode
- keep Theater's stage transition only for direct Terminal transitions and switch instantly between presentation modes
- serialize native window mutations and allow free manual resizing to avoid macOS resize crashes

## Verification

- `npm run test:run -- --maxWorkers=2` — 203 files, 2565 tests passed
- `npm run check`
- `npm run build`
- macOS runtime QA: mode switching, free resize, Theater transition behavior, and Immersive mode

Closes #156
