### PR TITLE
Fix Call and Portrait camera initialization on startup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -331,6 +331,7 @@ import {
 } from "./runtime/ui-pack-transition/stage-transition";
 import { getUiStateStore } from "./runtime/ui-state-store";
 import { useAuxiliaryScreenSharing } from "./runtime/use-auxiliary-screen-sharing";
+import { useViewModeCamera } from "./runtime/use-view-mode-camera";
 import {
   loadUserLayer,
   reconcileAmbientUiRegistration,
@@ -365,10 +366,6 @@ import {
   writeSessionPersonasText,
   writeYorishiroConfigText,
 } from "./runtime/user-pack-loader/yorishiro-io";
-import {
-  acquireFixedViewModeCamera,
-  acquireResponsiveCallCamera,
-} from "./runtime/view-mode-framing";
 import { enqueueNativeWindowMutation } from "./runtime/view-mode-native-window";
 import {
   nextViewModeHudVisibility,
@@ -1046,6 +1043,7 @@ function App() {
   // persona 切替で姿が変わるとき、カーテンが明けた瞬間に新しいアバターが
   // 立っているようにするため（ロードが終わらない場合は curtain の failsafe が開ける）。
   const [vrmReadyOnce, setVrmReadyOnce] = useState(false);
+  const [cameraBody, setCameraBody] = useState<Body | null>(null);
   const [appLanguage, setAppLanguage] = useState<{
     configured: AppLanguage;
     resolved: ResolvedLanguage;
@@ -1128,37 +1126,16 @@ function App() {
     },
     [],
   );
-  useEffect(() => {
-    // Settings is a temporary surface over the originating View Mode. Keep that
-    // mode's camera claim alive so opening/closing Settings never re-frames the resident.
-    const cameraViewModeId = pickerActiveViewModeId;
-    const compact = cameraViewModeId === companionPack.id || cameraViewModeId === "portrait";
-    const runtime = getThreeRuntime();
-    if (!compact) {
-      runtime.setCameraBase(0, 1.35, 1.1);
-      return;
-    }
-    const mode = cameraViewModeId === companionPack.id ? "scene" : cameraViewModeId;
-    const windowedMode = mode as "scene" | "portrait";
-    const characterAnchorY =
-      windowedMode === "portrait" ? runtime.getCharacterAnchor()?.y : undefined;
-    if (windowedMode === "portrait") {
-      return acquireResponsiveCallCamera(
-        characterAnchorY,
-        runtime.acquireFixedCamera.bind(runtime),
-        {
-          getWidth: () => window.innerWidth,
-          addEventListener: (_type, listener) => window.addEventListener("resize", listener),
-          removeEventListener: (_type, listener) => window.removeEventListener("resize", listener),
-        },
-      );
-    }
-    return acquireFixedViewModeCamera(
-      windowedMode,
-      runtime.acquireFixedCamera.bind(runtime),
-      characterAnchorY,
-    );
-  }, [pickerActiveViewModeId]);
+  // Settings keeps the originating View Mode's camera claim alive.
+  useViewModeCamera(
+    pickerActiveViewModeId === companionPack.id
+      ? "scene"
+      : pickerActiveViewModeId === "portrait"
+        ? "portrait"
+        : null,
+    cameraBody,
+    getThreeRuntime(),
+  );
   useEffect(() => {
     const rounded = roundedWindowForViewMode(activePresentationViewModeIdValue);
     document.documentElement.toggleAttribute("data-rounded-view", rounded);
@@ -4311,6 +4288,7 @@ function App() {
   const handleBodyReady = useCallback(
     (body: Body | null) => {
       bodyRef.current = body;
+      setCameraBody(body);
       if (body) {
         // VRM ロード完了時、runtime 側は tracking を強制 ON + 頭位置スナップ
         // 済み（three-runtime のロード完了処理）。leva の表示と手動制御分岐を

--- a/src/runtime/use-view-mode-camera.test.ts
+++ b/src/runtime/use-view-mode-camera.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useViewModeCamera } from "./use-view-mode-camera";
+import { entryCameraForViewMode, type WindowedViewMode } from "./view-mode-framing";
+
+function cameraRuntime() {
+  let anchorY = 1.2;
+  let camera = { x: 0, y: 1.35, z: 1.1 };
+  const setTarget = vi.fn();
+  const release = vi.fn();
+  const runtime = {
+    getCharacterAnchor: vi.fn(() => ({ x: 0, y: anchorY, z: 0 })),
+    setCameraBase: vi.fn(),
+    acquireFixedCamera: vi.fn((x: number, y: number, z: number) => {
+      const previous = camera;
+      camera = { x, y, z };
+      return {
+        setTarget,
+        dispose: () => {
+          camera = previous;
+          release();
+        },
+      };
+    }),
+  };
+  return {
+    runtime,
+    release,
+    setTarget,
+    get camera() {
+      return camera;
+    },
+    setAnchor: (y: number) => {
+      anchorY = y;
+    },
+    initializeLoadedCamera: () => {
+      camera = { x: 0, y: anchorY - 0.05, z: 1.1 };
+    },
+  };
+}
+
+describe("View Mode camera readiness", () => {
+  it.each<WindowedViewMode>([
+    "portrait",
+    "scene",
+  ])("%s startup waits for the body and restores the loaded camera on exit", (mode) => {
+    const fake = cameraRuntime();
+    const { rerender } = renderHook(
+      ({ mode, body }: { mode: WindowedViewMode | null; body: object | null }) =>
+        useViewModeCamera(mode, body, fake.runtime),
+      { initialProps: { mode: mode as WindowedViewMode | null, body: null as object | null } },
+    );
+    expect(fake.runtime.acquireFixedCamera).not.toHaveBeenCalled();
+    fake.initializeLoadedCamera();
+    const loadedCamera = fake.camera;
+    const body = {};
+    rerender({ mode, body });
+    expect(fake.camera).toEqual(entryCameraForViewMode(mode, 1.2));
+    expect(fake.runtime.acquireFixedCamera).toHaveBeenCalledOnce();
+    fake.setAnchor(1.8);
+    rerender({ mode, body });
+    act(() => window.dispatchEvent(new Event("resize")));
+    expect(fake.runtime.acquireFixedCamera).toHaveBeenCalledOnce();
+    expect(fake.camera).toEqual(entryCameraForViewMode(mode, 1.2));
+    rerender({ mode: null, body });
+    expect(fake.release).toHaveBeenCalledOnce();
+    expect(fake.camera).toEqual(loadedCamera);
+  });
+
+  it("uses the same Call framing for restored startup and entry from Terminal", () => {
+    const fake = cameraRuntime();
+    const body = {};
+    const { rerender, unmount } = renderHook(
+      ({ mode }: { mode: WindowedViewMode | null }) => useViewModeCamera(mode, body, fake.runtime),
+      { initialProps: { mode: null as WindowedViewMode | null } },
+    );
+    fake.initializeLoadedCamera();
+    rerender({ mode: "portrait" });
+    expect(fake.camera).toEqual(entryCameraForViewMode("portrait", 1.2));
+    unmount();
+    expect(fake.release).toHaveBeenCalledOnce();
+  });
+
+  it("does not acquire a stale mode when leaving it before loading completes", () => {
+    const fake = cameraRuntime();
+    const { rerender } = renderHook(
+      ({ mode, body }: { mode: WindowedViewMode | null; body: object | null }) =>
+        useViewModeCamera(mode, body, fake.runtime),
+      {
+        initialProps: { mode: "portrait" as WindowedViewMode | null, body: null as object | null },
+      },
+    );
+    rerender({ mode: null, body: null });
+    fake.initializeLoadedCamera();
+    rerender({ mode: null, body: {} });
+    expect(fake.runtime.acquireFixedCamera).not.toHaveBeenCalled();
+    expect(fake.runtime.setCameraBase).toHaveBeenCalledOnce();
+  });
+
+  it("releases the old body camera during loading and samples the replacement once", () => {
+    const fake = cameraRuntime();
+    const { rerender } = renderHook(
+      ({ body }: { body: object | null }) => useViewModeCamera("portrait", body, fake.runtime),
+      { initialProps: { body: {} as object | null } },
+    );
+    rerender({ body: null });
+    expect(fake.release).toHaveBeenCalledOnce();
+    fake.setAnchor(1.8);
+    fake.initializeLoadedCamera();
+    rerender({ body: {} });
+    expect(fake.camera).toEqual(entryCameraForViewMode("portrait", 1.8));
+    expect(fake.runtime.acquireFixedCamera).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/runtime/use-view-mode-camera.ts
+++ b/src/runtime/use-view-mode-camera.ts
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+import type { ThreeRuntime } from "./three-runtime/types";
+import {
+  acquireFixedViewModeCamera,
+  acquireResponsiveCallCamera,
+  type WindowedViewMode,
+} from "./view-mode-framing";
+
+type CameraRuntime = Pick<
+  ThreeRuntime,
+  "setCameraBase" | "getCharacterAnchor" | "acquireFixedCamera"
+>;
+
+/** Body identity changes only on load/unload, never as the resident moves. */
+export function useViewModeCamera(
+  mode: WindowedViewMode | null,
+  body: object | null,
+  runtime: CameraRuntime,
+): void {
+  useEffect(() => {
+    if (mode === null) {
+      runtime.setCameraBase(0, 1.35, 1.1);
+    }
+  }, [mode, runtime]);
+  useEffect(() => {
+    if (mode === null) return;
+    // Let VRM loading initialize the normal camera first. Claiming it earlier
+    // skips that initialization and freezes Call at a fallback head height,
+    // also retaining the uninitialized camera as its restore destination.
+    if (body === null) return;
+    if (mode === "portrait") {
+      return acquireResponsiveCallCamera(
+        runtime.getCharacterAnchor()?.y,
+        runtime.acquireFixedCamera.bind(runtime),
+        {
+          getWidth: () => window.innerWidth,
+          addEventListener: (_type, listener) => window.addEventListener("resize", listener),
+          removeEventListener: (_type, listener) => window.removeEventListener("resize", listener),
+        },
+      );
+    }
+    return acquireFixedViewModeCamera(mode, runtime.acquireFixedCamera.bind(runtime));
+  }, [mode, body, runtime]);
+}


### PR DESCRIPTION
Restoring Call at startup acquired a fixed camera before the VRM loaded, permanently using the fallback head height. Both compact modes also captured the pre-load camera as their restoration state.

Wait for Body readiness before acquiring the Call/Portrait camera so normal VRM camera initialization completes first. Call then samples the loaded head position once; framing stays fixed as the character moves, and existing resize behavior is preserved.

Validation: 10 regression and framing tests passed, along with TypeScript and Biome checks. Actual app restart and visual verification have not been performed.
