### PR TITLE
docs: clarify external terminal CLI setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,16 +62,6 @@ brew install --cask sktkkoo/yorishiro/yorishiro
 
 ダウンロードした`.dmg`を開き、`Yorishiro.app`を`/Applications`にドラッグしてください。署名・公証（notarize）済みのため、特別な操作なしに起動できます。
 
-Homebrewからインストールした場合は、同梱CLIが`yorishiro`コマンドとして自動的に使えるようになります。`.dmg`から直接インストールした場合や、シェルに`command not found: yorishiro`と表示された場合は、アプリ内のCLIをユーザー用ディレクトリへリンクし、そのディレクトリをPATHへ追加してください：
-
-```sh
-mkdir -p "$HOME/.local/bin"
-ln -s /Applications/Yorishiro.app/Contents/MacOS/yorishiro "$HOME/.local/bin/yorishiro"
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zprofile"
-exec zsh -l
-command -v yorishiro
-```
-
 インストール後の更新はアプリ内で完結します。設定画面を開くと新しいバージョンを自動で確認し、「更新して再起動」を押すだけで署名検証つきの更新が適用されます。
 
 ### 起動（ソースから）
@@ -89,7 +79,7 @@ npm run tauri dev
 
 タイトルバーのビューモードメニュー、または `⌥⌘0`〜`4` で切り替えられます。
 
-| モード | プレビュー | 向いている使い方 |
+| モード | プレビュー | 説明 |
 |---|---|---|
 | **Terminal** | <img src="docs/assets/view-mode-terminal.png" alt="Terminalビューモード" width="320" /> | ターミナルと住人を並べる標準ワークスペース |
 | **Portrait** | <img src="docs/assets/view-mode-portrait.png" alt="Portraitビューモード" width="320" /> | 外部ターミナルの隣に置く、細長い常時手前の住人ウィンドウ |
@@ -112,6 +102,16 @@ yorishiro attach [session-id]
 <p align="center">
   <img src="docs/assets/external-terminal-companion.png" alt="Yorishiroと接続中の外部ターミナル" width="960" />
 </p>
+
+Homebrewからインストールした場合は、同梱CLIを`yorishiro`コマンドとしてそのまま使えます。`.dmg`からインストールし、外部ターミナルに`command not found: yorishiro`と表示された場合は、アプリ内のCLIをユーザー用ディレクトリへリンクし、そのディレクトリをPATHへ追加してください：
+
+```sh
+mkdir -p "$HOME/.local/bin"
+ln -s /Applications/Yorishiro.app/Contents/MacOS/yorishiro "$HOME/.local/bin/yorishiro"
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zprofile"
+exec zsh -l
+command -v yorishiro
+```
 
 ### Yorishiroのコマンドとスキル
 

--- a/README.md
+++ b/README.md
@@ -61,18 +61,6 @@ Or download the latest build below.
 
 Open the `.dmg` and drag `Yorishiro.app` to `/Applications`. The builds are signed and notarized with an Apple Developer ID, so they launch without any extra steps.
 
-Homebrew installs the bundled CLI as `yorishiro`. If you installed the `.dmg`
-directly, or your shell reports `command not found: yorishiro`, link the app's
-CLI into a user-local directory and add that directory to your PATH:
-
-```sh
-mkdir -p "$HOME/.local/bin"
-ln -s /Applications/Yorishiro.app/Contents/MacOS/yorishiro "$HOME/.local/bin/yorishiro"
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zprofile"
-exec zsh -l
-command -v yorishiro
-```
-
 Updates after install are handled in-app: opening Settings checks for a new version, and a single click on "Update and restart" applies a signature-verified update.
 
 ### Launch (from source)
@@ -90,7 +78,7 @@ The first launch runs a health check for the selected agent, user data directory
 
 Switch from the View Mode menu in the title bar, or press `Option+Command+0` through `4`.
 
-| Mode | Preview | Best for |
+| Mode | Preview | Description |
 |---|---|---|
 | **Terminal** | <img src="docs/assets/view-mode-terminal.png" alt="Terminal view mode" width="320" /> | The full workspace, with the terminal and resident side by side |
 | **Portrait** | <img src="docs/assets/view-mode-portrait.png" alt="Portrait view mode" width="320" /> | A narrow, always-on-top resident window beside your external terminal |
@@ -119,6 +107,19 @@ When multiple sessions are live, pass the desired ID to `companion` or
 <p align="center">
   <img src="docs/assets/external-terminal-companion.png" alt="Yorishiro beside an attached external terminal" width="960" />
 </p>
+
+Homebrew makes the bundled CLI available as `yorishiro` automatically. If you
+installed Yorishiro from the `.dmg` and your external terminal reports
+`command not found: yorishiro`, link the app's CLI into a user-local directory
+and add that directory to your PATH:
+
+```sh
+mkdir -p "$HOME/.local/bin"
+ln -s /Applications/Yorishiro.app/Contents/MacOS/yorishiro "$HOME/.local/bin/yorishiro"
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zprofile"
+exec zsh -l
+command -v yorishiro
+```
 
 ### Yorishiro commands and skills
 


### PR DESCRIPTION
## Summary
- move the DMG CLI PATH instructions from installation into the external-terminal section
- clarify that Homebrew exposes the yorishiro command automatically
- rename the view-mode table column from Best for to Description in English and Japanese

## Verification
- tsc --noEmit
- Biome check
- cargo fmt
- cargo clippy
- TypeDoc validation