### PR TITLE
Prevent Leva debug controls from dragging the window

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,6 +130,7 @@ import {
   VoicePlaybackLeaseSync,
   VoicePlayer,
 } from "./core/voice";
+import { DebugControlsBoundary } from "./debug-controls-boundary";
 import {
   changeStrings,
   getStrings,
@@ -5939,30 +5940,32 @@ function App() {
           />
         }
       />
-      {runtimeLevaStore ? (
-        <LevaPanel
-          store={runtimeLevaStore}
-          hidden={levaHidden}
-          collapsed={false}
-          flat
-          titleBar={{
-            title: "Common",
-            drag: true,
-            filter: true,
-            position: { x: 0, y: 0 },
-          }}
-        />
-      ) : null}
-      {activeSceneLevaStore ? (
-        <LevaPanel
-          key={activeSceneLevaStore.storeId}
-          store={activeSceneLevaStore}
-          hidden={levaHidden}
-          collapsed={false}
-          flat
-          titleBar={{ title: "Scene", drag: true, filter: true, position: { x: -300, y: 0 } }}
-        />
-      ) : null}
+      <DebugControlsBoundary>
+        {runtimeLevaStore ? (
+          <LevaPanel
+            store={runtimeLevaStore}
+            hidden={levaHidden}
+            collapsed={false}
+            flat
+            titleBar={{
+              title: "Common",
+              drag: true,
+              filter: true,
+              position: { x: 0, y: 0 },
+            }}
+          />
+        ) : null}
+        {activeSceneLevaStore ? (
+          <LevaPanel
+            key={activeSceneLevaStore.storeId}
+            store={activeSceneLevaStore}
+            hidden={levaHidden}
+            collapsed={false}
+            flat
+            titleBar={{ title: "Scene", drag: true, filter: true, position: { x: -300, y: 0 } }}
+          />
+        ) : null}
+      </DebugControlsBoundary>
       <div className="app-body">
         <div
           className="shell-column"

--- a/src/debug-controls-boundary.test.tsx
+++ b/src/debug-controls-boundary.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { createPortal } from "react-dom";
+import { afterEach, expect, it, vi } from "vitest";
+import { DebugControlsBoundary } from "./debug-controls-boundary";
+import { shouldStartViewModeWindowDrag } from "./runtime/view-mode-window-interaction";
+
+afterEach(cleanup);
+
+it("isolates inline and portaled debug gestures while keeping blank-area window drag", () => {
+  const startDragging = vi.fn();
+  const debugGesture = vi.fn();
+  const { getByTestId } = render(
+    <div
+      onPointerDown={(event) => {
+        if (!shouldStartViewModeWindowDrag(true, event.button, event.target)) return;
+        event.preventDefault();
+        startDragging();
+      }}
+    >
+      <DebugControlsBoundary>
+        <div data-testid="panel-title" onPointerDown={debugGesture} />
+        {createPortal(
+          <div data-testid="color-picker" onPointerDown={debugGesture} />,
+          document.body,
+        )}
+      </DebugControlsBoundary>
+      <canvas data-testid="scene" />
+    </div>,
+  );
+
+  for (const id of ["panel-title", "color-picker"]) {
+    const event = new MouseEvent("pointerdown", { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(getByTestId(id), event);
+    expect(event.defaultPrevented).toBe(false);
+  }
+  expect(debugGesture).toHaveBeenCalledTimes(2);
+  expect(startDragging).not.toHaveBeenCalled();
+
+  fireEvent(
+    getByTestId("scene"),
+    new MouseEvent("pointerdown", { bubbles: true, cancelable: true, button: 0 }),
+  );
+  expect(startDragging).toHaveBeenCalledOnce();
+});

--- a/src/debug-controls-boundary.tsx
+++ b/src/debug-controls-boundary.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+/** Debug controls own their gestures, including Leva popovers portaled to body. */
+export function DebugControlsBoundary({ children }: { readonly children: ReactNode }) {
+  return (
+    <div
+      data-no-window-drag=""
+      style={{ display: "contents" }}
+      onPointerDown={(event) => event.stopPropagation()}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/runtime/view-mode-window-interaction.test.ts
+++ b/src/runtime/view-mode-window-interaction.test.ts
@@ -21,6 +21,40 @@ describe("chrome-hidden View Mode window interaction", () => {
     expect(shouldStartViewModeWindowDrag(true, 0, icon)).toBe(false);
   });
 
+  it("leaves debug panel drags and slider gestures inside their no-window-drag boundary", () => {
+    const root = document.createElement("div");
+    const debugPanels = document.createElement("div");
+    debugPanels.setAttribute("data-no-window-drag", "");
+    debugPanels.style.display = "contents";
+    const titleBar = document.createElement("div");
+    const sliderRail = document.createElement("div");
+    const sliderThumb = document.createElement("span");
+    sliderRail.append(sliderThumb);
+    debugPanels.append(titleBar, sliderRail);
+    const canvas = document.createElement("canvas");
+    root.append(debugPanels, canvas);
+    let windowDrags = 0;
+    let debugGestures = 0;
+    root.addEventListener("pointerdown", (event) => {
+      if (shouldStartViewModeWindowDrag(true, (event as MouseEvent).button, event.target)) {
+        event.preventDefault();
+        windowDrags++;
+      }
+    });
+    debugPanels.addEventListener("pointerdown", () => debugGestures++);
+
+    for (const target of [titleBar, sliderRail, sliderThumb]) {
+      const event = new MouseEvent("pointerdown", { bubbles: true, cancelable: true, button: 0 });
+      target.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(false);
+    }
+    expect(debugGestures).toBe(3);
+    expect(windowDrags).toBe(0);
+
+    canvas.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    expect(windowDrags).toBe(1);
+  });
+
   it("uses secondary click to reveal the HUD", () => {
     expect(shouldRevealViewModeHud(true, 2)).toBe(true);
     expect(shouldRevealViewModeHud(true, 0)).toBe(false);


### PR DESCRIPTION
In chrome-hidden view modes, dragging a Leva debug-panel title bar or slider also started native window dragging, preventing reliable F2 debug controls. Put both Common and Scene panels inside a layout-neutral no-window-drag boundary, and stop pointer-down bubbling so portaled color and joystick controls cannot reach the window-drag handler. Background dragging remains available.

Validation: 7 tests passed, covering panel gestures, React portals, and neighboring background dragging; TypeScript and Biome checks passed. Native interaction has not been manually verified.
