### PR TITLE
Default to Codex and fix Linux screen capture compilation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -302,7 +302,7 @@ packやinit.jsが変わるたびに、チェックポイントが自動で作ら
 
 ## Agent support
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code)または[Codex](https://github.com/openai/codex)をMain Agentとして使用できます。設定画面または`~/.yorishiro/config.json`から選択してください。どちらも自動起動・persona prompt overlay・PTY observation・Yorishiro MCP accessに対応しています。
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code)または[Codex](https://github.com/openai/codex)をMain Agentとして使用できます。エージェント未設定時の既定値はCodexです。設定画面または`~/.yorishiro/config.json`から選択してください。どちらも自動起動・persona prompt overlay・PTY observation・Yorishiro MCP accessに対応しています。
 
 agentによってコマンド記法が異なります。詳しくは[Yorishiroのコマンドとスキル](#yorishiroのコマンドとスキル)を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ What works today:
 
 ## Agent support
 
-Use either [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex](https://github.com/openai/codex) as the Main Agent. Select one in Settings or `~/.yorishiro/config.json`. Both support auto-launch, persona prompt overlay, PTY observation, and Yorishiro MCP access.
+Use either [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex](https://github.com/openai/codex) as the Main Agent. Codex is the default when no agent is configured. Select one in Settings or `~/.yorishiro/config.json`. Both support auto-launch, persona prompt overlay, PTY observation, and Yorishiro MCP access.
 
 Command syntax differs by agent; see [Yorishiro commands and skills](#yorishiro-commands-and-skills).
 

--- a/bundled-packs/ui/yorishiro-settings/ui.test.ts
+++ b/bundled-packs/ui/yorishiro-settings/ui.test.ts
@@ -679,7 +679,7 @@ describe("Pack Workbench helpers", () => {
         language: "en",
       }),
     ).toBe(
-      '/yori:update Diagnose and repair broken-effect (effect). Start with pack_diagnose({ id: "broken-effect" }).',
+      '$yori-update Diagnose and repair broken-effect (effect). Start with pack_diagnose({ id: "broken-effect" }).',
     );
     expect(
       resolvePackRepairPrompt({
@@ -689,7 +689,7 @@ describe("Pack Workbench helpers", () => {
         language: "en",
       }),
     ).toBe(
-      '/yori:update Diagnose and improve my-scene (scene). Start with pack_diagnose({ id: "my-scene" }).',
+      '$yori-update Diagnose and improve my-scene (scene). Start with pack_diagnose({ id: "my-scene" }).',
     );
     expect(
       resolvePackRepairPrompt({
@@ -699,7 +699,7 @@ describe("Pack Workbench helpers", () => {
         language: "ja",
       }),
     ).toBe(
-      '/yori:update broken-persona (persona) を診断して、修正してください。まず pack_diagnose({ id: "broken-persona" }) で状態を確認してください。',
+      '$yori-update broken-persona (persona) を診断して、修正してください。まず pack_diagnose({ id: "broken-persona" }) で状態を確認してください。',
     );
     expect(
       resolvePackRepairPrompt({
@@ -709,7 +709,7 @@ describe("Pack Workbench helpers", () => {
         language: "ja",
       }),
     ).toBe(
-      '/yori:update ok-scene (scene) を診断して、改善してください。まず pack_diagnose({ id: "ok-scene" }) で状態を確認してください。',
+      '$yori-update ok-scene (scene) を診断して、改善してください。まず pack_diagnose({ id: "ok-scene" }) で状態を確認してください。',
     );
   });
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ Yorishiro は起動時に `~/.yorishiro/config.json` を読み、壊れている
 | Field | Type | Default | Meaning |
 |---|---|---|---|
 | `defaultProfile` | `string` or `null` | `null` | 起動時 default-session に使う profile id（`shell` / `claude` / `codex` / `opencode` または user `profiles[]` の id）。`null` なら `terminalAgent` を fallback |
-| `terminalAgent` | `"claude"`, `"codex"`, or `"opencode"` | `"claude"` | legacy。`defaultProfile` 未指定時に使う coding agent |
+| `terminalAgent` | `"claude"`, `"codex"`, or `"opencode"` | `"codex"` | legacy。`defaultProfile` 未指定時に使う coding agent |
 | `codexRealtimeVoice` | `string` | `"sol"` | Codex GPT Live の出力 voice（global fallback）。新しい realtime session の開始時に読み込む |
 | `realtimeVoiceByPersona` | `{ [personaId: string]: string }` | `{}` | persona pack id ごとの GPT Live voice override。active persona に entry があれば `codexRealtimeVoice` より優先 |
 | `language` | `"auto"`, `"en"`, or `"ja"` | `"auto"` | UI / bundled persona fallback / global system prompt / Yorishiro command/skill prompts の言語 |

--- a/src-tauri/src/screen_annotation.rs
+++ b/src-tauri/src/screen_annotation.rs
@@ -595,9 +595,11 @@ fn draw(mark: &VisibleAnnotation) -> Result<(), String> {
     }
 }
 
-#[cfg(target_os = "macos")]
 pub(crate) fn window_id() -> Option<u32> {
-    macos::window_id()
+    #[cfg(target_os = "macos")]
+    return macos::window_id();
+    #[cfg(not(target_os = "macos"))]
+    None
 }
 
 #[tauri::command]

--- a/src-tauri/src/screen_annotation.rs
+++ b/src-tauri/src/screen_annotation.rs
@@ -880,6 +880,7 @@ fn start_watchdog(app: &AppHandle, generation: u64) {
 /// Keep existing marks visible while excluding their pinned window from capture.
 /// New show requests wait until capture completes so its filter stays valid.
 pub struct CaptureGuard {
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub(crate) excluded_window: Option<u32>,
     app: AppHandle,
     share_id: String,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1762,7 +1762,7 @@ function App() {
       // 旧設計は IIFE 2 つで個別に config を読んでいたが、同じ file を 2 度 parse
       // していた。1 回読み + 両 registry に流す。失敗しても次 step は続行
       // （bundled fallback で動く）。
-      let terminalAgent: TerminalAgent = "claude";
+      let terminalAgent: TerminalAgent = "codex";
       let defaultSpec: SpawnSpec | null = null;
       let ambientAudioMuted = false;
       let ambientAudioVolume = 1.0;
@@ -2620,7 +2620,7 @@ function App() {
         data: { error: err instanceof Error ? err.message : String(err) },
       });
       userLayerReadyResolve({
-        terminalAgent: "claude",
+        terminalAgent: "codex",
         defaultSpec: null,
         systemPrompt: null,
         pluginDir: null,
@@ -2688,7 +2688,7 @@ function App() {
     },
     [beginCurtainReload, updateConfig],
   );
-  const [terminalAgent, setTerminalAgent] = useState<TerminalAgent>("claude");
+  const [terminalAgent, setTerminalAgent] = useState<TerminalAgent>("codex");
   const [voiceEntryDialog, setVoiceEntryDialog] = useState<{
     readonly mode: VoiceEntryDialogMode;
     readonly targetAgentId: string | null;

--- a/src/i18n/strings.test.ts
+++ b/src/i18n/strings.test.ts
@@ -12,21 +12,28 @@ import {
 const FIXED_PROMPT_KEYS = ["help", "tutorial", "shortcut", "create-pack", "pomodoro"] as const;
 
 describe("resolveFixedTerminalPrompt", () => {
-  it("resolves fixed prompts per language", () => {
+  it("defaults to Codex fixed prompts per language", () => {
     expect(FIXED_PROMPT_KEYS.map((key) => [key, resolveFixedTerminalPrompt(key, "en")])).toEqual([
-      ["help", "/yori:help"],
-      ["tutorial", "/yori:tutorial"],
-      ["shortcut", "/yori:shortcut I want to change keyboard shortcuts"],
-      ["create-pack", "/yori:create I want to create a pack"],
-      ["pomodoro", "/yori:help I want to use Pomodoro"],
+      ["help", "$yori-help"],
+      ["tutorial", "$yori-tutorial"],
+      ["shortcut", "$yori-shortcut I want to change keyboard shortcuts"],
+      ["create-pack", "$yori-create I want to create a pack"],
+      ["pomodoro", "$yori-help I want to use Pomodoro"],
     ]);
     expect(FIXED_PROMPT_KEYS.map((key) => [key, resolveFixedTerminalPrompt(key, "ja")])).toEqual([
-      ["help", "/yori:help"],
-      ["tutorial", "/yori:tutorial"],
-      ["shortcut", "/yori:shortcut ショートカットを変更したい"],
-      ["create-pack", "/yori:create pack を作りたい"],
-      ["pomodoro", "/yori:help Pomodoro を使いたい"],
+      ["help", "$yori-help"],
+      ["tutorial", "$yori-tutorial"],
+      ["shortcut", "$yori-shortcut ショートカットを変更したい"],
+      ["create-pack", "$yori-create pack を作りたい"],
+      ["pomodoro", "$yori-help Pomodoro を使いたい"],
     ]);
+  });
+
+  it("preserves Claude command syntax when explicitly selected", () => {
+    expect(resolveFixedTerminalPrompt("help", "en", "claude")).toBe("/yori:help");
+    expect(resolveFixedTerminalPrompt("create-pack", "ja", "claude")).toBe(
+      "/yori:create pack を作りたい",
+    );
   });
 
   it("resolves Codex fixed prompts as $yori skills", () => {
@@ -53,11 +60,11 @@ describe("resolveFixedTerminalPrompt", () => {
     ]);
   });
 
-  it("falls back to Claude command syntax for an unknown agent", () => {
-    // 記法 table に無い agent は Claude 形式（/yori:<name>）に fall back する。
-    expect(resolveFixedTerminalPrompt("help", "en", "future-agent")).toBe("/yori:help");
+  it("falls back to Codex command syntax for an unknown agent", () => {
+    // 記法 table に無い agent は Codex 形式（$yori-<name>）に fall back する。
+    expect(resolveFixedTerminalPrompt("help", "en", "future-agent")).toBe("$yori-help");
     expect(resolveFixedTerminalPrompt("create-pack", "en", "future-agent")).toBe(
-      "/yori:create I want to create a pack",
+      "$yori-create I want to create a pack",
     );
   });
 
@@ -232,6 +239,14 @@ describe("restoreConfirmStrings", () => {
 });
 
 describe("resolvePackRepairPrompt", () => {
+  it("defaults to Codex while preserving an explicit Claude choice", () => {
+    const args = { id: "broken-effect", action: "repair", language: "en" } as const;
+    expect(resolvePackRepairPrompt(args)).toMatch(/^\$yori-update /);
+    expect(resolvePackRepairPrompt({ ...args, terminalAgent: "claude" })).toMatch(
+      /^\/yori:update /,
+    );
+  });
+
   it("uses $yori-update for Codex", () => {
     expect(
       resolvePackRepairPrompt({

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -799,9 +799,9 @@ export const AGENT_COMMAND_SYNTAX: Record<
 /** Yorishiro が prefill する固定プロンプト中に現れる yori コマンド名。 */
 const YORI_COMMAND_NAMES = ["create", "update", "help", "shortcut", "tutorial"] as const;
 
-/** 未知 agent は Claude 記法に fall back する。 */
+/** 未知 agent は Codex 記法に fall back する。 */
 function yoriCommand(name: string, terminalAgent: string): string {
-  const syntax = AGENT_COMMAND_SYNTAX[terminalAgent] ?? AGENT_COMMAND_SYNTAX.claude;
+  const syntax = AGENT_COMMAND_SYNTAX[terminalAgent] ?? AGENT_COMMAND_SYNTAX.codex;
   return `${syntax.prefix}yori${syntax.separator}${name}`;
 }
 
@@ -813,7 +813,7 @@ function commandPromptForAgent(prompt: string, terminalAgent: string): string {
   );
 }
 
-function updateCommandForAgent(terminalAgent = "claude"): string {
+function updateCommandForAgent(terminalAgent = "codex"): string {
   return yoriCommand("update", terminalAgent);
 }
 
@@ -824,7 +824,7 @@ function updateCommandForAgent(terminalAgent = "claude"): string {
 export function resolveFixedTerminalPrompt(
   key: FixedTerminalPromptKey,
   language: ResolvedLanguage,
-  terminalAgent = "claude",
+  terminalAgent = "codex",
 ): string {
   return commandPromptForAgent(getStrings(language)[FIXED_PROMPT_STRING[key]], terminalAgent);
 }

--- a/src/runtime/user-pack-loader/config.test.ts
+++ b/src/runtime/user-pack-loader/config.test.ts
@@ -51,7 +51,7 @@ describe("parseConfig", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -81,7 +81,7 @@ describe("parseConfig", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -111,7 +111,7 @@ describe("parseConfig", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -141,7 +141,7 @@ describe("parseConfig", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -171,7 +171,7 @@ describe("parseConfig", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -201,7 +201,7 @@ describe("parseConfig", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -236,7 +236,7 @@ describe("parseConfig", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -263,9 +263,9 @@ describe("parseConfig", () => {
     expect(config.terminalAgent).toBe("opencode");
   });
 
-  it("defaults unknown terminalAgent to claude", () => {
+  it("defaults unknown terminalAgent to codex", () => {
     const config = parseConfig('{"terminalAgent": "unknown"}');
-    expect(config.terminalAgent).toBe("claude");
+    expect(config.terminalAgent).toBe("codex");
   });
 
   it("reads tabMetadataBadges only when explicitly true", () => {
@@ -295,7 +295,7 @@ describe("serializeConfig", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -325,7 +325,7 @@ describe("serializeConfig", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -386,9 +386,16 @@ describe("serializeConfig", () => {
     expect(parseConfig(serializeConfig(cfg))).toEqual(cfg);
   });
 
-  it("writes terminalAgent when codex is selected", () => {
-    const cfg: YorishiroConfig = { ...EMPTY_CONFIG, terminalAgent: "codex" };
-    expect(JSON.parse(serializeConfig(cfg))).toEqual({ terminalAgent: "codex" });
+  it("preserves an explicit Claude choice through serialization", () => {
+    const cfg = parseConfig('{"terminalAgent":"claude"}');
+    const text = serializeConfig(cfg);
+    expect(JSON.parse(text)).toEqual({ terminalAgent: "claude" });
+    expect(parseConfig(text).terminalAgent).toBe("claude");
+  });
+
+  it("uses Codex when no agent is configured", () => {
+    expect(parseConfig("{}").terminalAgent).toBe("codex");
+    expect(JSON.parse(serializeConfig({ ...EMPTY_CONFIG, terminalAgent: "codex" }))).toEqual({});
   });
 
   it("writes terminalAgent when opencode is selected", () => {
@@ -776,7 +783,7 @@ describe("withDisabledPackAdded / withDisabledPackRemoved", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,
@@ -807,7 +814,7 @@ describe("withDisabledPackAdded / withDisabledPackRemoved", () => {
       activeAmbientUi: ["attention-aura", "pomodoro-ui"],
       tabMetadataBadges: false,
       language: "auto",
-      terminalAgent: "claude",
+      terminalAgent: "codex",
       ambientAudioMuted: false,
       ambientAudioVolume: 1,
       voiceVolume: 1,

--- a/src/runtime/user-pack-loader/config.ts
+++ b/src/runtime/user-pack-loader/config.ts
@@ -125,7 +125,7 @@ export const EMPTY_CONFIG: YorishiroConfig = {
   activeAmbientUi: ["attention-aura", "pomodoro-ui"],
   tabMetadataBadges: false,
   language: DEFAULT_LANGUAGE,
-  terminalAgent: "claude",
+  terminalAgent: "codex",
   ambientAudioMuted: false,
   ambientAudioVolume: 1.0,
   voiceVolume: 1.0,
@@ -188,7 +188,7 @@ const toTerminalAgent = (value: unknown): TerminalAgent => {
   if (typeof value === "string" && KNOWN_AGENT_IDS.has(value)) {
     return value;
   }
-  return "claude";
+  return EMPTY_CONFIG.terminalAgent;
 };
 
 const toBoolean = (value: unknown): boolean => {
@@ -388,7 +388,7 @@ export function serializeConfig(cfg: YorishiroConfig): string {
   }
   if (cfg.tabMetadataBadges) out.tabMetadataBadges = true;
   if (cfg.language !== DEFAULT_LANGUAGE) out.language = cfg.language;
-  if (cfg.terminalAgent !== "claude") out.terminalAgent = cfg.terminalAgent;
+  if (cfg.terminalAgent !== EMPTY_CONFIG.terminalAgent) out.terminalAgent = cfg.terminalAgent;
   if (cfg.ambientAudioMuted) out.ambientAudioMuted = true;
   if (cfg.ambientAudioVolume !== 1.0) out.ambientAudioVolume = cfg.ambientAudioVolume;
   if (cfg.voiceVolume !== 1.0) out.voiceVolume = cfg.voiceVolume;


### PR DESCRIPTION
Yorishiro now uses Codex when no agent is configured, including startup failure fallbacks and generated command prompts. Explicit Claude/OpenCode choices and default profiles retain their existing behavior. README translations and the configuration reference document the new default.

Also fixes the existing Ubuntu CI compile failure introduced by screen capture annotations: non-macOS window lookup now returns None instead of referring to a macOS-only helper.

Validation: all 2,775 frontend tests, 38 screen capture/annotation Rust tests, and all pre-push checks pass locally. Linux compilation and the full CI suite run on this PR.

Compatibility: older configurations that omitted terminalAgent now use Codex; an omitted historical Claude value cannot be distinguished from an unset default.
