### PR TITLE
Fix screen pointer clipping, contrast, and capture flicker

### DIFF
--- a/docs/decisions/shared-screen-pointers.md
+++ b/docs/decisions/shared-screen-pointers.md
@@ -118,7 +118,7 @@ cancels that wait immediately. Its deadline is 16 seconds (the capture timeout o
   age, document, sharing lease, pointer setting, generation, and display geometry
   before drawing. Only re-observation of the exact same cached image ID can refresh
   its age; a different newer image never lends its timestamp or coordinates.
-- The pointer panel is hidden during capture and its native window ID is also
+- The pointer panel remains visible during capture and its pinned native window ID is
   excluded from the ScreenCaptureKit filter. The still-current, unexpired mark
   is restored after capture. This prevents self-feedback in subsequent images.
 

--- a/scripts/render-screen-pointers.py
+++ b/scripts/render-screen-pointers.py
@@ -23,6 +23,11 @@ output_dir.mkdir(parents=True, exist_ok=True)
 source = (project / "src-tauri/src/screen_annotation/macos.rs").read_text()
 
 prefix='''#![allow(dead_code)]
+mod screen_capture {
+    pub(crate) fn display_pixel_dimensions(_: u32) -> Result<(usize, usize), String> {
+        Err("Synthetic previews do not inspect displays".to_string())
+    }
+}
 mod screen_annotation {
     #[derive(Debug,Clone,Copy,PartialEq)]
     pub(super) struct DisplayGeometry {pub source_id:u32,pub x:f64,pub y:f64,pub width:f64,pub height:f64,pub pixel_width:usize,pub pixel_height:usize,pub main_height:f64}
@@ -116,7 +121,7 @@ pub(crate) fn render_preview(){
         let size=NSSize::new(1120.0,504.0);
         let allocated=PreviewCanvas::alloc(mtm).set_ivars(PreviewStyle{mode});
         let canvas:Retained<PreviewCanvas>=unsafe{msg_send![super(allocated),initWithFrame:NSRect::new(NSPoint::ZERO,size)]};
-        let fg=if dark{FOREGROUND}else{0x28312b};
+        let fg=if dark{0xe4e4e4}else{0x282828};
         let dim=if dark{0x89968b}else{0x758173};
         caption(&canvas,mtm,"Yorishiro / 画面の注記",32.0,24.0,21.0,fg);
         caption(&canvas,mtm,match mode{0=>"Dark workspace · native handwriting",1=>"Light workspace · native handwriting",_=>"Mixed synthetic scene · native handwriting"},32.0,62.0,12.0,dim);

--- a/scripts/render-screen-pointers.py
+++ b/scripts/render-screen-pointers.py
@@ -37,7 +37,7 @@ mod screen_annotation {
 '''
 suffix=r'''
 use objc2::AnyThread;
-use objc2_app_kit::NSGradient;
+use objc2_app_kit::{NSGradient, NSTextField};
 #[derive(Debug)] struct PreviewStyle {mode:u8}
 define_class!(
     #[unsafe(super(NSView))]
@@ -116,9 +116,9 @@ pub(crate) fn render_preview(){
     let covered=font.coveredCharacterSet();
     for character in "この稜線設定のまとまり丸みここを調整範囲".encode_utf16() {assert!(covered.characterIsMember(character));}
     println!("Native label font={} size={} first_load_us={} Japanese_glyphs_verified=true",font.fontName(),font.pointSize(),font_start.elapsed().as_micros());
-    for (mode,name) in [(0,"dark"),(1,"light"),(2,"mixed")] {
+    for (mode,name) in [(0,"dark"),(1,"light"),(2,"mixed"),(3,"text-check")] {
         let dark=mode!=1;
-        let size=NSSize::new(1120.0,504.0);
+        let size=NSSize::new(1120.0,if mode==3{820.0}else{504.0});
         let allocated=PreviewCanvas::alloc(mtm).set_ivars(PreviewStyle{mode});
         let canvas:Retained<PreviewCanvas>=unsafe{msg_send![super(allocated),initWithFrame:NSRect::new(NSPoint::ZERO,size)]};
         let fg=if dark{0xe4e4e4}else{0x282828};
@@ -126,12 +126,18 @@ pub(crate) fn render_preview(){
         caption(&canvas,mtm,"Yorishiro / 画面の注記",32.0,24.0,21.0,fg);
         caption(&canvas,mtm,match mode{0=>"Dark workspace · native handwriting",1=>"Light workspace · native handwriting",_=>"Mixed synthetic scene · native handwriting"},32.0,62.0,12.0,dim);
         for (x,title) in [(52.0,"矢印"),(412.0,"囲み"),(772.0,"楕円")] {caption(&canvas,mtm,title,x,136.0,12.0,dim);}
+        if mode != 3 {
         for (target,label) in [
             (AnnotationTarget::Arrow{x:126.0,y:320.0},"この稜線"),
             (AnnotationTarget::Rect{x:424.0,y:228.0,width:252.0,height:142.0},"設定のまとまり"),
             (AnnotationTarget::Ellipse{x:792.0,y:228.0,width:232.0,height:142.0},"この丸み"),
         ] {canvas.addSubview(&create_view(mtm,target,size,Some(label)));}
-        caption(&canvas,mtm,"同じ注釈を明暗の背景で確認。背景の図形はプレビュー用の合成図です。",32.0,466.0,11.0,dim);
+        } else {
+            for (index,text) in ["ヨリ", "テスト", "文字の上が切れていないか確認するテストです", "What is your name?", "How are you?", "長い文字列でも最後まで表示できるか確認します。日本語と English text の混在でも文字や縁取りが上下左右で欠けないことを確認する表示テストです。"].iter().enumerate() {
+                canvas.addSubview(&create_view(mtm,AnnotationTarget::Rect{x:32.0,y:210.0+index as f64*105.0,width:32.0,height:20.0},size,Some(text)));
+            }
+        }
+        if mode != 3 { caption(&canvas,mtm,"同じ注釈を明暗の背景で確認。背景の図形はプレビュー用の合成図です。",32.0,466.0,11.0,dim); }
         let panel=create_panel(mtm,NSRect::new(NSPoint::ZERO,size));panel.setContentView(Some(&canvas));
         let bitmap=canvas.bitmapImageRepForCachingDisplayInRect(NSRect::new(NSPoint::ZERO,size)).unwrap();
         canvas.cacheDisplayInRect_toBitmapImageRep(NSRect::new(NSPoint::ZERO,size),&bitmap);

--- a/src-tauri/src/screen_annotation.rs
+++ b/src-tauri/src/screen_annotation.rs
@@ -212,6 +212,7 @@ struct AnnotationState {
     lease: Option<SharingLease>,
     // One accepted reference survives cache eviction while capture completes.
     pending_frame: Option<FrameAnchor>,
+    active_capture: Option<String>,
     visible: Option<VisibleAnnotation>,
     generation: u64,
     changes: watch::Sender<u64>,
@@ -226,6 +227,7 @@ impl Default for AnnotationState {
             pointer_epoch: 0,
             lease: None,
             pending_frame: None,
+            active_capture: None,
             visible: None,
             generation: 0,
             changes: watch::channel(0).0,
@@ -329,6 +331,10 @@ impl AnnotationState {
     }
 
     fn finish_capture(&mut self, share_id: &str) -> bool {
+        if self.active_capture.as_deref() == Some(share_id) {
+            self.active_capture = None;
+            self.changed();
+        }
         let Some(lease) = self.lease.as_mut().filter(|lease| lease.id == share_id) else {
             return false;
         };
@@ -488,7 +494,7 @@ impl AnnotationState {
         if geometry != pending.geometry {
             return Err("The shared display changed. Start sharing again before pointing.".into());
         }
-        Ok((geometry, lease.capturing))
+        Ok((geometry, lease.capturing || self.active_capture.is_some()))
     }
 
     fn should_hide(
@@ -869,10 +875,10 @@ fn start_watchdog(app: &AppHandle, generation: u64) {
     });
 }
 
-/// Hide annotations throughout capture, so a new/replaced window cannot sneak
-/// into a ScreenCaptureKit filter that was already constructed. Show requests
-/// await a bounded completion notification and only acknowledge an actual draw.
+/// Keep existing marks visible while excluding their pinned window from capture.
+/// New show requests wait until capture completes so its filter stays valid.
 pub struct CaptureGuard {
+    pub(crate) excluded_window: Option<u32>,
     app: AppHandle,
     share_id: String,
     geometry: DisplayGeometry,
@@ -895,24 +901,7 @@ impl Drop for CaptureGuard {
             let Ok(mut state) = managed.0.lock() else {
                 return;
             };
-            if !state.finish_capture(&share_id) {
-                return;
-            }
-            if let Some(mark) = state.visible.as_ref() {
-                let generation = mark.generation;
-                let geometry_matches =
-                    display_geometry(mark.geometry.source_id).ok() == Some(mark.geometry);
-                if Instant::now() < mark.expires_at && geometry_matches && draw(mark).is_ok() {
-                    return;
-                }
-                if geometry_matches {
-                    state.expire_visible(generation);
-                } else {
-                    state.lease = None;
-                    state.clear();
-                }
-                hide();
-            }
+            state.finish_capture(&share_id);
         });
     }
 }
@@ -923,13 +912,16 @@ pub async fn begin_capture(
     source_id: u32,
 ) -> Result<CaptureGuard, String> {
     let id = share_id.clone();
-    let (geometry, pointer_epoch) = on_main(app, move |app| {
+    let (geometry, pointer_epoch, excluded_window) = on_main(app, move |app| {
         let geometry = display_geometry(source_id)?;
         let managed = app.state::<ScreenAnnotationState>();
         let mut state = managed
             .0
             .lock()
             .map_err(|_| "Screen pointer state is unavailable.")?;
+        if state.active_capture.is_some() {
+            return Err("A screen capture is already in progress.".into());
+        }
         let lease = match state.lease(&id, geometry) {
             Ok(lease) => lease,
             Err(error) => {
@@ -943,12 +935,18 @@ pub async fn begin_capture(
             return Err("A screen capture is already in progress.".into());
         }
         lease.capturing = true;
+        let excluded_window = if state.visible.is_some() {
+            window_id()
+        } else {
+            None
+        };
+        state.active_capture = Some(id.clone());
         state.changed();
-        hide();
-        Ok((geometry, state.pointer_epoch))
+        Ok((geometry, state.pointer_epoch, excluded_window))
     })
     .await?;
     Ok(CaptureGuard {
+        excluded_window,
         app: app.clone(),
         share_id,
         geometry,
@@ -1569,6 +1567,47 @@ mod tests {
                 .register("lease", geometry(), fingerprint, (2560, 1440), 0, now)
                 .unwrap();
         }
+    }
+
+    #[test]
+    fn capture_completion_does_not_resurrect_expired_marks() {
+        let now = Instant::now();
+        let (mut state, pending) = waiting_pointer(now);
+        state.active_capture = Some("lease".into());
+        state.visible = Some(VisibleAnnotation {
+            generation: pending.generation,
+            geometry: geometry(),
+            target: AnnotationTarget::Arrow { x: 100.0, y: 100.0 },
+            label: Some("test".into()),
+            expires_at: now + Duration::from_secs(1),
+        });
+        let expiry = state.visible.as_ref().unwrap().expires_at;
+        assert!(state.finish_capture("lease"));
+        assert_eq!(state.visible.as_ref().unwrap().expires_at, expiry);
+        state.active_capture = Some("lease".into());
+        state.expire_visible(pending.generation);
+        assert!(state.finish_capture("lease"));
+        assert!(state.visible.is_none());
+    }
+
+    #[test]
+    fn restarted_sharing_waits_for_old_capture_without_replaying_a_mark() {
+        let now = Instant::now();
+        let (mut state, _) = waiting_pointer(now);
+        state.active_capture = Some("lease".into());
+        state.end("lease");
+        state.begin("new".into(), geometry());
+        let frame = state
+            .register("new", geometry(), 1, (2560, 1440), 0, now)
+            .unwrap();
+        let mut req = request(ScreenPointerKind::Arrow, 0.5, 0.5);
+        req.frame_id = frame;
+        let pending = state.reserve_show(Arc::new(req), now).unwrap();
+        assert!(state.pending_geometry(&pending, now).unwrap().1);
+        assert!(!state.finish_capture("lease"));
+        assert!(!state.pending_geometry(&pending, now).unwrap().1);
+        assert_eq!(state.lease.as_ref().unwrap().id, "new");
+        assert!(state.visible.is_none());
     }
 
     #[test]

--- a/src-tauri/src/screen_annotation/macos.rs
+++ b/src-tauri/src/screen_annotation/macos.rs
@@ -23,13 +23,13 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 static WINDOW_ID: AtomicU32 = AtomicU32::new(0);
 
-// Muted pencil colors derived from the Yorishiro shell. Pale ink with a fine
-// dark edge stays visible on mixed backgrounds without another screen capture.
-const ACCENT: u32 = 0xb8c7aa;
-const CONTRAST: u32 = 0x27332b;
-const FOREGROUND: u32 = 0xdce4d1;
+// Neutral dark gray ink with a white edge stays visible on mixed backgrounds
+// without another screen capture.
+const ACCENT: u32 = 0x333333;
+const CONTRAST: u32 = 0xffffff;
+const FOREGROUND: u32 = 0x333333;
 const MARK_WIDTH: f64 = 1.7;
-const CONTRAST_WIDTH: f64 = 2.8;
+const CONTRAST_WIDTH: f64 = 5.0;
 const LABEL_FONT_SIZE: f64 = 18.0;
 const LABEL_PADDING_X: f64 = 3.0;
 const LABEL_PADDING_Y: f64 = 3.0;
@@ -125,9 +125,9 @@ define_class!(
             let path = annotation_path(drawing.target, drawing.size);
             path.setLineCapStyle(NSLineCapStyle::Round);
             path.setLineJoinStyle(NSLineJoinStyle::Round);
-            // The two thin strokes read as dark ink on a light canvas and as
-            // pale pencil on dark content. No background sampling or animation.
-            color(CONTRAST, 0.84).setStroke();
+            // A white backing keeps the dark stroke visible on dark content.
+            // No background sampling or animation.
+            color(CONTRAST, 1.0).setStroke();
             path.setLineWidth(CONTRAST_WIDTH);
             path.stroke();
             color(ACCENT, 1.0).setStroke();
@@ -247,14 +247,16 @@ fn bundled_font() -> Option<Retained<NSFont>> {
 fn label_text(text: &str, mtm: MainThreadMarker) -> [Retained<NSAttributedString>; 2] {
     let font = annotation_font(mtm);
     let ink = color(FOREGROUND, 1.0);
-    let edge = color(CONTRAST, 0.90);
+    let edge = color(CONTRAST, 1.0);
     // Negative stroke width draws both fill and outline; the unit is percent
-    // of the font size. This is about 0.7 pt, not a plate around the note.
-    let stroke = NSNumber::new_f64(-4.0);
+    // of the font size. A 2.16 pt white stroke surrounds the dark letterforms.
+    let stroke = NSNumber::new_f64(-12.0);
+    // Thicken the handwriting slightly while keeping Japanese counters open.
+    let ink_stroke = NSNumber::new_f64(-2.5);
     let shadow = NSShadow::new();
-    shadow.setShadowColor(Some(&color(CONTRAST, 0.45)));
+    shadow.setShadowColor(Some(&color(CONTRAST, 0.70)));
     shadow.setShadowOffset(NSSize::new(0.0, -0.5));
-    shadow.setShadowBlurRadius(1.0);
+    shadow.setShadowBlurRadius(1.5);
     let values: [&AnyObject; 5] = [&font, &edge, &edge, &stroke, &shadow];
     // SAFETY: Each AppKit attribute has its documented value type. The
     // attributed string and native text field retain the values they use.
@@ -271,13 +273,18 @@ fn label_text(text: &str, mtm: MainThreadMarker) -> [Retained<NSAttributedString
         );
         let string = NSString::from_str(text);
         let outline = NSAttributedString::new_with_attributes(&string, &attributes);
-        let ink_values: [&AnyObject; 2] = [&font, &ink];
+        let ink_values: [&AnyObject; 4] = [&font, &ink, &ink, &ink_stroke];
         let ink_attributes = NSDictionary::from_slices(
-            &[NSFontAttributeName, NSForegroundColorAttributeName],
+            &[
+                NSFontAttributeName,
+                NSForegroundColorAttributeName,
+                NSStrokeColorAttributeName,
+                NSStrokeWidthAttributeName,
+            ],
             &ink_values,
         );
-        // Drawing the fill separately keeps the dark outline outside the fine
-        // pen strokes, instead of letting it cover their light centers.
+        // Drawing the fill separately keeps the light outline outside the fine
+        // pen strokes, instead of letting it cover their dark centers.
         [
             outline,
             NSAttributedString::new_with_attributes(&string, &ink_attributes),

--- a/src-tauri/src/screen_annotation/macos.rs
+++ b/src-tauri/src/screen_annotation/macos.rs
@@ -8,10 +8,10 @@ use objc2::rc::{autoreleasepool, Retained};
 use objc2::runtime::AnyObject;
 use objc2::{define_class, msg_send, DefinedClass, MainThreadOnly};
 use objc2_app_kit::{
-    NSBackingStoreType, NSBezierPath, NSColor, NSFont, NSFontAttributeName,
-    NSForegroundColorAttributeName, NSLineBreakMode, NSLineCapStyle, NSLineJoinStyle, NSPanel,
-    NSScreen, NSShadow, NSShadowAttributeName, NSStatusWindowLevel, NSStrokeColorAttributeName,
-    NSStrokeWidthAttributeName, NSTextField, NSView, NSWindowAnimationBehavior,
+    NSAttributedStringNSExtendedStringDrawing, NSBackingStoreType, NSBezierPath, NSColor, NSFont,
+    NSFontAttributeName, NSForegroundColorAttributeName, NSLineCapStyle, NSLineJoinStyle, NSPanel,
+    NSScreen, NSShadow, NSShadowAttributeName, NSStatusWindowLevel, NSStringDrawingOptions,
+    NSStrokeColorAttributeName, NSStrokeWidthAttributeName, NSView, NSWindowAnimationBehavior,
     NSWindowCollectionBehavior, NSWindowSharingType, NSWindowStyleMask,
 };
 use objc2_foundation::{
@@ -23,16 +23,16 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 static WINDOW_ID: AtomicU32 = AtomicU32::new(0);
 
-// Neutral dark gray ink with a white edge stays visible on mixed backgrounds
+// Muted green ink with a white edge stays visible on mixed backgrounds
 // without another screen capture.
-const ACCENT: u32 = 0x333333;
+const ACCENT: u32 = 0x506747;
 const CONTRAST: u32 = 0xffffff;
-const FOREGROUND: u32 = 0x333333;
+const FOREGROUND: u32 = 0x506747;
 const MARK_WIDTH: f64 = 1.7;
-const CONTRAST_WIDTH: f64 = 5.0;
+const CONTRAST_WIDTH: f64 = 7.0;
 const LABEL_FONT_SIZE: f64 = 18.0;
-const LABEL_PADDING_X: f64 = 3.0;
-const LABEL_PADDING_Y: f64 = 3.0;
+const LABEL_PADDING_X: f64 = 6.0;
+const LABEL_PADDING_Y: f64 = 6.0;
 
 thread_local! {
     // Reusing the panel gives capture a stable ID even while it is ordered out.
@@ -97,6 +97,13 @@ define_class!(
 struct Drawing {
     target: AnnotationTarget,
     size: NSSize,
+    label: Option<LabelDrawing>,
+}
+
+#[derive(Debug)]
+struct LabelDrawing {
+    passes: [Retained<NSAttributedString>; 2],
+    text_rect: NSRect,
 }
 
 // NSView supports drawRect subclassing. Drawing only happens on the main
@@ -125,7 +132,7 @@ define_class!(
             let path = annotation_path(drawing.target, drawing.size);
             path.setLineCapStyle(NSLineCapStyle::Round);
             path.setLineJoinStyle(NSLineJoinStyle::Round);
-            // A white backing keeps the dark stroke visible on dark content.
+            // A white backing separates the green stroke from dark content.
             // No background sampling or animation.
             color(CONTRAST, 1.0).setStroke();
             path.setLineWidth(CONTRAST_WIDTH);
@@ -133,6 +140,11 @@ define_class!(
             color(ACCENT, 1.0).setStroke();
             path.setLineWidth(MARK_WIDTH);
             path.stroke();
+            if let Some(label) = &drawing.label {
+                for text in &label.passes {
+                    text.drawWithRect_options_context(label.text_rect, label_options(), None);
+                }
+            }
         }
     }
 );
@@ -249,17 +261,17 @@ fn label_text(text: &str, mtm: MainThreadMarker) -> [Retained<NSAttributedString
     let ink = color(FOREGROUND, 1.0);
     let edge = color(CONTRAST, 1.0);
     // Negative stroke width draws both fill and outline; the unit is percent
-    // of the font size. A 2.16 pt white stroke surrounds the dark letterforms.
-    let stroke = NSNumber::new_f64(-12.0);
+    // of the font size. A 3.24 pt white stroke surrounds the pale letterforms.
+    let stroke = NSNumber::new_f64(-18.0);
     // Thicken the handwriting slightly while keeping Japanese counters open.
     let ink_stroke = NSNumber::new_f64(-2.5);
     let shadow = NSShadow::new();
-    shadow.setShadowColor(Some(&color(CONTRAST, 0.70)));
+    shadow.setShadowColor(Some(&color(CONTRAST, 0.45)));
     shadow.setShadowOffset(NSSize::new(0.0, -0.5));
     shadow.setShadowBlurRadius(1.5);
     let values: [&AnyObject; 5] = [&font, &edge, &edge, &stroke, &shadow];
     // SAFETY: Each AppKit attribute has its documented value type. The
-    // attributed string and native text field retain the values they use.
+    // attributed strings retain the values they use.
     unsafe {
         let attributes = NSDictionary::from_slices(
             &[
@@ -283,8 +295,8 @@ fn label_text(text: &str, mtm: MainThreadMarker) -> [Retained<NSAttributedString
             ],
             &ink_values,
         );
-        // Drawing the fill separately keeps the light outline outside the fine
-        // pen strokes, instead of letting it cover their dark centers.
+        // Drawing the fill separately keeps the white outline outside the fine
+        // pen strokes, instead of letting it cover their pale centers.
         [
             outline,
             NSAttributedString::new_with_attributes(&string, &ink_attributes),
@@ -451,9 +463,7 @@ fn arrow_points(x: f64, y: f64, size: NSSize) -> ArrowPoints {
 
 fn label_frame(target: AnnotationTarget, size: NSSize, text_size: NSSize) -> NSRect {
     let margin = 8.0_f64.min(size.width / 8.0).min(size.height / 8.0);
-    let width = (text_size.width.ceil() + LABEL_PADDING_X * 2.0)
-        .min(300.0)
-        .min(size.width - margin * 2.0);
+    let width = (text_size.width.ceil() + LABEL_PADDING_X * 2.0).min(size.width - margin * 2.0);
     let height = (text_size.height.ceil() + LABEL_PADDING_Y * 2.0).min(size.height - margin * 2.0);
     let (preferred_x, preferred_y) = match target {
         AnnotationTarget::Arrow { x, y } => {
@@ -495,43 +505,50 @@ fn label_frame(target: AnnotationTarget, size: NSSize, text_size: NSSize) -> NSR
     )
 }
 
+fn label_options() -> NSStringDrawingOptions {
+    NSStringDrawingOptions::UsesLineFragmentOrigin | NSStringDrawingOptions::UsesFontLeading
+}
+
 fn create_view(
     mtm: MainThreadMarker,
     target: AnnotationTarget,
     size: NSSize,
     label: Option<&str>,
 ) -> Retained<AnnotationView> {
-    let labels = label.filter(|label| !label.trim().is_empty()).map(|label| {
-        label_text(label, mtm).map(|text| {
-            let label = NSTextField::labelWithString(&NSString::from_str(label), mtm);
-            label.setAttributedStringValue(&text);
-            label.setEditable(false);
-            label.setSelectable(false);
-            label.setDrawsBackground(false);
-            label.setMaximumNumberOfLines(1);
-            label.setUsesSingleLineMode(true);
-            if let Some(cell) = label.cell() {
-                cell.setLineBreakMode(NSLineBreakMode::ByTruncatingTail);
-            }
-            label.sizeToFit();
-            label
-        })
-    });
-    let label_frame = labels
-        .as_ref()
-        .map(|labels| label_frame(target, size, labels[1].frame().size));
-    let view = AnnotationView::alloc(mtm).set_ivars(Drawing { target, size });
-    // SAFETY: NSView's designated initializer takes NSRect and returns self.
-    let view: Retained<AnnotationView> =
-        unsafe { msg_send![super(view), initWithFrame: NSRect::new(NSPoint::ZERO, size)] };
-    if let (Some(labels), Some(frame)) = (labels, label_frame) {
-        for label in labels {
-            label.setFrame(frame);
-            // addSubview retains both ink passes for the content view's life.
-            view.addSubview(&label);
+    let label = label.filter(|label| !label.trim().is_empty()).map(|label| {
+        let passes = label_text(label, mtm);
+        let margin = 8.0_f64.min(size.width / 8.0).min(size.height / 8.0);
+        let available_width = (size.width - 2.0 * (margin + LABEL_PADDING_X)).max(1.0);
+        // Measure and draw with the same multiline layout options. NSTextField's
+        // single-line cell clips tall handwriting and strokes even if its outer
+        // frame is enlarged. Drawing in the full overlay avoids that cell clip.
+        let bounds = passes[1].boundingRectWithSize_options_context(
+            NSSize::new(available_width, f64::MAX),
+            label_options(),
+            None,
+        );
+        let frame = label_frame(target, size, bounds.size);
+        LabelDrawing {
+            passes,
+            // Keep the measured wrapping width: tightening it to a rounded
+            // glyph width can move the last character onto an extra line.
+            // The label frame reserves real space around the glyphs for the
+            // outline and shadow, rather than adding space inside a text cell.
+            text_rect: rect(
+                frame.origin.x + LABEL_PADDING_X - bounds.origin.x,
+                frame.origin.y + LABEL_PADDING_Y - bounds.origin.y,
+                available_width,
+                bounds.size.height.ceil(),
+            ),
         }
-    }
-    view
+    });
+    let view = AnnotationView::alloc(mtm).set_ivars(Drawing {
+        target,
+        size,
+        label,
+    });
+    // SAFETY: NSView's designated initializer takes NSRect and returns self.
+    unsafe { msg_send![super(view), initWithFrame: NSRect::new(NSPoint::ZERO, size)] }
 }
 
 fn create_panel(mtm: MainThreadMarker, frame: NSRect) -> Retained<AnnotationPanel> {
@@ -566,7 +583,7 @@ fn create_panel(mtm: MainThreadMarker, frame: NSRect) -> Retained<AnnotationPane
     );
     panel.setLevel(NSStatusWindowLevel);
     // Defense in depth for capture APIs honoring this setting. ScreenCaptureKit
-    // also excludes WINDOW_ID; parent suppresses annotations during capture.
+    // also excludes WINDOW_ID; new annotations wait until capture completes.
     panel.setSharingType(NSWindowSharingType::None);
     panel
 }

--- a/src-tauri/src/screen_capture.rs
+++ b/src-tauri/src/screen_capture.rs
@@ -86,7 +86,7 @@ pub async fn screen_capture_frame(
     let guard =
         crate::screen_annotation::begin_capture(window.app_handle(), share_id, source_id).await?;
     #[cfg(target_os = "macos")]
-    let mut frame = macos::capture(source_id).await?;
+    let mut frame = macos::capture(source_id, guard.excluded_window).await?;
     #[cfg(not(target_os = "macos"))]
     let mut frame = unsupported_capture().await?;
     let reference = crate::screen_annotation::register_frame(&guard, &frame).await?;
@@ -306,7 +306,10 @@ mod macos {
         }
     }
 
-    pub(super) async fn capture(source_id: u32) -> Result<ScreenCaptureFrame, String> {
+    pub(super) async fn capture(
+        source_id: u32,
+        excluded_window: Option<u32>,
+    ) -> Result<ScreenCaptureFrame, String> {
         ensure_supported()?;
         if !unsafe { CGPreflightScreenCaptureAccess() } {
             return Err(PERMISSION_DENIED.into());
@@ -328,7 +331,7 @@ mod macos {
             _busy: BusyGuard,
         });
         let _cancel = CancelOnDrop(request.clone());
-        autoreleasepool(|_| begin_capture(request, source, dimensions))?;
+        autoreleasepool(|_| begin_capture(request, source, dimensions, excluded_window))?;
         tokio::time::timeout(Duration::from_secs(15), receiver)
             .await
             .map_err(|_| "Screen capture timed out. Stop sharing and try again.".to_string())?
@@ -339,6 +342,7 @@ mod macos {
         request: Arc<CaptureRequest>,
         source: ScreenCaptureSource,
         dimensions: (usize, usize),
+        excluded_window: Option<u32>,
     ) -> Result<(), String> {
         let content_class = sc_class(c"SCShareableContent")?;
         let callback = RcBlock::new(move |content: *mut AnyObject, error: *mut AnyObject| {
@@ -353,7 +357,13 @@ mod macos {
                 // SCShareableContent owns the display objects throughout this
                 // callback. The filter retains the selected display after it.
                 let result = unsafe {
-                    capture_from_content(content, request.clone(), source.clone(), dimensions)
+                    capture_from_content(
+                        content,
+                        request.clone(),
+                        source.clone(),
+                        dimensions,
+                        excluded_window,
+                    )
                 };
                 if let Err(error) = result {
                     request.complete(Err(error));
@@ -372,6 +382,7 @@ mod macos {
         request: Arc<CaptureRequest>,
         source: ScreenCaptureSource,
         dimensions: (usize, usize),
+        excluded_window: Option<u32>,
     ) -> Result<(), String> {
         let displays: *mut AnyObject = msg_send![content, displays];
         if displays.is_null() {
@@ -392,10 +403,10 @@ mod macos {
                 "The selected display is no longer available. Choose a display again.".into(),
             );
         }
-        // The host also hides the panel for the entire capture interval. Exclude
-        // its stable native window ID as defense against capture self-feedback.
+        // Exclude the mark that was visible when capture began. New marks wait
+        // for this capture to finish; the existing mark never needs to blink.
         let mut excluded = Vec::new();
-        if let Some(overlay_id) = crate::screen_annotation::window_id() {
+        if let Some(overlay_id) = excluded_window {
             let windows: *mut AnyObject = msg_send![content, windows];
             if !windows.is_null() {
                 let count: usize = msg_send![windows, count];
@@ -409,6 +420,12 @@ mod macos {
                     }
                 }
             }
+        }
+        if excluded_window.is_some() && excluded.is_empty() {
+            return Err(
+                "Could not exclude the screen pointer from capture. Try again after it expires."
+                    .into(),
+            );
         }
         let excluded_windows = NSArray::from_retained_slice(&excluded);
         let filter: Option<Retained<AnyObject>> = msg_send![


### PR DESCRIPTION
Screen pointer labels could clip at the top and truncate long text, while screen capture briefly hid and redisplayed active marks. Labels now use measured multiline drawing with room for outlines, and captures exclude the existing pointer window without hiding or replaying it. New marks wait for in-flight captures, including across sharing restarts.

The final style uses darker green text and arrows with thicker white outlines. Native previews now include Japanese, English, and long wrapping labels.

Validation: 38 screen annotation/capture tests passed; native previews visually checked; rustfmt and commit hooks passed.
