### PR TITLE
Show a recovery screen when application startup fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,6 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/src/bootstrap.ts"></script>
   </body>
 </html>

--- a/public/boot.css
+++ b/public/boot.css
@@ -24,3 +24,37 @@ body,
   background: #020304;
   color: #e8ebe7;
 }
+
+/* Recovery must remain visible even if application styles never load. */
+#startup-error {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  box-sizing: border-box;
+  overflow: auto;
+  padding: 24px;
+  background: #151815;
+  color: #e8ebe7;
+  font: 14px / 1.6 system-ui, sans-serif;
+  -webkit-app-region: no-drag;
+}
+
+#startup-error h1 {
+  font-size: 20px;
+}
+
+#startup-error button {
+  padding: 8px 16px;
+  margin: 8px 0 16px;
+  cursor: pointer;
+}
+
+#startup-error summary {
+  cursor: pointer;
+}
+
+#startup-error pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  user-select: text;
+}

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,4 @@
+import { startApplication } from "./startup-error";
+
+// Dynamic import lets recovery run even when the application module graph cannot load.
+void startApplication(() => import("./main"));

--- a/src/components/StartupErrorBoundary.tsx
+++ b/src/components/StartupErrorBoundary.tsx
@@ -1,0 +1,19 @@
+import { Component, type ReactNode } from "react";
+import { showStartupError } from "../startup-error";
+
+/** Sits outside lazy imports, including the application's richer recovery screen. */
+export class StartupErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error): void {
+    showStartupError(error);
+  }
+
+  render(): ReactNode {
+    return this.state.failed ? null : this.props.children;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { isTauri } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { StartupErrorBoundary } from "./components/StartupErrorBoundary";
 import { resolveWindowView } from "./runtime/auxiliary-windows";
 
 const view = resolveWindowView(
@@ -27,8 +28,10 @@ const Application = React.lazy(async () => {
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <React.Suspense fallback={null}>
-      <Application />
-    </React.Suspense>
+    <StartupErrorBoundary>
+      <React.Suspense fallback={null}>
+        <Application />
+      </React.Suspense>
+    </StartupErrorBoundary>
   </React.StrictMode>,
 );

--- a/src/startup-error.test.tsx
+++ b/src/startup-error.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from "@testing-library/react";
+import { lazy, Suspense } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StartupErrorBoundary } from "./components/StartupErrorBoundary";
+import { startApplication } from "./startup-error";
+
+afterEach(() => {
+  cleanup();
+  document.getElementById("startup-error")?.remove();
+  vi.restoreAllMocks();
+});
+
+describe("startup recovery", () => {
+  it("shows import failures without React or application styles", async () => {
+    await startApplication(() => Promise.reject(new Error("Missing export <App>")));
+    const panel = document.getElementById("startup-error");
+    expect(panel?.textContent).toContain("Missing export <App>");
+    expect(panel?.querySelector("app")).toBeNull();
+    expect(panel?.querySelector("button")?.textContent).toBe("Reload");
+    expect(document.activeElement).toBe(panel?.querySelector("button"));
+    expect(panel?.querySelector("details")?.open).toBe(false);
+  });
+
+  it("does not show recovery when startup succeeds", async () => {
+    await startApplication(() => Promise.resolve());
+    expect(document.getElementById("startup-error")).toBeNull();
+  });
+
+  it("catches lazy application import rejection outside Suspense", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const Application = lazy(() => Promise.reject(new Error("Cannot import App")));
+    await act(async () => {
+      render(
+        <StartupErrorBoundary>
+          <Suspense fallback={null}>
+            <Application />
+          </Suspense>
+        </StartupErrorBoundary>,
+      );
+    });
+    expect(document.getElementById("startup-error")?.textContent).toContain("Cannot import App");
+  });
+
+  it("catches render errors even when the richer recovery boundary cannot render", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    function Broken(): never {
+      throw new Error("Render failed");
+    }
+    render(
+      <StartupErrorBoundary>
+        <Broken />
+      </StartupErrorBoundary>,
+    );
+    expect(document.getElementById("startup-error")?.textContent).toContain("Render failed");
+  });
+});

--- a/src/startup-error.ts
+++ b/src/startup-error.ts
@@ -1,0 +1,37 @@
+/** Keep recovery independent of React and application modules: either may fail to load. */
+export function showStartupError(error: unknown): void {
+  if (document.getElementById("startup-error")) return;
+  const japanese = navigator.language.startsWith("ja");
+  const panel = document.createElement("main");
+  panel.id = "startup-error";
+  panel.setAttribute("role", "alert");
+  const title = document.createElement("h1");
+  title.textContent = japanese
+    ? "Yorishiro を表示できませんでした"
+    : "Yorishiro could not be displayed";
+  const explanation = document.createElement("p");
+  explanation.textContent = japanese
+    ? "画面の読み込み中にエラーが発生しました。開発中の場合はコードを修正してから再読み込みしてください。"
+    : "An error interrupted the application. If you are developing, fix the code before reloading.";
+  const reload = document.createElement("button");
+  reload.type = "button";
+  reload.textContent = japanese ? "再読み込み" : "Reload";
+  reload.addEventListener("click", () => window.location.reload());
+  const details = document.createElement("details");
+  const summary = document.createElement("summary");
+  summary.textContent = japanese ? "エラーの詳細" : "Error details";
+  const message = document.createElement("pre");
+  message.textContent = error instanceof Error ? error.stack || error.message : String(error);
+  details.append(summary, message);
+  panel.append(title, explanation, reload, details);
+  document.body.append(panel);
+  reload.focus();
+}
+
+export async function startApplication(load: () => Promise<unknown>): Promise<void> {
+  try {
+    await load();
+  } catch (error) {
+    showStartupError(error);
+  }
+}


### PR DESCRIPTION
A missing export or failed lazy import could leave the development window black because the existing application error boundary was loaded inside the same failing import. Add a lightweight bootstrap and an outer boundary so startup/module-loading failures show a recovery screen even when the main application cannot load.

The screen offers Reload and collapsed error details in Japanese or English, without depending on React or application styles for the fallback. Existing application-level recovery remains in place, and auxiliary windows do not import main-window modules.

Validation: 4 tests cover bootstrap rejection/success, lazy import failure, and rendering failure. TypeScript, scoped Biome, and production Vite build passed. Vite HMR may retain its own error overlay; native process failures and failures in the bootstrap itself are outside this recovery path.

Independent of fullscreen transition PR #174.
