### PR TITLE
Guard Quick Chat when GPT Live is active

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -220,6 +220,7 @@ import {
   resolveCurrentProjectRoot,
 } from "./runtime/project-context/project-context";
 import {
+  canUseQuickChat,
   installQuickChatKeybinding,
   supportsQuickChatForViewMode,
 } from "./runtime/quick-chat-input";
@@ -5553,7 +5554,7 @@ function App() {
     voiceEntryDialog === null &&
     reloadCurtainPhase === "hidden";
   const quickVoiceStatus = codexRealtimeState.status === "idle" ? null : codexRealtimeState.status;
-  const quickChatEnabled = conversationShortcutEnabled && quickVoiceStatus === null;
+  const quickChatEnabled = canUseQuickChat(conversationShortcutEnabled, codexRealtimeState.status);
 
   useEffect(() => {
     if (!conversationShortcutEnabled) {

--- a/src/runtime/quick-chat-input.test.ts
+++ b/src/runtime/quick-chat-input.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { installQuickChatKeybinding, supportsQuickChatForViewMode } from "./quick-chat-input";
+import {
+  canUseQuickChat,
+  installQuickChatKeybinding,
+  supportsQuickChatForViewMode,
+} from "./quick-chat-input";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -20,6 +24,22 @@ describe("quick chat availability", () => {
     expect(supportsQuickChatForViewMode("immersive")).toBe(false);
     expect(supportsQuickChatForViewMode(null)).toBe(false);
     expect(supportsQuickChatForViewMode("custom-ui")).toBe(false);
+  });
+
+  it("keeps text Quick Chat available while GPT Live is idle", () => {
+    expect(canUseQuickChat(true, "idle")).toBe(true);
+  });
+
+  it.each([
+    "connecting",
+    "active",
+    "error",
+  ] as const)("disables text Quick Chat while GPT Live is %s", (status) => {
+    expect(canUseQuickChat(true, status)).toBe(false);
+  });
+
+  it("respects the surrounding conversation shortcut guard", () => {
+    expect(canUseQuickChat(false, "idle")).toBe(false);
   });
 });
 

--- a/src/runtime/quick-chat-input.ts
+++ b/src/runtime/quick-chat-input.ts
@@ -1,8 +1,18 @@
+import type { CodexRealtimeStatus } from "./codex-realtime";
+
 const QUICK_CHAT_VIEW_MODE_IDS = new Set(["companion", "portrait", "theater"]);
 
 /** Host-owned quick chat is available only in the bundled character-first View Modes. */
 export function supportsQuickChatForViewMode(viewModeId: string | null): boolean {
   return viewModeId !== null && QUICK_CHAT_VIEW_MODE_IDS.has(viewModeId);
+}
+
+/** Text Quick Chat remains available only while GPT Live is fully idle. */
+export function canUseQuickChat(
+  conversationShortcutEnabled: boolean,
+  realtimeStatus: CodexRealtimeStatus,
+): boolean {
+  return conversationShortcutEnabled && realtimeStatus === "idle";
 }
 
 interface ModifierTapTarget {


### PR DESCRIPTION
## Summary
- make Quick Chat availability explicitly depend on GPT Live being idle
- keep text Quick Chat available when GPT Live is off
- add regression coverage for idle, connecting, active, and error states

## Verification
- npx vitest run src/runtime/quick-chat-input.test.ts src/runtime/terminal-runtime/terminal-runtime.test.ts
- npm run build
- pre-push checks (TypeScript, Biome, cargo fmt, cargo clippy, TypeDoc)