### PR TITLE
docs: document CLI path setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,6 +62,16 @@ brew install --cask sktkkoo/yorishiro/yorishiro
 
 ダウンロードした`.dmg`を開き、`Yorishiro.app`を`/Applications`にドラッグしてください。署名・公証（notarize）済みのため、特別な操作なしに起動できます。
 
+Homebrewからインストールした場合は、同梱CLIが`yorishiro`コマンドとして自動的に使えるようになります。`.dmg`から直接インストールした場合や、シェルに`command not found: yorishiro`と表示された場合は、アプリ内のCLIをユーザー用ディレクトリへリンクし、そのディレクトリをPATHへ追加してください：
+
+```sh
+mkdir -p "$HOME/.local/bin"
+ln -s /Applications/Yorishiro.app/Contents/MacOS/yorishiro "$HOME/.local/bin/yorishiro"
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zprofile"
+exec zsh -l
+command -v yorishiro
+```
+
 インストール後の更新はアプリ内で完結します。設定画面を開くと新しいバージョンを自動で確認し、「更新して再起動」を押すだけで署名検証つきの更新が適用されます。
 
 ### 起動（ソースから）

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ Or download the latest build below.
 
 Open the `.dmg` and drag `Yorishiro.app` to `/Applications`. The builds are signed and notarized with an Apple Developer ID, so they launch without any extra steps.
 
+Homebrew installs the bundled CLI as `yorishiro`. If you installed the `.dmg`
+directly, or your shell reports `command not found: yorishiro`, link the app's
+CLI into a user-local directory and add that directory to your PATH:
+
+```sh
+mkdir -p "$HOME/.local/bin"
+ln -s /Applications/Yorishiro.app/Contents/MacOS/yorishiro "$HOME/.local/bin/yorishiro"
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zprofile"
+exec zsh -l
+command -v yorishiro
+```
+
 Updates after install are handled in-app: opening Settings checks for a new version, and a single click on "Update and restart" applies a signature-verified update.
 
 ### Launch (from source)


### PR DESCRIPTION
## Summary
- explain that Homebrew installations expose the bundled yorishiro CLI
- document the fallback setup for direct DMG installations
- include a command lookup check after adding the user-local bin directory to PATH

## Related change
- Homebrew cask CLI link: https://github.com/sktkkoo/homebrew-yorishiro/pull/2

## Validation
- git diff --check
- pre-push hooks: TypeScript, Biome, cargo fmt, cargo clippy, TypeDoc