### PR TITLE
Exit fullscreen before switching to compact view modes

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,8 @@
     "core:window:allow-set-size",
     "core:window:allow-set-always-on-top",
     "core:window:allow-set-fullscreen",
+    "core:window:allow-unmaximize",
+    "core:window:allow-maximize",
     "core:window:allow-set-background-color",
     "opener:default",
     "dialog:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod screen_annotation;
 mod screen_capture;
 mod sessions;
 mod tts;
+mod window_fullscreen;
 
 use pty::{start_hook_server, PtyState};
 use realtime_bridge::RealtimeBridgeState;
@@ -3948,6 +3949,7 @@ pub fn run() {
             history::snapshot_prune,
             external_attach_sync_client_count,
             set_window_controls_visible,
+            window_fullscreen::exit_window_fullscreen,
             system_exec
         ])
         .setup(move |app| {

--- a/src-tauri/src/window_fullscreen.rs
+++ b/src-tauri/src/window_fullscreen.rs
@@ -1,0 +1,136 @@
+/// Complete the native fullscreen transition before compact mode resizes the window.
+#[tauri::command]
+pub async fn exit_window_fullscreen(window: tauri::WebviewWindow) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    return macos::exit(window).await;
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        if window.is_fullscreen().map_err(|error| error.to_string())? {
+            window
+                .set_fullscreen(false)
+                .map_err(|error| error.to_string())?;
+            tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                while window.is_fullscreen().map_err(|error| error.to_string())? {
+                    tokio::time::sleep(std::time::Duration::from_millis(16)).await;
+                }
+                Ok::<(), String>(())
+            })
+            .await
+            .map_err(|_| "Fullscreen exit timed out".to_string())??;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use block2::RcBlock;
+    use objc2::{msg_send, rc::Retained, runtime::ProtocolObject};
+    use objc2_app_kit::{NSWindowDidExitFullScreenNotification, NSWindowStyleMask};
+    use objc2_foundation::{NSNotificationCenter, NSObjectProtocol};
+    use std::{
+        cell::RefCell,
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc, Mutex,
+        },
+        time::Duration,
+    };
+    use tauri::Manager;
+    use tokio::sync::oneshot;
+
+    thread_local! {
+        // AppKit observer ownership never leaves the main thread.
+        static OBSERVERS: RefCell<HashMap<u64, Retained<ProtocolObject<dyn NSObjectProtocol>>>> = RefCell::new(HashMap::new());
+    }
+    static NEXT_OBSERVER: AtomicU64 = AtomicU64::new(1);
+
+    struct ObserverCleanup {
+        app: tauri::AppHandle,
+        id: u64,
+    }
+
+    impl Drop for ObserverCleanup {
+        fn drop(&mut self) {
+            let id = self.id;
+            let _ = self.app.run_on_main_thread(move || {
+                OBSERVERS.with(|observers| {
+                    if let Some(observer) = observers.borrow_mut().remove(&id) {
+                        unsafe {
+                            NSNotificationCenter::defaultCenter().removeObserver(observer.as_ref());
+                        }
+                    }
+                });
+            });
+        }
+    }
+
+    pub(super) async fn exit(window: tauri::WebviewWindow) -> Result<(), String> {
+        let id = NEXT_OBSERVER.fetch_add(1, Ordering::Relaxed);
+        let _cleanup = ObserverCleanup {
+            app: window.app_handle().clone(),
+            id,
+        };
+        let (sender, receiver) = oneshot::channel();
+        let sender = Arc::new(Mutex::new(Some(sender)));
+        let native_window = window.clone();
+        window
+            .run_on_main_thread(move || {
+                // Cancellation before this queued callback must not initiate a transition.
+                if sender
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .is_none_or(|sender| sender.is_closed())
+                {
+                    return;
+                }
+                let result = (|| -> Result<bool, String> {
+                    let pointer = native_window
+                        .ns_window()
+                        .map_err(|error| error.to_string())?;
+                    let object = unsafe { &*pointer.cast::<objc2::runtime::AnyObject>() };
+                    let style: usize = unsafe { msg_send![object, styleMask] };
+                    if style & NSWindowStyleMask::FullScreen.bits() == 0 {
+                        return Ok(false);
+                    }
+                    let completed = Arc::clone(&sender);
+                    let block = RcBlock::new(move |_| {
+                        if let Some(sender) = completed.lock().unwrap().take() {
+                            let _ = sender.send(Ok(()));
+                        }
+                    });
+                    let observer = unsafe {
+                        NSNotificationCenter::defaultCenter()
+                            .addObserverForName_object_queue_usingBlock(
+                                Some(NSWindowDidExitFullScreenNotification),
+                                Some(object),
+                                None,
+                                &block,
+                            )
+                    };
+                    OBSERVERS.with(|observers| {
+                        observers.borrow_mut().insert(id, observer);
+                    });
+                    // Tao updates its cached flag before AppKit finishes the animation.
+                    // Only the notification above authorizes the caller to resize.
+                    native_window
+                        .set_fullscreen(false)
+                        .map_err(|error| error.to_string())?;
+                    Ok(true)
+                })();
+                if !matches!(result, Ok(true)) {
+                    if let Some(sender) = sender.lock().unwrap().take() {
+                        let _ = sender.send(result.map(|_| ()));
+                    }
+                }
+            })
+            .map_err(|error| error.to_string())?;
+        tokio::time::timeout(Duration::from_secs(10), receiver)
+            .await
+            .map_err(|_| "Fullscreen exit timed out".to_string())?
+            .map_err(|_| "Fullscreen exit notification was cancelled".to_string())?
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import * as ReactThreeFiber from "@react-three/fiber";
 import * as ReactThreePostprocessing from "@react-three/postprocessing";
 import { getVersion } from "@tauri-apps/api/app";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type {
   AmbientAudioAPI,
@@ -30,6 +30,7 @@ import * as ReactDomClient from "react-dom/client";
 import * as THREE from "three";
 import {
   checkTutorialDone,
+  exitWindowFullscreen,
   listSupportedAgents,
   markTutorialDone,
   prepareLocalizedPluginDir,
@@ -367,7 +368,10 @@ import {
   writeSessionPersonasText,
   writeYorishiroConfigText,
 } from "./runtime/user-pack-loader/yorishiro-io";
-import { enqueueNativeWindowMutation } from "./runtime/view-mode-native-window";
+import {
+  createNativeWindowLayoutApplier,
+  enqueueNativeWindowMutation,
+} from "./runtime/view-mode-native-window";
 import {
   nextViewModeHudVisibility,
   shouldRevealViewModeHud,
@@ -3246,51 +3250,13 @@ function App() {
     let currentAbort: AbortController | null = null;
     let currentLayout: UiLayout | null = null;
     let currentEntryId: string | null = null;
-    let savedWindowSize: LogicalSize | null = null;
-    let savedFullscreen: boolean | null = null;
+    const applyWindowLayout = createNativeWindowLayoutApplier(
+      getCurrentWindow(),
+      exitWindowFullscreen,
+    );
     const applyNativeWindowLayout = (layout: UiLayout | null): void => {
-      const width = layout?.window?.width;
-      const height = layout?.window?.height;
-      const minWidth = layout?.window?.minWidth ?? 900;
-      const minHeight = layout?.window?.minHeight ?? 600;
-      const alwaysOnTop = layout?.window?.alwaysOnTop ?? false;
-      const fullscreen = layout?.window?.fullscreen ?? false;
-
-      // active UI が短時間に連続で変わっても古い async call が後から勝たないよう直列化する。
-      void enqueueNativeWindowMutation(async () => {
-        const appWindow = getCurrentWindow();
-        const requestsSize = width !== undefined || height !== undefined;
-        if (requestsSize && savedWindowSize === null) {
-          const [innerSize, scaleFactor] = await Promise.all([
-            appWindow.innerSize(),
-            appWindow.scaleFactor(),
-          ]);
-          savedWindowSize = innerSize.toLogical(scaleFactor);
-        }
-
-        await appWindow.setMinSize(new LogicalSize(minWidth, minHeight));
-        if (requestsSize) {
-          const [innerSize, scaleFactor] = await Promise.all([
-            appWindow.innerSize(),
-            appWindow.scaleFactor(),
-          ]);
-          const currentSize = innerSize.toLogical(scaleFactor);
-          await appWindow.setSize(
-            new LogicalSize(width ?? currentSize.width, height ?? currentSize.height),
-          );
-        } else if (savedWindowSize !== null) {
-          const restoreSize = savedWindowSize;
-          savedWindowSize = null;
-          await appWindow.setSize(restoreSize);
-        }
-        await appWindow.setAlwaysOnTop(alwaysOnTop);
-        if (savedFullscreen === null) savedFullscreen = await appWindow.isFullscreen();
-        await appWindow.setFullscreen(fullscreen || savedFullscreen === true);
-        if (!layout && savedFullscreen !== null) {
-          await appWindow.setFullscreen(savedFullscreen);
-          savedFullscreen = null;
-        }
-      }).catch((error) => {
+      // Keep native transitions serialized when View Modes change in quick succession.
+      void enqueueNativeWindowMutation(() => applyWindowLayout(layout)).catch((error) => {
         devLog.write({
           subsystem: "UiPack",
           phase: "window-layout",

--- a/src/bindings/tauri-commands.ts
+++ b/src/bindings/tauri-commands.ts
@@ -23,6 +23,9 @@ import type { SnapshotEntry } from "../sdk/history";
 const call = <T>(cmd: string, args: object): Promise<T> =>
   invoke<T>(cmd, args as unknown as InvokeArgs);
 
+/** Wait for native fullscreen exit before changing the window size. */
+export const exitWindowFullscreen = (): Promise<void> => call("exit_window_fullscreen", {});
+
 export interface ScreenCaptureSource {
   readonly id: number;
   readonly name: string;

--- a/src/runtime/view-mode-native-window.test.ts
+++ b/src/runtime/view-mode-native-window.test.ts
@@ -1,8 +1,107 @@
-import { describe, expect, it } from "vitest";
+import { LogicalSize, PhysicalSize } from "@tauri-apps/api/window";
+import { describe, expect, it, vi } from "vitest";
 import {
+  createNativeWindowLayoutApplier,
   enqueueNativeWindowMutation,
   resolveWindowAspectRatioStrategy,
 } from "./view-mode-native-window";
+
+function mockWindow(fullscreen = false, maximized = false) {
+  let size = new PhysicalSize(1200, 800);
+  return {
+    innerSize: vi.fn(async () => size),
+    scaleFactor: vi.fn(async () => 1),
+    isFullscreen: vi.fn(async () => fullscreen),
+    setFullscreen: vi.fn(async (value: boolean) => {
+      fullscreen = value;
+    }),
+    isMaximized: vi.fn(async () => maximized),
+    maximize: vi.fn(async () => {
+      maximized = true;
+    }),
+    unmaximize: vi.fn(async () => {
+      maximized = false;
+    }),
+    setMinSize: vi.fn(async () => {}),
+    setSize: vi.fn(async (value: LogicalSize) => {
+      size = new PhysicalSize(value.width, value.height);
+    }),
+    setAlwaysOnTop: vi.fn(async () => {}),
+  };
+}
+
+describe("View Mode native window layout", () => {
+  it.each([
+    [200, 300],
+    [280, 560],
+  ])("waits for fullscreen exit before applying compact size %ix%i", async (width, height) => {
+    const window = mockWindow(true);
+    let finishExit!: () => void;
+    const exitFullscreen = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishExit = resolve;
+        }),
+    );
+    const apply = createNativeWindowLayoutApplier(window, exitFullscreen);
+    const pending = apply({ window: { width, height } });
+    await vi.waitFor(() => expect(exitFullscreen).toHaveBeenCalledOnce());
+    expect(window.setSize).not.toHaveBeenCalled();
+    expect(window.setMinSize).not.toHaveBeenCalled();
+    finishExit();
+    await pending;
+    expect(window.setSize).toHaveBeenCalledWith(new LogicalSize(width, height));
+    expect(window.setFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("unmaximizes before sizing and restores normal size and maximization on exit", async () => {
+    const window = mockWindow(false, true);
+    const apply = createNativeWindowLayoutApplier(window, async () => {});
+    await apply({ window: { width: 200, height: 300 } });
+    expect(window.unmaximize).toHaveBeenCalledOnce();
+    expect(window.unmaximize.mock.invocationCallOrder[0]).toBeLessThan(
+      window.setSize.mock.invocationCallOrder[0],
+    );
+    await apply({ window: { width: 280, height: 560 } });
+    await apply(null);
+    expect(window.setSize).toHaveBeenLastCalledWith(new LogicalSize(1200, 800));
+    expect(window.maximize).toHaveBeenCalledOnce();
+  });
+
+  it("restores initial fullscreen after leaving compact mode", async () => {
+    const window = mockWindow(true);
+    const apply = createNativeWindowLayoutApplier(window, async () => {});
+    await apply({ window: { width: 200, height: 300 } });
+    expect(window.setFullscreen).not.toHaveBeenCalled();
+    await apply(null);
+    expect(window.setFullscreen).toHaveBeenCalledWith(true);
+  });
+
+  it("preserves fullscreen for unsized layouts and honors explicit fullscreen requests", async () => {
+    const window = mockWindow(true);
+    const exitFullscreen = vi.fn(async () => {});
+    const apply = createNativeWindowLayoutApplier(window, exitFullscreen);
+    await apply({ chrome: { visible: false } });
+    expect(exitFullscreen).not.toHaveBeenCalled();
+    expect(window.setFullscreen).toHaveBeenCalledWith(true);
+    await apply({ window: { fullscreen: false } });
+    expect(exitFullscreen).toHaveBeenCalledOnce();
+    await apply({ window: { fullscreen: true, width: 200, height: 300 } });
+    expect(exitFullscreen).toHaveBeenCalledOnce();
+    expect(window.setSize).not.toHaveBeenCalled();
+    expect(window.setFullscreen).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not resize when native fullscreen exit fails", async () => {
+    const window = mockWindow(true);
+    const apply = createNativeWindowLayoutApplier(window, async () => {
+      throw new Error("fullscreen transition timed out");
+    });
+    await expect(apply({ window: { width: 200, height: 300 } })).rejects.toThrow("timed out");
+    expect(window.setSize).not.toHaveBeenCalled();
+    expect(window.setMinSize).not.toHaveBeenCalled();
+  });
+});
 
 describe("View Mode native window aspect ratio", () => {
   it("disables aspect enforcement on macOS for resize stability", () => {

--- a/src/runtime/view-mode-native-window.ts
+++ b/src/runtime/view-mode-native-window.ts
@@ -1,3 +1,6 @@
+import { LogicalSize, type Window } from "@tauri-apps/api/window";
+import type { UiLayout } from "@yorishiro/sdk";
+
 export interface WindowAspectRatioStrategy {
   readonly nativeAspectRatio: number | null;
   readonly jsAspectRatio: number | null;
@@ -16,4 +19,79 @@ export function enqueueNativeWindowMutation(operation: () => Promise<void>): Pro
   const result = nativeWindowMutationQueue.then(operation);
   nativeWindowMutationQueue = result.catch(() => undefined);
   return result;
+}
+
+type LayoutWindow = Pick<
+  Window,
+  | "innerSize"
+  | "scaleFactor"
+  | "isFullscreen"
+  | "setFullscreen"
+  | "isMaximized"
+  | "maximize"
+  | "unmaximize"
+  | "setMinSize"
+  | "setSize"
+  | "setAlwaysOnTop"
+>;
+
+/** Call through the native mutation queue so a later mode cannot overtake an earlier one. */
+export function createNativeWindowLayoutApplier(
+  appWindow: LayoutWindow,
+  exitFullscreen: () => Promise<void>,
+) {
+  let savedSize: LogicalSize | null = null;
+  let savedMaximized: boolean | null = null;
+  let savedFullscreen: boolean | null = null;
+
+  const readSize = async () => {
+    const [size, scale] = await Promise.all([appWindow.innerSize(), appWindow.scaleFactor()]);
+    return size.toLogical(scale);
+  };
+
+  return async (layout: UiLayout | null): Promise<void> => {
+    const windowLayout = layout?.window;
+    // Fullscreen owns the display dimensions; compact sizes apply only in windowed modes.
+    const requestsSize =
+      windowLayout?.fullscreen !== true &&
+      (windowLayout?.width !== undefined || windowLayout?.height !== undefined);
+    const fullscreen = await appWindow.isFullscreen();
+    if (layout && savedFullscreen === null) savedFullscreen = fullscreen;
+    // An explicit compact size takes precedence over inherited fullscreen state.
+    const targetFullscreen =
+      windowLayout?.fullscreen ?? (requestsSize ? false : (savedFullscreen ?? fullscreen));
+    const resizesWindow = requestsSize || savedSize !== null;
+    if (resizesWindow || !targetFullscreen) {
+      // macOS setFullscreen resolves before its Space transition completes.
+      await exitFullscreen();
+    }
+    if (requestsSize && savedSize === null) {
+      savedMaximized = await appWindow.isMaximized();
+      if (savedMaximized) await appWindow.unmaximize();
+      savedSize = await readSize();
+    } else if (resizesWindow && (await appWindow.isMaximized())) {
+      await appWindow.unmaximize();
+    }
+
+    await appWindow.setMinSize(
+      new LogicalSize(windowLayout?.minWidth ?? 900, windowLayout?.minHeight ?? 600),
+    );
+    if (requestsSize) {
+      const currentSize = await readSize();
+      await appWindow.setSize(
+        new LogicalSize(
+          windowLayout?.width ?? currentSize.width,
+          windowLayout?.height ?? currentSize.height,
+        ),
+      );
+    } else if (savedSize !== null) {
+      await appWindow.setSize(savedSize);
+      if (savedMaximized) await appWindow.maximize();
+      savedSize = null;
+      savedMaximized = null;
+    }
+    await appWindow.setAlwaysOnTop(windowLayout?.alwaysOnTop ?? false);
+    if (targetFullscreen) await appWindow.setFullscreen(true);
+    if (!layout) savedFullscreen = null;
+  };
 }


### PR DESCRIPTION
Switching from native fullscreen or a maximized window to Call or Portrait could leave a compact view surrounded by a black fullscreen area. Compact dimensions now override inherited fullscreen state: wait for fullscreen exit, unmaximize, then apply the configured size. Restore the previous normal dimensions and window state when leaving compact modes.

On macOS, wait for the AppKit fullscreen-exit notification rather than the early cached fullscreen flag, with timeout and observer cleanup. Window changes remain serialized.

Validation: 9 window-layout tests passed, including both compact sizes, transition ordering, state restoration, explicit fullscreen, and exit failure. TypeScript, Biome, and native cargo check passed. The user confirmed the updated behavior appears to work in the running development app.

Startup error recovery is excluded and will be a separate PR.
